### PR TITLE
Return an error if /modules/info doesn't return anything.

### DIFF
--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -1560,6 +1560,11 @@ def v0_api(api):
             log.error("(v0_modules_info) %s", str(e))
             return jsonify(status=False, errors=[str(e)]), 400
 
+        if not modules:
+            msg = "one of the requested modules does not exist: %s" % module_names
+            log.error("(v0_modules_info) %s" % msg)
+            return jsonify(status=False, errors=[msg]), 400
+
         return jsonify(modules=modules)
 
     @api.route("/api/v0/compose", methods=["POST"])


### PR DESCRIPTION
Unfortunately, this isn't very useful if /modules/info is provided with
multiple modules.  yum doesn't traceback when doPackageLists is given
something that doesn't exist.  It just returns an empty list.  If
/modules/info is given just one module and yum gives us an empty list,
it's easy to say what happened.  If /modules/info is given several
modules and just one does not exist, we will not be able to detect that.

Fixing this would require doing more yum operations, which is likely to
slow things down and isn't the direction I want to be going.