### PR TITLE
composer-cli: clean up "list" commands and add bash completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ install: all
 	mkdir -p $(DESTDIR)/$(mandir)/man1
 	install -m 644 docs/man/lorax.1 $(DESTDIR)/$(mandir)/man1
 	install -m 644 docs/man/livemedia-creator.1 $(DESTDIR)/$(mandir)/man1
+	mkdir -p $(DESTDIR)/etc/bash_completion.d
+	install -m 644 etc/bash_completion.d/composer-cli $(DESTDIR)/etc/bash_completion.d
 
 check:
 	@echo "*** Running pylint ***"

--- a/etc/bash_completion.d/composer-cli
+++ b/etc/bash_completion.d/composer-cli
@@ -1,0 +1,143 @@
+# bash completion for composer-cli
+
+__composer_cli_flags="-h --help -j --json -s --socket --log -a --api --test -V"
+
+declare -A __composer_cli_cmds=(
+  [compose]="list start types status log cancel delete details metadata logs results image"
+  [blueprints]="list show changes diff save delete depsolve push freeze tag undo workspace"
+  [modules]="list"
+  [projects]="list info"
+  [sources]="list info add change delete"
+  [help]=""
+)
+
+__composer_socket_ok() {
+    [ -w "${COMPOSER_SOCKET:-/run/weldr/api.socket}" ]
+}
+
+__composer_blueprints() {
+    __composer_socket_ok && composer-cli blueprints list
+}
+
+__composer_sources() {
+    __composer_socket_ok && composer-cli sources list
+}
+
+__composer_compose_types() {
+    __composer_socket_ok && composer-cli compose types
+}
+
+__composer_composes() {
+    __composer_socket_ok && composer-cli compose list $@ | while read id rest; do echo $id; done
+}
+
+__word_in_list() {
+    local w word=$1; shift
+    for w in "$@"; do
+        [ "$w" == "$word" ] && return 0
+    done
+    return 1
+}
+
+_composer_cli() {
+    local cur="${COMP_WORDS[COMP_CWORD]}" prev="${COMP_WORDS[COMP_CWORD-1]}"
+    local w="" wi=0 cmd="__NONE__" subcmd="__NONE__" cmd_cword=0
+
+    # find the command and its subcommand
+    for (( wi=0; wi < ${#COMP_WORDS[*]}; wi++ )); do
+        if __word_in_list "${COMP_WORDS[wi]}" "${!__composer_cli_cmds[@]}"; then
+            cmd="${COMP_WORDS[wi]}"
+            subcmd="${COMP_WORDS[wi+1]}"
+            cmd_cword=$((COMP_CWORD-wi))
+            break
+        fi
+    done
+
+    COMPREPLY=()
+
+    if [ "$cmd_cword" -le 0 ]; then
+        # No command yet, complete flags or commands
+        case "$prev" in
+            -s|--socket|--log)
+                # If it's a flag that takes a filename, suggest filenames
+                compopt -o filenames
+                COMPREPLY=($(compgen -f -- "${cur}"))
+            ;;
+            -a|--api|--test)
+                # If it's a flag that takes an arg we can't guess, don't suggest anything
+                COMPREPLY=()
+            ;;
+            *)
+                if [ "${cur:0:1}" == "-" ]; then
+                    # Suggest flags if cur starts with '-'
+                    COMPREPLY=($(compgen -W "${__composer_cli_flags}" -- "${cur}"))
+                else
+                    # Suggest commands if there isn't one already
+                    COMPREPLY=($(compgen -W "${!__composer_cli_cmds[*]}" -- "${cur}"))
+                fi
+            ;;
+        esac
+    elif [ $cmd_cword == 1 ]; then
+        # Complete the word after the command
+        COMPREPLY=($(compgen -W "${__composer_cli_cmds[$cmd]} help" -- "${cur}"))
+    elif [ $cmd_cword == 2 ]; then
+        # Complete word(s) after subcommand
+        case "$cmd:$subcmd" in
+            compose:list)
+                COMPREPLY=($(compgen -W "waiting running finish failed" -- "${cur}"))
+            ;;
+            *:list|*:help|compose:types)
+                COMPREPLY=()
+            ;;
+            sources:info|sources:delete)
+                COMPREPLY=($(compgen -W "$(__composer_sources)" -- "${cur}"))
+            ;;
+            sources:add|sources:change|blueprints:workspace|blueprints:push)
+                compopt -o filenames
+                COMPREPLY=($(compgen -f -- "${cur}"))
+            ;;
+            blueprints:freeze)
+                COMPREPLY=($(compgen -W "$(__composer_blueprints) show save" -- "${cur}"))
+            ;;
+            compose:start|blueprints:*)
+                COMPREPLY=($(compgen -W "$(__composer_blueprints)" -- "${cur}"))
+            ;;
+            compose:cancel)
+                COMPREPLY=($(compgen -W "$(__composer_composes running waiting)" -- "${cur}"))
+            ;;
+            compose:delete|compose:results|compose:metadata)
+                COMPREPLY=($(compgen -W "$(__composer_composes finished failed)" -- "${cur}"))
+            ;;
+            compose:log*)
+                COMPREPLY=($(compgen -W "$(__composer_composes running finished failed)" -- "${cur}"))
+            ;;
+            compose:image)
+                COMPREPLY=($(compgen -W "$(__composer_composes finished)" -- "${cur}"))
+            ;;
+            compose:*)
+                COMPREPLY=($(compgen -W "$(__composer_composes)" -- "${cur}"))
+            ;;
+        esac
+    else
+        # Complete words past the subcommand's argument (if appropriate)
+        case "$cmd:$subcmd" in
+            compose:delete)
+                COMPREPLY=($(compgen -W "$(__composer_composes finished failed)" -- "${cur}"))
+            ;;
+            compose:start)
+                if [ "$cmd_cword" == 3 ]; then
+                    COMPREPLY=($(compgen -W "$(__composer_compose_types)" -- "${cur}"))
+                fi
+            ;;
+            # TODO: blueprints:diff and blueprints:undo want commits
+            blueprints:freeze|blueprints:save|blueprints:depsolve|blueprints:changes|blueprints:show)
+                COMPREPLY=($(compgen -W "$(__composer_blueprints)" -- "${cur}"))
+            ;;
+            sources:info)
+                COMPREPLY=($(compgen -W "$(__composer_sources)" -- "${cur}"))
+            ;;
+        esac
+    fi
+}
+
+complete -F _composer_cli composer-cli

--- a/lorax.spec
+++ b/lorax.spec
@@ -225,6 +225,7 @@ getent passwd weldr >/dev/null 2>&1 || useradd -r -g weldr -d / -s /sbin/nologin
 %files -n composer-cli
 %{_bindir}/composer-cli
 %{python3_sitelib}/composer/*
+%{_sysconfdir}/bash-completion/composer-cli
 
 %changelog
 * Fri Jul 20 2018 Brian C. Lane <bcl@redhat.com> 29.10-1

--- a/src/composer/cli/blueprints.py
+++ b/src/composer/cli/blueprints.py
@@ -77,7 +77,8 @@ def blueprints_list(socket_path, api_version, args, show_json=False):
     if exit_now:
         return rc
 
-    print("blueprints: " + ", ".join([r for r in result["blueprints"]]))
+    # "list" should output a plain list of identifiers, one per line.
+    print("\n".join(result["blueprints"]))
 
     return rc
 

--- a/src/composer/cli/help.py
+++ b/src/composer/cli/help.py
@@ -25,6 +25,9 @@ compose types
 compose status
     List the status of all running and finished composes.
 
+compose list [waiting|running|finished|failed]
+    List basic information about composes.
+
 compose log <UUID> [<SIZE>]
     Show the last SIZE kB of the compose log.
 

--- a/src/composer/cli/modules.py
+++ b/src/composer/cli/modules.py
@@ -42,6 +42,7 @@ def modules_cmd(opts):
     if exit_now:
         return rc
 
-    print("Modules:\n" + "\n".join(["    "+r["name"] for r in result["modules"]]))
+    # "list" should output a plain list of identifiers, one per line.
+    print("\n".join(r["name"] for r in result["modules"]))
 
     return rc

--- a/src/composer/cli/sources.py
+++ b/src/composer/cli/sources.py
@@ -67,7 +67,8 @@ def sources_list(socket_path, api_version, args, show_json=False):
     if exit_now:
         return rc
 
-    print("Sources: %s" % ", ".join(result["sources"]))
+    # "list" should output a plain list of identifiers, one per line.
+    print("\n".join(result["sources"]))
     return rc
 
 def sources_info(socket_path, api_version, args, show_json=False):


### PR DESCRIPTION
Here's two commits to that clean up the various composer-cli "list" commands and then add `/etc/bash_completion.d/composer-cli`, which does fancy tab completion to make composer-cli funner to use. Such fun. Man.