### PR TITLE
Add support for systemd socket activation

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -131,12 +131,15 @@ getent passwd weldr >/dev/null 2>&1 || useradd -r -g weldr -d / -s /sbin/nologin
 
 %post composer
 %systemd_post lorax-composer.service
+%systemd_post lorax-composer.socket
 
 %preun composer
 %systemd_preun lorax-composer.service
+%systemd_preun lorax-composer.socket
 
 %postun composer
 %systemd_postun_with_restart lorax-composer.service
+%systemd_postun_with_restart lorax-composer.socket
 
 %files
 %defattr(-,root,root,-)
@@ -162,6 +165,8 @@ getent passwd weldr >/dev/null 2>&1 || useradd -r -g weldr -d / -s /sbin/nologin
 %{python_sitelib}/pylorax/api/*
 %{_sbindir}/lorax-composer
 %{_unitdir}/lorax-composer.service
+%{_unitdir}/lorax-composer.socket
+%{_tmpfilesdir}/lorax-composer.conf
 
 %files -n composer-cli
 %{_bindir}/composer-cli

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,9 @@ import sys
 # config file
 data_files = [("/etc/lorax", ["etc/lorax.conf"]),
               ("/etc/lorax", ["etc/composer.conf"]),
-              ("/usr/lib/systemd/system", ["systemd/lorax-composer.service"])]
+              ("/usr/lib/systemd/system", ["systemd/lorax-composer.service",
+                                           "systemd/lorax-composer.socket"]),
+              ("/usr/lib/temfiles.d/", ["systemd/lorax-composer.conf"])]
 
 # shared files
 for root, dnames, fnames in os.walk("share"):

--- a/src/sbin/lorax-composer
+++ b/src/sbin/lorax-composer
@@ -228,14 +228,27 @@ if __name__ == '__main__':
             log.error(e)
         sys.exit(1)
 
-    # Setup the Unix Domain Socket, remove old one, set ownership and permissions
-    if os.path.exists(opts.socket):
-        os.unlink(opts.socket)
-    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    listener.bind(opts.socket)
-    os.chmod(opts.socket, 0o660)
-    os.chown(opts.socket, 0, gid)
-    listener.listen(1)
+    # Did systemd pass any extra fds (for socket activation)?
+    try:
+        fds = int(os.environ['LISTEN_FDS'])
+    except (ValueError, KeyError):
+        fds = 0
+
+    if fds == 1:
+        # Inherit the fd passed by systemd
+        listener = socket.fromfd(3, socket.AF_UNIX, socket.SOCK_STREAM)
+    elif fds > 1:
+        log.error("lorax-composer only supports inheriting 1 fd from systemd.")
+        sys.exit(1)
+    else:
+        # Setup the Unix Domain Socket, remove old one, set ownership and permissions
+        if os.path.exists(opts.socket):
+            os.unlink(opts.socket)
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.bind(opts.socket)
+        os.chmod(opts.socket, 0o660)
+        os.chown(opts.socket, 0, gid)
+        listener.listen(1)
 
     start_queue_monitor(server.config["COMPOSER_CFG"], uid, gid)
 

--- a/systemd/lorax-composer.conf
+++ b/systemd/lorax-composer.conf
@@ -1,0 +1,1 @@
+d /run/weldr 750 root weldr

--- a/systemd/lorax-composer.socket
+++ b/systemd/lorax-composer.socket
@@ -1,0 +1,12 @@
+[Unit]
+Description=lorax-composer socket activation
+
+[Socket]
+ListenStream=/run/weldr/api.socket
+SocketUser=root
+SocketGroup=weldr
+SocketMode=0660
+DirectoryMode=0750
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
Instead of enabling lorax-composer.service enable lorax-composer.socket
and it will start lorax-composer on first access to
/run/weldr/api.socket