### PR TITLE
Add --dracut-arg support to lorax

### DIFF
--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -57,6 +57,8 @@ except ImportError:
 else:
     vernum = pylorax.version.num
 
+DRACUT_DEFAULT = ["--xz", "--install", "/.buildstamp", "--no-early-microcode", "--add", "fips"]
+
 # List of drivers to remove on ppc64 arch to keep initrd < 32MiB
 REMOVE_PPC64_DRIVERS = "floppy scsi_debug nouveau radeon cirrus mgag200"
 REMOVE_PPC64_MODULES = "drm plymouth"
@@ -157,7 +159,8 @@ class Lorax(BaseLoraxClass):
             add_template_vars=None,
             add_arch_templates=None,
             add_arch_template_vars=None,
-            template_tempdir=None):
+            template_tempdir=None,
+            user_dracut_args=None):
 
         assert self._configured
 
@@ -311,7 +314,13 @@ class Lorax(BaseLoraxClass):
                                   workdir=self.workdir)
 
         logger.info("rebuilding initramfs images")
-        dracut_args = ["--xz", "--install", "/.buildstamp", "--no-early-microcode", "--add", "fips"]
+        if not user_dracut_args:
+            dracut_args = DRACUT_DEFAULT
+        else:
+            dracut_args = []
+            for arg in user_dracut_args:
+                dracut_args += arg.split(" ", 1)
+
         anaconda_args = dracut_args + ["--add", "anaconda pollcdrom"]
 
         # ppc64 cannot boot an initrd > 32MiB so remove some drivers
@@ -322,6 +331,8 @@ class Lorax(BaseLoraxClass):
             # upgrade.img
             anaconda_args.extend(["--omit", REMOVE_PPC64_MODULES])
 
+        logger.info("dracut args = %s", dracut_args)
+        logger.info("anaconda args = %s", anaconda_args)
         treebuilder.rebuild_initrds(add_args=anaconda_args)
 
         if doupgrade:

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -67,7 +67,7 @@ except ImportError:
 
 VERSION = "{0}-{1}".format(os.path.basename(sys.argv[0]), vernum)
 
-# Default parameters for rebuilding initramfs, override with --dracut-args
+# Default parameters for rebuilding initramfs, override with --dracut-arg
 DRACUT_DEFAULT = ["--xz", "--add", "livenet dmsquash-live convertfs pollcdrom",
                   "--omit", "plymouth", "--no-hostonly", "--no-early-microcode"]
 

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -41,6 +41,7 @@ import yum
 # handler setup.  We already set one up so we don't need it to run.
 yum.logginglevels._added_handlers = True
 import pylorax
+from pylorax import DRACUT_DEFAULT
 
 VERSION = "{0}-{1}".format(os.path.basename(sys.argv[0]), pylorax.vernum)
 
@@ -149,6 +150,14 @@ def main(args):
     optional.add_option("--noverifyssl", action="store_true", default=False,
                         help="Do not verify SSL certificates")
 
+    # dracut arguments
+    dracut_group = OptionGroup(parser, "dracut arguments")
+    dracut_group.add_option("--dracut-arg", action="append", dest="dracut_args",
+                            help="Argument to pass to dracut when "
+                                 "rebuilding the initramfs. Pass this "
+                                 "once for each argument. NOTE: this "
+                                 "overrides the default. (default: %s)" % (DRACUT_DEFAULT,) )
+
     # add the option groups to the parser
     parser.add_option_group(required)
     parser.add_option_group(optional)
@@ -232,7 +241,8 @@ def main(args):
               add_template_vars=parsed_add_template_vars,
               add_arch_templates=opts.add_arch_templates,
               add_arch_template_vars=parsed_add_arch_template_vars,
-              remove_temp=True)
+              remove_temp=True,
+              user_dracut_args=opts.dracut_args)
 
 
 def get_yum_base_object(installroot, repositories, mirrorlists=[], repo_files=[],


### PR DESCRIPTION
Use it to override the default dracut arguments (displayed as part of
the --help output). If you want to extend the default arguments they
all need to be passed in on the cmdline as well. eg.

--dracut-arg='--xz' --dracut-arg='--install /.buildstamp' ...

Resolves: rhbz#1452220