### PR TITLE
Improve depsolve error reporting

### DIFF
--- a/src/pylorax/api/projects.py
+++ b/src/pylorax/api/projects.py
@@ -203,10 +203,20 @@ def projects_depsolve(yb, projects):
     try:
         # This resets the transaction
         yb.closeRpmDB()
+        install_errors = []
         for name, version in projects:
             if not version:
                 version = "*"
-            yb.install(pattern="%s-%s" % (name, version))
+            pattern = "%s-%s" % (name, version)
+            try:
+                yb.install(pattern=pattern)
+            except YumBaseError as e:
+                install_errors.append((pattern, str(e)))
+
+        # Were there problems installing these packages?
+        if install_errors:
+            raise ProjectsError("The following package(s) had problems: %s" % ",".join(["%s (%s)" % (pattern, err) for pattern, err in install_errors]))
+
         (rc, msg) = yb.buildTransaction()
         if rc not in [0, 1, 2]:
             raise ProjectsError("There was a problem depsolving %s: %s" % (projects, msg))
@@ -252,10 +262,20 @@ def projects_depsolve_with_size(yb, projects, with_core=True):
     try:
         # This resets the transaction
         yb.closeRpmDB()
+        install_errors = []
         for name, version in projects:
             if not version:
                 version = "*"
-            yb.install(pattern="%s-%s" % (name, version))
+            pattern = "%s-%s" % (name, version)
+            try:
+                yb.install(pattern=pattern)
+            except YumBaseError as e:
+                install_errors.append((pattern, str(e)))
+
+        # Were there problems installing these packages?
+        if install_errors:
+            raise ProjectsError("The following package(s) had problems: %s" % ",".join(["%s (%s)" % (pattern, err) for pattern, err in install_errors]))
+
         if with_core:
             yb.selectGroup("core", group_package_types=['mandatory', 'default', 'optional'])
         (rc, msg) = yb.buildTransaction()

--- a/src/pylorax/api/server.py
+++ b/src/pylorax/api/server.py
@@ -65,13 +65,19 @@ def v0_status():
             "db_supported": true,
             "db_version": "0",
             "schema_version": "0",
-            "backend": "lorax-composer"}
+            "backend": "lorax-composer",
+            "msgs": []}
+
+    The 'msgs' field can be a list of strings describing startup problems or status that
+    should be displayed to the user. eg. if the compose templates are not depsolving properly
+    the errors will be in 'msgs'.
     """
     return jsonify(backend="lorax-composer",
                    build=vernum,
                    api="0",
                    db_version="0",
                    schema_version="0",
-                   db_supported=True)
+                   db_supported=True,
+                   msgs=server.config["TEMPLATE_ERRORS"])
 
 v0_api(server)

--- a/src/sbin/lorax-composer
+++ b/src/sbin/lorax-composer
@@ -37,6 +37,7 @@ from gevent.pywsgi import WSGIServer
 
 from pylorax import vernum
 from pylorax.api.config import configure, make_yum_dirs, make_queue_dirs
+from pylorax.api.compose import test_templates
 from pylorax.api.queue import start_queue_monitor
 from pylorax.api.recipes import open_or_create_repo, commit_recipe_directory
 from pylorax.api.server import server, GitLock, YumLock
@@ -279,6 +280,9 @@ if __name__ == '__main__':
     # Get a YumBase to share with the requests
     yb = get_base_object(server.config["COMPOSER_CFG"])
     server.config["YUMLOCK"] = YumLock(yb=yb, lock=Lock())
+
+    # Depsolve the templates and make a note of the failures for /api/status to report
+    server.config["TEMPLATE_ERRORS"] = test_templates(yb, server.config["COMPOSER_CFG"].get("composer", "share_dir"))
 
     # Setup access to the git repo
     server.config["REPO_DIR"] = opts.BLUEPRINTS

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -61,6 +61,9 @@ class ServerTestCase(unittest.TestCase):
         yb = get_base_object(server.config["COMPOSER_CFG"])
         server.config["YUMLOCK"] = YumLock(yb=yb, lock=Lock())
 
+        # Include a message in /api/status output
+        server.config["TEMPLATE_ERRORS"] = ["Test message"]
+
         server.config['TESTING'] = True
         self.server = server.test_client()
         self.repo_dir = repo_dir
@@ -84,11 +87,15 @@ class ServerTestCase(unittest.TestCase):
 
     def test_01_status(self):
         """Test the /api/status route"""
-        status_fields = ["build", "api", "db_version", "schema_version", "db_supported", "backend"]
+        status_fields = ["build", "api", "db_version", "schema_version", "db_supported", "backend", "msgs"]
         resp = self.server.get("/api/status")
         data = json.loads(resp.data)
-        # Just make sure the fields are present
+        # Make sure the fields are present
         self.assertEqual(sorted(data.keys()), sorted(status_fields))
+
+        # Check for test message
+        self.assertEqual(data["msgs"], ["Test message"])
+
 
     def test_02_blueprints_list(self):
         """Test the /api/v0/blueprints/list route"""


### PR DESCRIPTION
Include individual package names when things fail.
Depsolve the compose template packages at startup and include failures in /api/status in a 'msgs' field that is a list of strings.
