### PR TITLE
Move status to /api/status

### DIFF
--- a/src/pylorax/api/server.py
+++ b/src/pylorax/api/server.py
@@ -18,10 +18,11 @@ import logging
 log = logging.getLogger("lorax-composer")
 
 from collections import namedtuple
-from flask import Flask, send_from_directory
+from flask import Flask, jsonify, redirect, send_from_directory
 from glob import glob
 import os
 
+from pylorax import vernum
 from pylorax.api.crossdomain import crossdomain
 from pylorax.api.v0 import v0_api
 from pylorax.sysutils import joinpaths
@@ -34,9 +35,8 @@ server = Flask(__name__)
 __all__ = ["server", "GitLock"]
 
 @server.route('/')
-@crossdomain(origin="*")
-def hello_world():
-    return 'Hello, World!'
+def server_root():
+    redirect("/api/docs/")
 
 @server.route("/api/docs/")
 @server.route("/api/docs/<path:path>")
@@ -51,5 +51,27 @@ def api_docs(path=None):
     if not path:
         path="index.html"
     return send_from_directory(docs_path, path)
+
+@server.route("/api/status")
+@crossdomain(origin="*")
+def v0_status():
+    """
+    `/api/v0/status`
+    ^^^^^^^^^^^^^^^^
+    Return the status of the API Server::
+
+          { "api": "0",
+            "build": "devel",
+            "db_supported": true,
+            "db_version": "0",
+            "schema_version": "0",
+            "backend": "lorax-composer"}
+    """
+    return jsonify(backend="lorax-composer",
+                   build=vernum,
+                   api="0",
+                   db_version="0",
+                   schema_version="0",
+                   db_supported=True)
 
 v0_api(server)

--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -49,21 +49,6 @@ used then the API will use the `master` branch for blueprints. If you want to cr
 a new branch use the `new` or `workspace` routes with ?branch=<branch-name> to
 store the new blueprint on the new branch.
 
-`/api/v0/test`
-^^^^^^^^^^^^^^
-
-  Return a test string. It is not JSON encoded.
-
-`/api/v0/status`
-^^^^^^^^^^^^^^^^
-  Return the status of the API Server::
-
-      { "api": "0",
-        "build": "devel",
-        "db_supported": false,
-        "db_version": "0",
-        "schema_version": "0" }
-
 `/api/v0/blueprints/list`
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -930,16 +915,6 @@ def take_limits(iterable, offset, limit):
 
 def v0_api(api):
     # Note that Sphinx will not generate documentations for any of these.
-    @api.route("/api/v0/test")
-    @crossdomain(origin="*")
-    def v0_test():
-        return "API v0 test"
-
-    @api.route("/api/v0/status")
-    @crossdomain(origin="*")
-    def v0_status():
-        return jsonify(build="devel", api="0", db_version="0", schema_version="0", db_supported=False)
-
     @api.route("/api/v0/blueprints/list")
     @crossdomain(origin="*")
     def v0_blueprints_list():

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -69,17 +69,13 @@ class ServerTestCase(unittest.TestCase):
     def tearDownClass(self):
         shutil.rmtree(server.config["REPO_DIR"])
 
-    def test_00_hello(self):
-        """Test /"""
-        resp = self.server.get("/")
-        self.assertEqual(resp.data, 'Hello, World!')
-
     def test_01_status(self):
-        """Test the /api/v0/status route"""
-        status_dict = {"build":"devel", "api":"0", "db_version":"0", "schema_version":"0", "db_supported":False}
-        resp = self.server.get("/api/v0/status")
+        """Test the /api/status route"""
+        status_fields = ["build", "api", "db_version", "schema_version", "db_supported", "backend"]
+        resp = self.server.get("/api/status")
         data = json.loads(resp.data)
-        self.assertEqual(data, status_dict)
+        # Just make sure the fields are present
+        self.assertEqual(sorted(data.keys()), sorted(status_fields))
 
     def test_02_blueprints_list(self):
         """Test the /api/v0/blueprints/list route"""


### PR DESCRIPTION
Also drops /api/v0/test, and redirects / to /api/docs/

db and schema are fixed at 0 since lorax-composer uses yum, not the bdcs
metadata.db