### PR TITLE
Run as root/weldr by default.

### DIFF
--- a/src/sbin/lorax-composer
+++ b/src/sbin/lorax-composer
@@ -45,6 +45,9 @@ from pylorax.api.yumbase import get_base_object
 
 VERSION = "{0}-{1}".format(os.path.basename(sys.argv[0]), vernum)
 
+DEFAULT_USER  = "root"
+DEFAULT_GROUP = "weldr"
+
 def get_parser():
     """ Return the ArgumentParser for lorax-composer"""
 
@@ -53,9 +56,9 @@ def get_parser():
 
     parser.add_argument("--socket", default="/run/weldr/api.socket", metavar="SOCKET",
                         help="Path to the socket file to listen on")
-    parser.add_argument("--user", default="weldr", metavar="USER",
+    parser.add_argument("--user", default=DEFAULT_USER, metavar="USER",
                         help="User to use for reduced permissions")
-    parser.add_argument("--group", default="weldr", metavar="GROUP",
+    parser.add_argument("--group", default=DEFAULT_GROUP, metavar="GROUP",
                         help="Group to set ownership of the socket to")
     parser.add_argument("--log", dest="logfile", default="/var/log/lorax-composer/composer.log", metavar="LOG",
                         help="Path to logfile (/var/log/lorax-composer/composer.log)")
@@ -267,7 +270,8 @@ if __name__ == '__main__':
 
     start_queue_monitor(server.config["COMPOSER_CFG"], uid, gid)
 
-    # Drop root privileges on the main process
+    # Change user and group on the main process.  Note that this still happens even if
+    # --user and --group were passed in, but changing to the same user should be fine.
     os.setgid(gid)
     os.setuid(uid)
     log.debug("user is now %s:%s", os.getresuid(), os.getresgid())


### PR DESCRIPTION
We need to be root to read the certificates that give access to the
package repos.  Right now, the alternative seems to be changing
permissions on the certs themselves, which seems less good.  We're
running anaconda as root anyway.