### PR TITLE
templates: Stop using gconfset

### DIFF
--- a/docs/lorax.rst
+++ b/docs/lorax.rst
@@ -92,7 +92,6 @@ installation. A number of template commands are used here:
 
 * :func:`append <pylorax.ltmpl.LoraxTemplateRunner.append>` to add text to a file.
 * :func:`chmod <pylorax.ltmpl.LoraxTemplateRunner.chmod>` changes the file's mode.
-* :func:`gconfset <pylorax.ltmpl.LoraxTemplateRunner.gconfset>` runs gconfset.
 * :func:`install <pylorax.ltmpl.LoraxTemplateRunner.install>` to install a file into the installroot.
 * :func:`mkdir <pylorax.ltmpl.LoraxTemplateRunner.mkdir>` makes a new directory.
 * :func:`move <pylorax.ltmpl.LoraxTemplateRunner.move>` to move a file into the installroot

--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -89,9 +89,6 @@ append etc/shadow "install::14438:0:99999:7:::"
 ## remove root password
 replace "root:\*:" "root::" etc/shadow
 
-## gconf settings
-gconfset /desktop/gnome/interface/accessibility bool true
-
 ## gsettings settings
 install ${configdir}/org.gtk.Settings.Debug.gschema.override usr/share/glib-2.0/schemas
 runcmd chroot ${root} glib-compile-schemas /usr/share/glib-2.0/schemas

--- a/src/pylorax/ltmpl.py
+++ b/src/pylorax/ltmpl.py
@@ -129,7 +129,7 @@ class LoraxTemplateRunner(object):
     * Parsing and execution are *separate* passes - so you can't use the result
       of a command in an %if statement (or any other control statements)!
 
-    * Commands that run external programs (systemctl, gconfset) currently use
+    * Commands that run external programs (e.g. systemctl) currently use
       the *host*'s copy of that program, which may cause problems if there's a
       big enough difference between the host and the image you're modifying.
 
@@ -458,22 +458,6 @@ class LoraxTemplateRunner(object):
         '''
         for f in rglob(self._out(fileglob), fatal=True):
             os.chmod(f, int(mode,8))
-
-    # TODO: do we need a new command for gsettings?
-    def gconfset(self, path, keytype, value, outfile=None):
-        '''
-        gconfset PATH KEYTYPE VALUE [OUTFILE]
-          Set the given gconf PATH, with type KEYTYPE, to the given value.
-          OUTFILE defaults to /etc/gconf/gconf.xml.defaults if not given.
-          Example:
-            gconfset /apps/metacity/general/num_workspaces int 1
-        '''
-        if outfile is None:
-            outfile = self._out("etc/gconf/gconf.xml.defaults")
-        cmd = ["gconftool-2", "--direct",
-                    "--config-source=xml:readwrite:%s" % outfile,
-                    "--set", "--type", keytype, path, value]
-        runcmd(cmd)
 
     def log(self, msg):
         '''


### PR DESCRIPTION
We had only been indirectly pulling in GConf, and anyways
nothing was listening to these keys.

<kalev> I still think it's a fallout from https://src.fedoraproject.org/rpms/libgnomekbd/c/27a90d973faeddc74e6f78b149e480ea728fbe0e?branch=master

Really in general, if we wanted to make changes like this
it'd probably be a lot simpler to do them on boot or so.

https://bugzilla.redhat.com/show_bug.cgi?id=1581838