### PR TITLE
really kill kernel-bootwrapper on ppc

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -61,7 +61,6 @@ Requires:       syslinux >= 6.02-4
 %endif
 
 %ifarch ppc ppc64 ppc64le
-Requires:       kernel-bootwrapper
 Requires:       grub2
 Requires:       grub2-tools
 %endif


### PR DESCRIPTION
We forgot to remove kernel-bootwrapper from Requires in lorax spec.

Please make a new release too as this fixes broken ppc64/ppc64le composes.