### PR TITLE
Install 'hostname' in runtime-install (for iSCSI)

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -95,7 +95,8 @@ installpkg device-mapper-persistent-data
 installpkg xfsdump
 
 ## extra storage packages
-installpkg udisks2 udisks2-iscsi
+# hostname is needed for iscsi to work, see RHBZ#1593917
+installpkg udisks2 udisks2-iscsi hostname
 
 ## extra libblockdev plugins
 installpkg libblockdev-lvm-dbus


### PR DESCRIPTION
As explained in detail in the bug, 'hostname' must be installed
for the dracut 95iscsi module to work (and thus for key iscsi
modules to be included in the initramfs generated by lorax). Up
till recently, we got it as a dependency of initscripts, but
when network-scripts split from initscripts, the dependency went
with it. Now nothing else pulls it in as a dep, so let's just
pull it in explicitly here.

Resolves: rhbz#1593657

Signed-off-by: Adam Williamson <awilliam@redhat.com>