### PR TITLE
Include example blueprints in the rpm

### DIFF
--- a/lorax-composer.spec
+++ b/lorax-composer.spec
@@ -62,7 +62,9 @@ make DESTDIR=$RPM_BUILD_ROOT mandir=%{_mandir} install
 # Install example blueprints from the test suite.
 # This path MUST match the lorax-composer.service blueprint path.
 mkdir -p $RPM_BUILD_ROOT/var/lib/lorax/composer/blueprints/
-cp ./tests/pylorax/blueprints/*toml $RPM_BUILD_ROOT/var/lib/lorax/composer/blueprints/
+for bp in http-server.toml glusterfs.toml development.toml atlas.toml; do
+    cp ./tests/pylorax/blueprints/$bp $RPM_BUILD_ROOT/var/lib/lorax/composer/blueprints/
+done
 
 # Do Not Package the lorax files
 rm -f $RPM_BUILD_ROOT/%{python_sitelib}/lorax-*.egg-info

--- a/lorax-composer.spec
+++ b/lorax-composer.spec
@@ -59,6 +59,11 @@ make docs
 rm -rf $RPM_BUILD_ROOT
 make DESTDIR=$RPM_BUILD_ROOT mandir=%{_mandir} install
 
+# Install example blueprints from the test suite.
+# This path MUST match the lorax-composer.service blueprint path.
+mkdir -p $RPM_BUILD_ROOT/var/lib/lorax/composer/blueprints/
+cp ./tests/pylorax/blueprints/*toml $RPM_BUILD_ROOT/var/lib/lorax/composer/blueprints/
+
 # Do Not Package the lorax files
 rm -f $RPM_BUILD_ROOT/%{python_sitelib}/lorax-*.egg-info
 rm -rf $RPM_BUILD_ROOT/%{python_sitelib}/pylorax/*py
@@ -105,6 +110,9 @@ getent passwd weldr >/dev/null 2>&1 || useradd -r -g weldr -d / -s /sbin/nologin
 %{_unitdir}/lorax-composer.service
 %{_unitdir}/lorax-composer.socket
 %{_tmpfilesdir}/lorax-composer.conf
+%dir %attr(0771, root, weldr) %{_sharedstatedir}/lorax/composer/
+%dir %attr(0771, root, weldr) %{_sharedstatedir}/lorax/composer/blueprints/
+%attr(0771, weldr, weldr) %{_sharedstatedir}/lorax/composer/blueprints/*
 
 %files -n composer-cli
 %{_bindir}/composer-cli

--- a/systemd/lorax-composer.service
+++ b/systemd/lorax-composer.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 User=root
 Type=simple
 ExecStartPre=/usr/bin/systemd-tmpfiles --create /usr/lib/tmpfiles.d/lorax-composer.conf
-ExecStart=/usr/sbin/lorax-composer /var/lib/lorax/composer/recipes/
+ExecStart=/usr/sbin/lorax-composer /var/lib/lorax/composer/blueprints/
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This also sets ownership of /var/lib/lorax/composer/ to root:weldr to
allow missing directories to be created at runtime.