### PR TITLE
Fix anaconda metapackage name

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -2,7 +2,7 @@
 <%page args="basearch, product"/>
 
 ## anaconda package
-installpkg anaconda anaconda-widgets kexec-tools-anaconda-addon anaconda-install-deps
+installpkg anaconda anaconda-widgets kexec-tools-anaconda-addon anaconda-install-env-deps
 ## Other available payloads
 installpkg dnf
 installpkg rpm-ostree ostree


### PR DESCRIPTION
"anaconda-install-deps" was the original placeholder name
of the metapackage and it looks like I forgot to change it
to "anaconda-install-env-deps", which is the final name
we have decided sounds better.

Oops! (it's even correct in the commit message...)