### PR TITLE
Update to use only qemu-kvm

### DIFF
--- a/docs/livemedia-creator.rst
+++ b/docs/livemedia-creator.rst
@@ -25,7 +25,7 @@ minimum you need:
 
 ``--ks`` to select the kickstart file describing what to install.
 
-To use livemedia-creator with virtualization you will need to have qemu installed.
+To use livemedia-creator with virtualization you will need to have qemu-kvm installed.
 
 If you are going to be using Anaconda directly, with ``--no-virt`` mode, make sure
 you have the anaconda-tui package installed.

--- a/lorax.spec
+++ b/lorax.spec
@@ -90,16 +90,15 @@ Anaconda's image install feature.
 %package lmc-virt
 Summary:  livemedia-creator libvirt dependencies
 Requires: lorax = %{version}-%{release}
-Requires: qemu
+Requires: qemu-kvm
 
 # Fedora edk2 builds currently only support these arches
 %ifarch %{ix86} x86_64 %{arm} aarch64
 Requires: edk2-ovmf
 %endif
-Recommends: qemu-kvm
 
 %description lmc-virt
-Additional dependencies required by livemedia-creator when using it with qemu.
+Additional dependencies required by livemedia-creator when using it with qemu-kvm.
 
 %package lmc-novirt
 Summary:  livemedia-creator no-virt dependencies

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -84,8 +84,8 @@ def main():
         errors.append("the volume id cannot be longer than 32 characters")
 
     if is_install and not opts.no_virt \
-       and not any(glob.glob("/usr/bin/qemu-system-*")):
-        errors.append("qemu needs to be installed.")
+       and not any(glob.glob("/usr/libexec/qemu-kvm")):
+        errors.append("qemu-kvm needs to be installed.")
 
     if is_install and opts.no_virt \
        and not os.path.exists("/usr/sbin/anaconda"):


### PR DESCRIPTION
We only have qemu-kvm available, so use that. This also means that there
will not me any support for using qemu with arches that are different
from the host.