### PR TITLE
Make sure /run/weldr has correct ownership and permissions

### DIFF
--- a/systemd/lorax-composer.service
+++ b/systemd/lorax-composer.service
@@ -6,6 +6,7 @@ Wants=network-online.target
 [Service]
 User=root
 Type=simple
+ExecStartPre=/usr/bin/systemd-tmpfiles --create /usr/lib/tmpfiles.d/lorax-composer.conf
 ExecStart=/usr/sbin/lorax-composer /var/lib/lorax/composer/recipes/
 
 [Install]


### PR DESCRIPTION
Normally tmpfiles.d will handle this at boot time, but if you install
lorax-composer without rebooting it was ending up with root:root
ownership instead of root:weldr