### PR TITLE
Add --dracut-arg support to lorax

### DIFF
--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -26,7 +26,7 @@ from pylorax import vernum
 
 version = "{0}-{1}".format(os.path.basename(sys.argv[0]), vernum)
 
-def lorax_parser():
+def lorax_parser(dracut_default=""):
     """ Return the ArgumentParser for lorax"""
 
     parser = argparse.ArgumentParser(description="Create the Anaconda boot.iso")
@@ -107,6 +107,14 @@ def lorax_parser():
                           help="Size of root filesystem in GiB. Defaults to 2.")
     optional.add_argument("--noverifyssl", action="store_true", default=False,
                           help="Do not verify SSL certificates")
+
+    # dracut arguments
+    dracut_group = parser.add_argument_group("dracut arguments")
+    dracut_group.add_argument("--dracut-arg", action="append", dest="dracut_args",
+                              help="Argument to pass to dracut when "
+                                   "rebuilding the initramfs. Pass this "
+                                   "once for each argument. NOTE: this "
+                                   "overrides the default. (default: %s)" % dracut_default)
 
     # add the show version option
     parser.add_argument("-V", help="show program's version number and exit",

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -29,13 +29,13 @@ import tempfile
 # Use the Lorax treebuilder branch for iso creation
 from pylorax import setup_logging, find_templates, vernum
 from pylorax.cmdline import lmc_parser
-from pylorax.creator import run_creator
+from pylorax.creator import run_creator, DRACUT_DEFAULT
 from pylorax.imgutils import default_image_name
 from pylorax.sysutils import joinpaths
 
 
 def main():
-    parser = lmc_parser()
+    parser = lmc_parser(DRACUT_DEFAULT)
     opts = parser.parse_args()
 
     setup_logging(opts.logfile, log)

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -33,6 +33,7 @@ import dnf
 import dnf.logging
 import librepo
 import pylorax
+from pylorax import DRACUT_DEFAULT
 from pylorax.cmdline import lorax_parser
 import selinux
 
@@ -52,7 +53,7 @@ def setup_logging(opts):
 
 
 def main():
-    parser = lorax_parser()
+    parser = lorax_parser(DRACUT_DEFAULT)
     opts = parser.parse_args()
 
     log.info("Lorax v%s", pylorax.vernum)
@@ -138,7 +139,8 @@ def main():
               add_template_vars=parsed_add_template_vars,
               add_arch_templates=opts.add_arch_templates,
               add_arch_template_vars=parsed_add_arch_template_vars,
-              remove_temp=True, verify=opts.verify)
+              remove_temp=True, verify=opts.verify,
+              user_dracut_args=opts.dracut_args)
 
 
 def get_dnf_base_object(installroot, sources, mirrorlists=None, repos=None,


### PR DESCRIPTION
Use it to override the default dracut arguments (displayed as part of
the --help output). If you want to extend the default arguments they
all need to be passed in on the cmdline as well. eg.

--dracut-arg='--xz' --dracut-arg='--install /.buildstamp' ...

Resolves: rhbz#1452220