### PR TITLE
Include the anaconda-install-env-deps metapackage

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -2,11 +2,7 @@
 <%page args="basearch, product"/>
 
 ## anaconda package
-installpkg anaconda anaconda-widgets kexec-tools-anaconda-addon
-## anaconda deps that aren't in the RPM
-installpkg tmux
-## for anaconda crash handling
-installpkg gdb
+installpkg anaconda anaconda-widgets kexec-tools-anaconda-addon anaconda-install-deps
 ## Other available payloads
 installpkg dnf
 installpkg rpm-ostree ostree


### PR DESCRIPTION
Use the anaconda-install-env-deps metapackage to pull in the
Anaconda dependencies needed in the installation environment.

The anaconda-install-env-deps metapackage lists all install time
dependencies and makes it possible for packages such as
Initial Setup to depend on Anaconda without pulling all
the (mainly storage related) install time dependencies
to the installed system.

The same is applicable for dirinstall which also does
not require the install time dependencies as it is just
installing to a local folder.

Also drop the tmux and gdb dependencies from the template as
both have been added to the metapackage to make install time
dependency tracking more consistent.