### PR TITLE
Increase default ram used with lmc and virt to 2048

### DIFF
--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -233,7 +233,7 @@ def lmc_parser(dracut_default=""):
 
     # Group of arguments to pass to qemu
     virt_group = parser.add_argument_group("qemu arguments")
-    virt_group.add_argument("--ram", metavar="MEMORY", type=int, default=1024,
+    virt_group.add_argument("--ram", metavar="MEMORY", type=int, default=2048,
                             help="Memory to allocate for installer in megabytes.")
     virt_group.add_argument("--vcpus", type=int, default=None,
                             help="Passed to qemu -smp command")


### PR DESCRIPTION
1024 is a bit small in some situations, double it.

Resolves: rhbz#1538747