### PR TITLE
Add error IDs to the API

### DIFF
--- a/src/composer/cli/utilities.py
+++ b/src/composer/cli/utilities.py
@@ -59,7 +59,7 @@ def handle_api_result(result, show_json=False):
     :param result: JSON result from the http query
     :type result: dict
     :rtype: tuple
-    :returns: (rc, errors)
+    :returns: (rc, should_exit_now)
 
     Return the correct rc for the program (0 or 1), and whether or
     not to continue processing the results.
@@ -68,7 +68,7 @@ def handle_api_result(result, show_json=False):
         print(json.dumps(result, indent=4))
     else:
         for err in result.get("errors", []):
-            log.error(err)
+            log.error(err["msg"])
 
     # What's the rc? If status is present, use that
     # If not, use length of errors

--- a/src/composer/http_client.py
+++ b/src/composer/http_client.py
@@ -50,7 +50,8 @@ def get_url_raw(socket_path, url):
     if r.status == 400:
         err = json.loads(r.data.decode("utf-8"))
         if "status" in err and err["status"] == False:
-            raise RuntimeError(", ".join(err["errors"]))
+            msgs = [e["msg"] for e in err["errors"]]
+            raise RuntimeError(", ".join(msgs))
 
     return r.data.decode('utf-8')
 
@@ -172,7 +173,8 @@ def download_file(socket_path, url, progress=True):
     if r.status == 400:
         err = json.loads(r.data.decode("utf-8"))
         if not err["status"]:
-            raise RuntimeError(", ".join(err["errors"]))
+            msgs = [e["msg"] for e in err["errors"]]
+            raise RuntimeError(", ".join(msgs))
 
     filename = get_filename(r.headers)
     if os.path.exists(filename):

--- a/src/pylorax/api/errors.py
+++ b/src/pylorax/api/errors.py
@@ -25,5 +25,12 @@ BAD_LIMIT_OR_OFFSET = "BadLimitOrOffset"
 # a build that is not yet done.
 BUILD_IN_WRONG_STATE = "BuildInWrongState"
 
+# Returned from the API when a blueprint name or other similar identifier is
+# given that contains invalid characters.
+INVALID_NAME = "InvalidName"
+
+# Returned from the API when a blueprint that was requested does not exist.
+UNKNOWN_BLUEPRINT = "UnknownBlueprint"
+
 # Returned from the API when a UUID that was requested does not exist.
 UNKNOWN_UUID = "UnknownUUID"

--- a/src/pylorax/api/errors.py
+++ b/src/pylorax/api/errors.py
@@ -29,6 +29,9 @@ BUILD_IN_WRONG_STATE = "BuildInWrongState"
 # given that contains invalid characters.
 INVALID_NAME = "InvalidName"
 
+# Returned from the API when someone tries to modify an immutable system source.
+SYSTEM_SOURCE = "SystemSource"
+
 # Returned from the API when a blueprint that was requested does not exist.
 UNKNOWN_BLUEPRINT = "UnknownBlueprint"
 
@@ -40,6 +43,9 @@ UNKNOWN_MODULE = "UnknownModule"
 
 # Returned from the API when a project that was requested does not exist.
 UNKNOWN_PROJECT = "UnknownProject"
+
+# Returned from the API when a source that was requested does not exist.
+UNKNOWN_SOURCE = "UnknownSource"
 
 # Returned from the API when a UUID that was requested does not exist.
 UNKNOWN_UUID = "UnknownUUID"

--- a/src/pylorax/api/errors.py
+++ b/src/pylorax/api/errors.py
@@ -32,5 +32,8 @@ INVALID_NAME = "InvalidName"
 # Returned from the API when a blueprint that was requested does not exist.
 UNKNOWN_BLUEPRINT = "UnknownBlueprint"
 
+# Returned from the API when a commit that was requested does not exist.
+UNKNOWN_COMMIT = "UnknownCommit"
+
 # Returned from the API when a UUID that was requested does not exist.
 UNKNOWN_UUID = "UnknownUUID"

--- a/src/pylorax/api/errors.py
+++ b/src/pylorax/api/errors.py
@@ -24,6 +24,9 @@ BAD_COMPOSE_TYPE = "BadComposeType"
 # not convert into an integer.
 BAD_LIMIT_OR_OFFSET = "BadLimitOrOffset"
 
+# Returned from the API for all other errors from a /blueprints/* route.
+BLUEPRINTS_ERROR = "BlueprintsError"
+
 # Returned from the API for any other error resulting from /compose failing.
 BUILD_FAILED = "BuildFailed"
 
@@ -32,6 +35,13 @@ BUILD_FAILED = "BuildFailed"
 # a build that is not yet done.
 BUILD_IN_WRONG_STATE = "BuildInWrongState"
 
+# Returned from the API when some file is requested that is not present - a log
+# file, the compose results, etc.
+BUILD_MISSING_FILE = "BuildMissingFile"
+
+# Returned from the API for all other errors from a /compose/* route.
+COMPOSE_ERROR = "ComposeError"
+
 # Returned from the API when a blueprint name or other similar identifier is
 # given that contains invalid characters.
 INVALID_NAME = "InvalidName"
@@ -39,6 +49,12 @@ INVALID_NAME = "InvalidName"
 # Returned from the API when /compose is called without the POST body telling it
 # what to compose.
 MISSING_POST = "MissingPost"
+
+# Returned from the API for all other errors from a /modules/* route.
+MODULES_ERROR = "ModulesError"
+
+# Returned from the API for all other errors from a /projects/* route.
+PROJECTS_ERROR = "ProjectsError"
 
 # Returned from the API when someone tries to modify an immutable system source.
 SYSTEM_SOURCE = "SystemSource"

--- a/src/pylorax/api/errors.py
+++ b/src/pylorax/api/errors.py
@@ -16,9 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# Returned from the API when either an invalid compose type is given, or not
+# compose type is given.
+BAD_COMPOSE_TYPE = "BadComposeType"
+
 # Returned from the API when ?limit= or ?offset= is given something that does
 # not convert into an integer.
 BAD_LIMIT_OR_OFFSET = "BadLimitOrOffset"
+
+# Returned from the API for any other error resulting from /compose failing.
+BUILD_FAILED = "BuildFailed"
 
 # Returned from the API when it expected a build to be in a state other than
 # what it currently is.  This most often happens when asking for results from
@@ -28,6 +35,10 @@ BUILD_IN_WRONG_STATE = "BuildInWrongState"
 # Returned from the API when a blueprint name or other similar identifier is
 # given that contains invalid characters.
 INVALID_NAME = "InvalidName"
+
+# Returned from the API when /compose is called without the POST body telling it
+# what to compose.
+MISSING_POST = "MissingPost"
 
 # Returned from the API when someone tries to modify an immutable system source.
 SYSTEM_SOURCE = "SystemSource"

--- a/src/pylorax/api/errors.py
+++ b/src/pylorax/api/errors.py
@@ -1,0 +1,21 @@
+#
+# lorax-composer API server
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Returned from the API when ?limit= or ?offset= is given something that does
+# not convert into an integer.
+BAD_LIMIT_OR_OFFSET = "BadLimitOrOffset"

--- a/src/pylorax/api/errors.py
+++ b/src/pylorax/api/errors.py
@@ -35,5 +35,11 @@ UNKNOWN_BLUEPRINT = "UnknownBlueprint"
 # Returned from the API when a commit that was requested does not exist.
 UNKNOWN_COMMIT = "UnknownCommit"
 
+# Returned from the API when a module that was requested does not exist.
+UNKNOWN_MODULE = "UnknownModule"
+
+# Returned from the API when a project that was requested does not exist.
+UNKNOWN_PROJECT = "UnknownProject"
+
 # Returned from the API when a UUID that was requested does not exist.
 UNKNOWN_UUID = "UnknownUUID"

--- a/src/pylorax/api/errors.py
+++ b/src/pylorax/api/errors.py
@@ -19,3 +19,8 @@
 # Returned from the API when ?limit= or ?offset= is given something that does
 # not convert into an integer.
 BAD_LIMIT_OR_OFFSET = "BadLimitOrOffset"
+
+# Returned from the API when it expected a build to be in a state other than
+# what it currently is.  This most often happens when asking for results from
+# a build that is not yet done.
+BUILD_IN_WRONG_STATE = "BuildInWrongState"

--- a/src/pylorax/api/errors.py
+++ b/src/pylorax/api/errors.py
@@ -42,9 +42,9 @@ BUILD_MISSING_FILE = "BuildMissingFile"
 # Returned from the API for all other errors from a /compose/* route.
 COMPOSE_ERROR = "ComposeError"
 
-# Returned from the API when a blueprint name or other similar identifier is
-# given that contains invalid characters.
-INVALID_NAME = "InvalidName"
+# Returned from the API when invalid characters are used in a route path or in
+# some identifier.
+INVALID_CHARS = "InvalidChars"
 
 # Returned from the API when /compose is called without the POST body telling it
 # what to compose.

--- a/src/pylorax/api/errors.py
+++ b/src/pylorax/api/errors.py
@@ -24,3 +24,6 @@ BAD_LIMIT_OR_OFFSET = "BadLimitOrOffset"
 # what it currently is.  This most often happens when asking for results from
 # a build that is not yet done.
 BUILD_IN_WRONG_STATE = "BuildInWrongState"
+
+# Returned from the API when a UUID that was requested does not exist.
+UNKNOWN_UUID = "UnknownUUID"

--- a/src/pylorax/api/queue.py
+++ b/src/pylorax/api/queue.py
@@ -452,7 +452,7 @@ def uuid_info(cfg, uuid):
     :type cfg: ComposerConfig
     :param uuid: The UUID of the build
     :type uuid: str
-    :returns: dictionary of information about the composition
+    :returns: dictionary of information about the composition or None
     :rtype: dict
     :raises: RuntimeError if there was a problem
 
@@ -468,7 +468,7 @@ def uuid_info(cfg, uuid):
     """
     uuid_dir = joinpaths(cfg.get("composer", "lib_dir"), "results", uuid)
     if not os.path.exists(uuid_dir):
-        raise RuntimeError("%s is not a valid build_id" % uuid)
+        return None
 
     # Load the compose configuration
     cfg_path = joinpaths(uuid_dir, "config.toml")

--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -983,6 +983,7 @@ from pylorax.sysutils import joinpaths
 from pylorax.api.checkparams import checkparams
 from pylorax.api.compose import start_build, compose_types
 from pylorax.api.crossdomain import crossdomain
+from pylorax.api.errors import *                               # pylint: disable=wildcard-import
 from pylorax.api.projects import projects_list, projects_info, projects_depsolve
 from pylorax.api.projects import modules_list, modules_info, ProjectsError, repo_to_source
 from pylorax.api.projects import get_repo_sources, delete_repo_source, source_to_repo, yum_repo_to_file_repo
@@ -1025,7 +1026,7 @@ def v0_api(api):
             limit = int(request.args.get("limit", "20"))
             offset = int(request.args.get("offset", "0"))
         except ValueError as e:
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": BAD_LIMIT_OR_OFFSET, "msg": str(e)}]), 400
 
         with api.config["GITLOCK"].lock:
             blueprints = take_limits(map(lambda f: f[:-5], list_branch_files(api.config["GITLOCK"].repo, branch)), offset, limit)
@@ -1114,7 +1115,7 @@ def v0_api(api):
             limit = int(request.args.get("limit", "20"))
             offset = int(request.args.get("offset", "0"))
         except ValueError as e:
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": BAD_LIMIT_OR_OFFSET, "msg": str(e)}]), 400
 
         blueprints = []
         errors = []
@@ -1465,7 +1466,7 @@ def v0_api(api):
             limit = int(request.args.get("limit", "20"))
             offset = int(request.args.get("offset", "0"))
         except ValueError as e:
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": BAD_LIMIT_OR_OFFSET, "msg": str(e)}]), 400
 
         try:
             with api.config["YUMLOCK"].lock:
@@ -1670,7 +1671,7 @@ def v0_api(api):
             limit = int(request.args.get("limit", "20"))
             offset = int(request.args.get("offset", "0"))
         except ValueError as e:
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": BAD_LIMIT_OR_OFFSET, "msg": str(e)}]), 400
 
         if module_names:
             module_names = module_names.split(",")

--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -1508,6 +1508,11 @@ def v0_api(api):
             log.error("(v0_projects_info) %s", str(e))
             return jsonify(status=False, errors=[str(e)]), 400
 
+        if not projects:
+            msg = "one of the requested projects does not exist: %s" % project_names
+            log.error("(v0_projects_info) %s", msg)
+            return jsonify(status=False, errors=[{"id": UNKNOWN_PROJECT, "msg": msg}]), 400
+
         return jsonify(projects=projects)
 
     @api.route("/api/v0/projects/depsolve", defaults={'project_names': ""})
@@ -1525,6 +1530,11 @@ def v0_api(api):
         except ProjectsError as e:
             log.error("(v0_projects_depsolve) %s", str(e))
             return jsonify(status=False, errors=[str(e)]), 400
+
+        if not deps:
+            msg = "one of the requested projects does not exist: %s" % project_names
+            log.error("(v0_projects_depsolve) %s", msg)
+            return jsonify(status=False, errors=[{"id": UNKNOWN_PROJECT, "msg": msg}]), 400
 
         return jsonify(projects=deps)
 
@@ -1697,6 +1707,11 @@ def v0_api(api):
             log.error("(v0_modules_list) %s", str(e))
             return jsonify(status=False, errors=[str(e)]), 400
 
+        if module_names and not available:
+            msg = "one of the requested modules does not exist: %s" % module_names
+            log.error("(v0_modules_list) %s", msg)
+            return jsonify(status=False, errors=[{"id": UNKNOWN_MODULE, "msg": msg}]), 400
+
         modules = take_limits(available, offset, limit)
         return jsonify(modules=modules, offset=offset, limit=limit, total=len(available))
 
@@ -1718,7 +1733,7 @@ def v0_api(api):
         if not modules:
             msg = "one of the requested modules does not exist: %s" % module_names
             log.error("(v0_modules_info) %s", msg)
-            return jsonify(status=False, errors=[msg]), 400
+            return jsonify(status=False, errors=[{"id": UNKNOWN_MODULE, "msg": msg}]), 400
 
         return jsonify(modules=modules)
 

--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -1270,7 +1270,7 @@ def v0_api(api):
                 workspace_write(api.config["GITLOCK"].repo, branch, blueprint)
         except Exception as e:
             log.error("(v0_blueprints_undo) %s", str(e))
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": UNKNOWN_COMMIT, "msg": str(e)}]), 400
         else:
             return jsonify(status=True)
 
@@ -1323,7 +1323,7 @@ def v0_api(api):
                     old_blueprint = read_recipe_commit(api.config["GITLOCK"].repo, branch, blueprint_name, from_commit)
         except Exception as e:
             log.error("(v0_blueprints_diff) %s", str(e))
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": UNKNOWN_COMMIT, "msg": str(e)}]), 400
 
         try:
             if to_commit == "WORKSPACE":
@@ -1341,7 +1341,7 @@ def v0_api(api):
                     new_blueprint = read_recipe_commit(api.config["GITLOCK"].repo, branch, blueprint_name, to_commit)
         except Exception as e:
             log.error("(v0_blueprints_diff) %s", str(e))
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": UNKNOWN_COMMIT, "msg": str(e)}]), 400
 
         diff = recipe_diff(old_blueprint, new_blueprint)
         return jsonify(diff=diff)

--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -1819,7 +1819,7 @@ def v0_api(api):
             return jsonify(status=False, errors=["%s is not a valid build uuid" % uuid]), 400
 
         if status["queue_status"] not in ["WAITING", "RUNNING"]:
-            return jsonify(status=False, errors=["Build %s is not in WAITING or RUNNING." % uuid])
+            return jsonify(status=False, errors=[{"id": BUILD_IN_WRONG_STATE, "msg": "Build %s is not in WAITING or RUNNING." % uuid}])
 
         try:
             uuid_cancel(api.config["COMPOSER_CFG"], uuid)
@@ -1844,7 +1844,7 @@ def v0_api(api):
             if status is None:
                 errors.append("%s is not a valid build uuid" % uuid)
             elif status["queue_status"] not in ["FINISHED", "FAILED"]:
-                errors.append("Build %s is not in FINISHED or FAILED." % uuid)
+                errors.append({"id": BUILD_IN_WRONG_STATE, "msg": "Build %s is not in FINISHED or FAILED." % uuid})
             else:
                 try:
                     uuid_delete(api.config["COMPOSER_CFG"], uuid)
@@ -1883,7 +1883,7 @@ def v0_api(api):
         if status is None:
             return jsonify(status=False, errors=["%s is not a valid build uuid" % uuid]), 400
         if status["queue_status"] not in ["FINISHED", "FAILED"]:
-            return jsonify(status=False, errors=["Build %s not in FINISHED or FAILED state." % uuid]), 400
+            return jsonify(status=False, errors=[{"id": BUILD_IN_WRONG_STATE, "msg": "Build %s not in FINISHED or FAILED state." % uuid}]), 400
         else:
             return Response(uuid_tar(api.config["COMPOSER_CFG"], uuid, metadata=True, image=False, logs=False),
                             mimetype="application/x-tar",
@@ -1903,7 +1903,7 @@ def v0_api(api):
         if status is None:
             return jsonify(status=False, errors=["%s is not a valid build uuid" % uuid]), 400
         elif status["queue_status"] not in ["FINISHED", "FAILED"]:
-            return jsonify(status=False, errors=["Build %s not in FINISHED or FAILED state." % uuid]), 400
+            return jsonify(status=False, errors=[{"id": BUILD_IN_WRONG_STATE, "msg": "Build %s not in FINISHED or FAILED state." % uuid}]), 400
         else:
             return Response(uuid_tar(api.config["COMPOSER_CFG"], uuid, metadata=True, image=True, logs=True),
                             mimetype="application/x-tar",
@@ -1923,7 +1923,7 @@ def v0_api(api):
         if status is None:
             return jsonify(status=False, errors=["%s is not a valid build uuid" % uuid]), 400
         elif status["queue_status"] not in ["FINISHED", "FAILED"]:
-            return jsonify(status=False, errors=["Build %s not in FINISHED or FAILED state." % uuid]), 400
+            return jsonify(status=False, errors=[{"id": BUILD_IN_WRONG_STATE, "msg": "Build %s not in FINISHED or FAILED state." % uuid}]), 400
         else:
             return Response(uuid_tar(api.config["COMPOSER_CFG"], uuid, metadata=False, image=False, logs=True),
                             mimetype="application/x-tar",
@@ -1943,7 +1943,7 @@ def v0_api(api):
         if status is None:
             return jsonify(status=False, errors=["%s is not a valid build uuid" % uuid]), 400
         elif status["queue_status"] not in ["FINISHED", "FAILED"]:
-            return jsonify(status=False, errors=["Build %s not in FINISHED or FAILED state." % uuid]), 400
+            return jsonify(status=False, errors=[{"id": BUILD_IN_WRONG_STATE, "msg": "Build %s not in FINISHED or FAILED state." % uuid}]), 400
         else:
             image_name, image_path = uuid_image(api.config["COMPOSER_CFG"], uuid)
 
@@ -1974,7 +1974,7 @@ def v0_api(api):
         if status is None:
             return jsonify(status=False, errors=["%s is not a valid build uuid" % uuid]), 400
         elif status["queue_status"] == "WAITING":
-            return jsonify(status=False, errors=["Build %s has not started yet. No logs to view" % uuid])
+            return jsonify(status=False, errors=[{"id": BUILD_IN_WRONG_STATE, "msg": "Build %s has not started yet. No logs to view" % uuid}])
         try:
             return Response(uuid_log(api.config["COMPOSER_CFG"], uuid, size), direct_passthrough=True)
         except RuntimeError as e:

--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -1572,7 +1572,7 @@ def v0_api(api):
             with api.config["YUMLOCK"].lock:
                 repo = api.config["YUMLOCK"].yb.repos.repos.get(source, None)
             if not repo:
-                errors.append("%s is not a valid source" % source)
+                errors.append({"id": UNKNOWN_SOURCE, "msg": "%s is not a valid source" % source})
                 continue
             sources[repo.id] = repo_to_source(repo, repo.id in system_sources)
 
@@ -1596,7 +1596,7 @@ def v0_api(api):
 
         system_sources = get_repo_sources("/etc/yum.repos.d/*.repo")
         if source["name"] in system_sources:
-            return jsonify(status=False, errors=["%s is a system source, it cannot be changed." % source["name"]]), 400
+            return jsonify(status=False, errors=[{"id": SYSTEM_SOURCE, "msg": "%s is a system source, it cannot be changed." % source["name"]}]), 400
 
         try:
             # Delete it from yum (if it exists) and replace it with the new one
@@ -1659,7 +1659,7 @@ def v0_api(api):
 
         system_sources = get_repo_sources("/etc/yum.repos.d/*.repo")
         if source_name in system_sources:
-            return jsonify(status=False, errors=["%s is a system source, it cannot be deleted." % source_name]), 400
+            return jsonify(status=False, errors=[{"id": SYSTEM_SOURCE, "msg": "%s is a system source, it cannot be deleted." % source_name}]), 400
         share_dir = api.config["COMPOSER_CFG"].get("composer", "repo_dir")
         try:
             # Remove the file entry for the source
@@ -1679,7 +1679,7 @@ def v0_api(api):
 
         except ProjectsError as e:
             log.error("(v0_projects_source_delete) %s", str(e))
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": UNKNOWN_SOURCE, "msg": str(e)}]), 400
 
         return jsonify(status=True)
 

--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -1758,7 +1758,7 @@ def v0_api(api):
 
         errors = []
         if not compose:
-            return jsonify(status=False, errors=["Missing POST body"]), 400
+            return jsonify(status=False, errors=[{"id": MISSING_POST, "msg": "Missing POST body"}]), 400
 
         if "blueprint_name" not in compose:
             errors.append({"id": UNKNOWN_BLUEPRINT,"msg": "No 'blueprint_name' in the JSON request"})
@@ -1771,7 +1771,7 @@ def v0_api(api):
             branch = compose["branch"]
 
         if "compose_type" not in compose:
-            errors.append("No 'compose_type' in the JSON request")
+            errors.append({"id": BAD_COMPOSE_TYPE, "msg": "No 'compose_type' in the JSON request"})
         else:
             compose_type = compose["compose_type"]
 
@@ -1785,7 +1785,10 @@ def v0_api(api):
             build_id = start_build(api.config["COMPOSER_CFG"], api.config["YUMLOCK"], api.config["GITLOCK"],
                                    branch, blueprint_name, compose_type, test_mode)
         except Exception as e:
-            return jsonify(status=False, errors=[str(e)]), 400
+            if "Invalid compose type" in str(e):
+                return jsonify(status=False, errors=[{"id": BAD_COMPOSE_TYPE, "msg": str(e)}]), 400
+            else:
+                return jsonify(status=False, errors=[{"id": BUILD_FAILED, "msg": str(e)}]), 400
 
         return jsonify(status=True, build_id=build_id)
 

--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -1090,7 +1090,6 @@ def v0_api(api):
         # Sort all the results by case-insensitive blueprint name
         changes = sorted(changes, key=lambda c: c["name"].lower())
         blueprints = sorted(blueprints, key=lambda r: r["name"].lower())
-        errors = sorted(errors, key=lambda e: e.lower())
 
         if out_fmt == "toml":
             # With TOML output we just want to dump the raw blueprint, skipping the rest.
@@ -1131,7 +1130,6 @@ def v0_api(api):
                 blueprints.append({"name":blueprint_name, "changes":commits, "total":len(commits)})
 
         blueprints = sorted(blueprints, key=lambda r: r["name"].lower())
-        errors = sorted(errors, key=lambda e: e.lower())
 
         return jsonify(blueprints=blueprints, errors=errors, offset=offset, limit=limit)
 

--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -1029,7 +1029,7 @@ def v0_api(api):
         """List the available blueprints on a branch."""
         branch = request.args.get("branch", "master")
         if VALID_API_STRING.match(branch) is None:
-            return jsonify(status=False, errors=["Invalid characters in branch argument"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in branch argument"}]), 400
 
         try:
             limit = int(request.args.get("limit", "20"))
@@ -1048,15 +1048,15 @@ def v0_api(api):
     def v0_blueprints_info(blueprint_names):
         """Return the contents of the blueprint, or a list of blueprints"""
         if VALID_API_STRING.match(blueprint_names) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         branch = request.args.get("branch", "master")
         if VALID_API_STRING.match(branch) is None:
-            return jsonify(status=False, errors=["Invalid characters in branch argument"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in branch argument"}]), 400
 
         out_fmt = request.args.get("format", "json")
         if VALID_API_STRING.match(out_fmt) is None:
-            return jsonify(status=False, errors=["Invalid characters in format argument"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in format argument"}]), 400
 
         blueprints = []
         changes = []
@@ -1114,11 +1114,11 @@ def v0_api(api):
     def v0_blueprints_changes(blueprint_names):
         """Return the changes to a blueprint or list of blueprints"""
         if VALID_API_STRING.match(blueprint_names) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         branch = request.args.get("branch", "master")
         if VALID_API_STRING.match(branch) is None:
-            return jsonify(status=False, errors=["Invalid characters in branch argument"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in branch argument"}]), 400
 
         try:
             limit = int(request.args.get("limit", "20"))
@@ -1154,7 +1154,7 @@ def v0_api(api):
         """Commit a new blueprint"""
         branch = request.args.get("branch", "master")
         if VALID_API_STRING.match(branch) is None:
-            return jsonify(status=False, errors=["Invalid characters in branch argument"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in branch argument"}]), 400
 
         try:
             if request.headers['Content-Type'] == "text/x-toml":
@@ -1163,7 +1163,7 @@ def v0_api(api):
                 blueprint = recipe_from_dict(request.get_json(cache=False))
 
             if VALID_API_STRING.match(blueprint["name"]) is None:
-                return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+                return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
             with api.config["GITLOCK"].lock:
                 commit_recipe(api.config["GITLOCK"].repo, branch, blueprint)
@@ -1184,11 +1184,11 @@ def v0_api(api):
     def v0_blueprints_delete(blueprint_name):
         """Delete a blueprint from git"""
         if VALID_API_STRING.match(blueprint_name) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         branch = request.args.get("branch", "master")
         if VALID_API_STRING.match(branch) is None:
-            return jsonify(status=False, errors=[{"id": INVALID_NAME, "msg": "Invalid characters in branch argument"}]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in branch argument"}]), 400
 
         try:
             with api.config["GITLOCK"].lock:
@@ -1205,7 +1205,7 @@ def v0_api(api):
         """Write a blueprint to the workspace"""
         branch = request.args.get("branch", "master")
         if VALID_API_STRING.match(branch) is None:
-            return jsonify(status=False, errors=["Invalid characters in branch argument"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in branch argument"}]), 400
 
         try:
             if request.headers['Content-Type'] == "text/x-toml":
@@ -1214,7 +1214,7 @@ def v0_api(api):
                 blueprint = recipe_from_dict(request.get_json(cache=False))
 
             if VALID_API_STRING.match(blueprint["name"]) is None:
-                return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+                return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
             with api.config["GITLOCK"].lock:
                 workspace_write(api.config["GITLOCK"].repo, branch, blueprint)
@@ -1231,11 +1231,11 @@ def v0_api(api):
     def v0_blueprints_delete_workspace(blueprint_name):
         """Delete a blueprint from the workspace"""
         if VALID_API_STRING.match(blueprint_name) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         branch = request.args.get("branch", "master")
         if VALID_API_STRING.match(branch) is None:
-            return jsonify(status=False, errors=[{"id": INVALID_NAME, "msg": "Invalid characters in branch argument"}]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in branch argument"}]), 400
 
         try:
             with api.config["GITLOCK"].lock:
@@ -1255,11 +1255,11 @@ def v0_api(api):
     def v0_blueprints_undo(blueprint_name, commit):
         """Undo changes to a blueprint by reverting to a previous commit."""
         if VALID_API_STRING.match(blueprint_name) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         branch = request.args.get("branch", "master")
         if VALID_API_STRING.match(branch) is None:
-            return jsonify(status=False, errors=[{"id": INVALID_NAME, "msg": "Invalid characters in branch argument"}]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in branch argument"}]), 400
 
         try:
             with api.config["GITLOCK"].lock:
@@ -1281,11 +1281,11 @@ def v0_api(api):
     def v0_blueprints_tag(blueprint_name):
         """Tag a blueprint's latest blueprint commit as a 'revision'"""
         if VALID_API_STRING.match(blueprint_name) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         branch = request.args.get("branch", "master")
         if VALID_API_STRING.match(branch) is None:
-            return jsonify(status=False, errors=[{"id": INVALID_NAME, "msg": "Invalid characters in branch argument"}]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in branch argument"}]), 400
 
         try:
             with api.config["GITLOCK"].lock:
@@ -1308,11 +1308,11 @@ def v0_api(api):
         """Return the differences between two commits of a blueprint"""
         for s in [blueprint_name, from_commit, to_commit]:
             if VALID_API_STRING.match(s) is None:
-                return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+                return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         branch = request.args.get("branch", "master")
         if VALID_API_STRING.match(branch) is None:
-            return jsonify(status=False, errors=[{"id": INVALID_NAME, "msg": "Invalid characters in branch argument"}]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in branch argument"}]), 400
 
         try:
             if from_commit == "NEWEST":
@@ -1353,15 +1353,15 @@ def v0_api(api):
     def v0_blueprints_freeze(blueprint_names):
         """Return the blueprint with the exact modules and packages selected by depsolve"""
         if VALID_API_STRING.match(blueprint_names) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         branch = request.args.get("branch", "master")
         if VALID_API_STRING.match(branch) is None:
-            return jsonify(status=False, errors=["Invalid characters in branch argument"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in branch argument"}]), 400
 
         out_fmt = request.args.get("format", "json")
         if VALID_API_STRING.match(out_fmt) is None:
-            return jsonify(status=False, errors=["Invalid characters in format argument"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in format argument"}]), 400
 
         blueprints = []
         errors = []
@@ -1417,11 +1417,11 @@ def v0_api(api):
     def v0_blueprints_depsolve(blueprint_names):
         """Return the dependencies for a blueprint"""
         if VALID_API_STRING.match(blueprint_names) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         branch = request.args.get("branch", "master")
         if VALID_API_STRING.match(branch) is None:
-            return jsonify(status=False, errors=["Invalid characters in branch argument"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in branch argument"}]), 400
 
         blueprints = []
         errors = []
@@ -1499,7 +1499,7 @@ def v0_api(api):
     def v0_projects_info(project_names):
         """Return detailed information about the listed projects"""
         if VALID_API_STRING.match(project_names) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         try:
             with api.config["YUMLOCK"].lock:
@@ -1522,7 +1522,7 @@ def v0_api(api):
     def v0_projects_depsolve(project_names):
         """Return detailed information about the listed projects"""
         if VALID_API_STRING.match(project_names) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         try:
             with api.config["YUMLOCK"].lock:
@@ -1554,11 +1554,11 @@ def v0_api(api):
     def v0_projects_source_info(source_names):
         """Return detailed info about the list of sources"""
         if VALID_API_STRING.match(source_names) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         out_fmt = request.args.get("format", "json")
         if VALID_API_STRING.match(out_fmt) is None:
-            return jsonify(status=False, errors=["Invalid characters in format argument"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in format argument"}]), 400
 
         # Return info on all of the sources
         if source_names == "*":
@@ -1655,7 +1655,7 @@ def v0_api(api):
     def v0_projects_source_delete(source_name):
         """Delete the named source and return a status response"""
         if VALID_API_STRING.match(source_name) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         system_sources = get_repo_sources("/etc/yum.repos.d/*.repo")
         if source_name in system_sources:
@@ -1689,7 +1689,7 @@ def v0_api(api):
     def v0_modules_list(module_names=None):
         """List available modules, filtering by module_names"""
         if module_names and VALID_API_STRING.match(module_names) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         try:
             limit = int(request.args.get("limit", "20"))
@@ -1722,7 +1722,7 @@ def v0_api(api):
     def v0_modules_info(module_names):
         """Return detailed information about the listed modules"""
         if VALID_API_STRING.match(module_names) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
         try:
             with api.config["YUMLOCK"].lock:
                 modules = modules_info(api.config["YUMLOCK"].yb, module_names.split(","))
@@ -1776,7 +1776,7 @@ def v0_api(api):
             compose_type = compose["compose_type"]
 
         if VALID_API_STRING.match(blueprint_name) is None:
-            errors.append("Invalid characters in API path")
+            errors.append({"id": INVALID_CHARS, "msg": "Invalid characters in API path"})
 
         if errors:
             return jsonify(status=False, errors=errors), 400
@@ -1827,7 +1827,7 @@ def v0_api(api):
     def v0_compose_status(uuids):
         """Return the status of the listed uuids"""
         if VALID_API_STRING.match(uuids) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         results = []
         errors = []
@@ -1847,7 +1847,7 @@ def v0_api(api):
     def v0_compose_cancel(uuid):
         """Cancel a running compose and delete its results directory"""
         if VALID_API_STRING.match(uuid) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         status = uuid_status(api.config["COMPOSER_CFG"], uuid)
         if status is None:
@@ -1870,7 +1870,7 @@ def v0_api(api):
     def v0_compose_delete(uuids):
         """Delete the compose results for the listed uuids"""
         if VALID_API_STRING.match(uuids) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         results = []
         errors = []
@@ -1896,7 +1896,7 @@ def v0_api(api):
     def v0_compose_info(uuid):
         """Return detailed info about a compose"""
         if VALID_API_STRING.match(uuid) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         try:
             info = uuid_info(api.config["COMPOSER_CFG"], uuid)
@@ -1915,7 +1915,7 @@ def v0_api(api):
     def v0_compose_metadata(uuid):
         """Return a tar of the metadata for the build"""
         if VALID_API_STRING.match(uuid) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         status = uuid_status(api.config["COMPOSER_CFG"], uuid)
         if status is None:
@@ -1935,7 +1935,7 @@ def v0_api(api):
     def v0_compose_results(uuid):
         """Return a tar of the metadata and the results for the build"""
         if VALID_API_STRING.match(uuid) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         status = uuid_status(api.config["COMPOSER_CFG"], uuid)
         if status is None:
@@ -1955,7 +1955,7 @@ def v0_api(api):
     def v0_compose_logs(uuid):
         """Return a tar of the metadata for the build"""
         if VALID_API_STRING.match(uuid) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         status = uuid_status(api.config["COMPOSER_CFG"], uuid)
         if status is None:
@@ -1975,7 +1975,7 @@ def v0_api(api):
     def v0_compose_image(uuid):
         """Return the output image for the build"""
         if VALID_API_STRING.match(uuid) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         status = uuid_status(api.config["COMPOSER_CFG"], uuid)
         if status is None:
@@ -2001,7 +2001,7 @@ def v0_api(api):
     def v0_compose_log_tail(uuid):
         """Return the end of the main anaconda.log, defaults to 1Mbytes"""
         if VALID_API_STRING.match(uuid) is None:
-            return jsonify(status=False, errors=["Invalid characters in API path"]), 400
+            return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
 
         try:
             size = int(request.args.get("size", "1024"))

--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -1139,7 +1139,7 @@ def v0_api(api):
                 with api.config["GITLOCK"].lock:
                     commits = take_limits(list_commits(api.config["GITLOCK"].repo, branch, filename), offset, limit)
             except Exception as e:
-                errors.append("%s: %s" % (blueprint_name, str(e)))
+                errors.append({"id": BLUEPRINTS_ERROR, "msg": "%s: %s" % (blueprint_name, str(e))})
                 log.error("(v0_blueprints_changes) %s", str(e))
             else:
                 blueprints.append({"name":blueprint_name, "changes":commits, "total":len(commits)})
@@ -1173,7 +1173,7 @@ def v0_api(api):
                 workspace_write(api.config["GITLOCK"].repo, branch, blueprint)
         except Exception as e:
             log.error("(v0_blueprints_new) %s", str(e))
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": BLUEPRINTS_ERROR, "msg": str(e)}]), 400
         else:
             return jsonify(status=True)
 
@@ -1195,7 +1195,7 @@ def v0_api(api):
                 delete_recipe(api.config["GITLOCK"].repo, branch, blueprint_name)
         except Exception as e:
             log.error("(v0_blueprints_delete) %s", str(e))
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": BLUEPRINTS_ERROR, "msg": str(e)}]), 400
         else:
             return jsonify(status=True)
 
@@ -1220,7 +1220,7 @@ def v0_api(api):
                 workspace_write(api.config["GITLOCK"].repo, branch, blueprint)
         except Exception as e:
             log.error("(v0_blueprints_workspace) %s", str(e))
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": BLUEPRINTS_ERROR, "msg": str(e)}]), 400
         else:
             return jsonify(status=True)
 
@@ -1242,7 +1242,7 @@ def v0_api(api):
                 workspace_delete(api.config["GITLOCK"].repo, branch, blueprint_name)
         except Exception as e:
             log.error("(v0_blueprints_delete_workspace) %s", str(e))
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": BLUEPRINTS_ERROR, "msg": str(e)}]), 400
         else:
             return jsonify(status=True)
 
@@ -1292,7 +1292,7 @@ def v0_api(api):
                 tag_recipe_commit(api.config["GITLOCK"].repo, branch, blueprint_name)
         except Exception as e:
             log.error("(v0_blueprints_tag) %s", str(e))
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": BLUEPRINTS_ERROR, "msg": str(e)}]), 400
         else:
             return jsonify(status=True)
 
@@ -1381,7 +1381,7 @@ def v0_api(api):
                     with api.config["GITLOCK"].lock:
                         blueprint = read_recipe_commit(api.config["GITLOCK"].repo, branch, blueprint_name)
                 except Exception as e:
-                    errors.append("%s: %s" % (blueprint_name, str(e)))
+                    errors.append({"id": BLUEPRINTS_ERROR, "msg": "%s: %s" % (blueprint_name, str(e))})
                     log.error("(v0_blueprints_freeze) %s", str(e))
 
             # No blueprint found, skip it.
@@ -1399,7 +1399,7 @@ def v0_api(api):
                 with api.config["YUMLOCK"].lock:
                     deps = projects_depsolve(api.config["YUMLOCK"].yb, projects, blueprint.group_names)
             except ProjectsError as e:
-                errors.append("%s: %s" % (blueprint_name, str(e)))
+                errors.append({"id": BLUEPRINTS_ERROR, "msg": "%s: %s" % (blueprint_name, str(e))})
                 log.error("(v0_blueprints_freeze) %s", str(e))
 
             blueprints.append({"blueprint": blueprint.freeze(deps)})
@@ -1441,7 +1441,7 @@ def v0_api(api):
                     with api.config["GITLOCK"].lock:
                         blueprint = read_recipe_commit(api.config["GITLOCK"].repo, branch, blueprint_name)
                 except Exception as e:
-                    errors.append("%s: %s" % (blueprint_name, str(e)))
+                    errors.append({"id": BLUEPRINTS_ERROR, "msg": "%s: %s" % (blueprint_name, str(e))})
                     log.error("(v0_blueprints_depsolve) %s", str(e))
 
             # No blueprint found, skip it.
@@ -1458,7 +1458,7 @@ def v0_api(api):
                 with api.config["YUMLOCK"].lock:
                     deps = projects_depsolve(api.config["YUMLOCK"].yb, projects, blueprint.group_names)
             except ProjectsError as e:
-                errors.append("%s: %s" % (blueprint_name, str(e)))
+                errors.append({"id": BLUEPRINTS_ERROR, "msg": "%s: %s" % (blueprint_name, str(e))})
                 log.error("(v0_blueprints_depsolve) %s", str(e))
 
             # Get the NEVRA's of the modules and projects, add as "modules"
@@ -1487,7 +1487,7 @@ def v0_api(api):
                 available = projects_list(api.config["YUMLOCK"].yb)
         except ProjectsError as e:
             log.error("(v0_projects_list) %s", str(e))
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": PROJECTS_ERROR, "msg": str(e)}]), 400
 
         projects = take_limits(available, offset, limit)
         return jsonify(projects=projects, offset=offset, limit=limit, total=len(available))
@@ -1506,7 +1506,7 @@ def v0_api(api):
                 projects = projects_info(api.config["YUMLOCK"].yb, project_names.split(","))
         except ProjectsError as e:
             log.error("(v0_projects_info) %s", str(e))
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": PROJECTS_ERROR, "msg": str(e)}]), 400
 
         if not projects:
             msg = "one of the requested projects does not exist: %s" % project_names
@@ -1529,7 +1529,7 @@ def v0_api(api):
                 deps = projects_depsolve(api.config["YUMLOCK"].yb, [(n, "*") for n in project_names.split(",")], [])
         except ProjectsError as e:
             log.error("(v0_projects_depsolve) %s", str(e))
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": PROJECTS_ERROR, "msg": str(e)}]), 400
 
         if not deps:
             msg = "one of the requested projects does not exist: %s" % project_names
@@ -1644,7 +1644,7 @@ def v0_api(api):
                     log.info("Updating repository metadata after adding %s failed", source["name"])
                     update_metadata(yb)
 
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": PROJECTS_ERROR, "msg": str(e)}]), 400
 
         return jsonify(status=True)
 
@@ -1705,7 +1705,7 @@ def v0_api(api):
                 available = modules_list(api.config["YUMLOCK"].yb, module_names)
         except ProjectsError as e:
             log.error("(v0_modules_list) %s", str(e))
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": MODULES_ERROR, "msg": str(e)}]), 400
 
         if module_names and not available:
             msg = "one of the requested modules does not exist: %s" % module_names
@@ -1728,7 +1728,7 @@ def v0_api(api):
                 modules = modules_info(api.config["YUMLOCK"].yb, module_names.split(","))
         except ProjectsError as e:
             log.error("(v0_modules_info) %s", str(e))
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": MODULES_ERROR, "msg": str(e)}]), 400
 
         if not modules:
             msg = "one of the requested modules does not exist: %s" % module_names
@@ -1859,7 +1859,7 @@ def v0_api(api):
         try:
             uuid_cancel(api.config["COMPOSER_CFG"], uuid)
         except Exception as e:
-            return jsonify(status=False, errors=["%s: %s" % (uuid, str(e))]),400
+            return jsonify(status=False, errors=[{"id": COMPOSE_ERROR, "msg": "%s: %s" % (uuid, str(e))}]),400
         else:
             return jsonify(status=True, uuid=uuid)
 
@@ -1884,7 +1884,7 @@ def v0_api(api):
                 try:
                     uuid_delete(api.config["COMPOSER_CFG"], uuid)
                 except Exception as e:
-                    errors.append("%s: %s" % (uuid, str(e)))
+                    errors.append({"id": COMPOSE_ERROR, "msg": "%s: %s" % (uuid, str(e))})
                 else:
                     results.append({"uuid":uuid, "status":True})
         return jsonify(uuids=results, errors=errors)
@@ -1901,7 +1901,7 @@ def v0_api(api):
         try:
             info = uuid_info(api.config["COMPOSER_CFG"], uuid)
         except Exception as e:
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": COMPOSE_ERROR, "msg": str(e)}]), 400
 
         if info is None:
             return jsonify(status=False, errors=[{"id": UNKNOWN_UUID, "msg": "%s is not a valid build uuid" % uuid}]), 400
@@ -1987,7 +1987,7 @@ def v0_api(api):
 
             # Make sure it really exists
             if not os.path.exists(image_path):
-                return jsonify(status=False, errors=["Build %s is missing image file %s" % (uuid, image_name)]), 400
+                return jsonify(status=False, errors=[{"id": BUILD_MISSING_FILE, "msg": "Build %s is missing image file %s" % (uuid, image_name)}]), 400
 
             # Make the image name unique
             image_name = uuid + "-" + image_name
@@ -2006,7 +2006,7 @@ def v0_api(api):
         try:
             size = int(request.args.get("size", "1024"))
         except ValueError as e:
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": COMPOSE_ERROR, "msg": str(e)}]), 400
 
         status = uuid_status(api.config["COMPOSER_CFG"], uuid)
         if status is None:
@@ -2016,4 +2016,4 @@ def v0_api(api):
         try:
             return Response(uuid_log(api.config["COMPOSER_CFG"], uuid, size), direct_passthrough=True)
         except RuntimeError as e:
-            return jsonify(status=False, errors=[str(e)]), 400
+            return jsonify(status=False, errors=[{"id": COMPOSE_ERROR, "msg": str(e)}]), 400

--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -1798,12 +1798,15 @@ def v0_api(api):
             return jsonify(status=False, errors=["Invalid characters in API path"]), 400
 
         results = []
+        errors = []
         for uuid in [n.strip().lower() for n in uuids.split(",")]:
             details = uuid_status(api.config["COMPOSER_CFG"], uuid)
             if details is not None:
                 results.append(details)
+            else:
+                errors.append({"id": UNKNOWN_UUID, "msg": "%s is not a valid build uuid" % uuid})
 
-        return jsonify(uuids=results)
+        return jsonify(uuids=results, errors=errors)
 
     @api.route("/api/v0/compose/cancel", defaults={'uuid': ""}, methods=["DELETE"])
     @api.route("/api/v0/compose/cancel/<uuid>", methods=["DELETE"])
@@ -1816,7 +1819,7 @@ def v0_api(api):
 
         status = uuid_status(api.config["COMPOSER_CFG"], uuid)
         if status is None:
-            return jsonify(status=False, errors=["%s is not a valid build uuid" % uuid]), 400
+            return jsonify(status=False, errors=[{"id": UNKNOWN_UUID, "msg": "%s is not a valid build uuid" % uuid}]), 400
 
         if status["queue_status"] not in ["WAITING", "RUNNING"]:
             return jsonify(status=False, errors=[{"id": BUILD_IN_WRONG_STATE, "msg": "Build %s is not in WAITING or RUNNING." % uuid}])
@@ -1842,7 +1845,7 @@ def v0_api(api):
         for uuid in [n.strip().lower() for n in uuids.split(",")]:
             status = uuid_status(api.config["COMPOSER_CFG"], uuid)
             if status is None:
-                errors.append("%s is not a valid build uuid" % uuid)
+                errors.append({"id": UNKNOWN_UUID, "msg": "%s is not a valid build uuid" % uuid})
             elif status["queue_status"] not in ["FINISHED", "FAILED"]:
                 errors.append({"id": BUILD_IN_WRONG_STATE, "msg": "Build %s is not in FINISHED or FAILED." % uuid})
             else:
@@ -1868,7 +1871,10 @@ def v0_api(api):
         except Exception as e:
             return jsonify(status=False, errors=[str(e)]), 400
 
-        return jsonify(**info)
+        if info is None:
+            return jsonify(status=False, errors=[{"id": UNKNOWN_UUID, "msg": "%s is not a valid build uuid" % uuid}]), 400
+        else:
+            return jsonify(**info)
 
     @api.route("/api/v0/compose/metadata", defaults={'uuid': ""})
     @api.route("/api/v0/compose/metadata/<uuid>")
@@ -1881,7 +1887,7 @@ def v0_api(api):
 
         status = uuid_status(api.config["COMPOSER_CFG"], uuid)
         if status is None:
-            return jsonify(status=False, errors=["%s is not a valid build uuid" % uuid]), 400
+            return jsonify(status=False, errors=[{"id": UNKNOWN_UUID, "msg": "%s is not a valid build uuid" % uuid}]), 400
         if status["queue_status"] not in ["FINISHED", "FAILED"]:
             return jsonify(status=False, errors=[{"id": BUILD_IN_WRONG_STATE, "msg": "Build %s not in FINISHED or FAILED state." % uuid}]), 400
         else:
@@ -1901,7 +1907,7 @@ def v0_api(api):
 
         status = uuid_status(api.config["COMPOSER_CFG"], uuid)
         if status is None:
-            return jsonify(status=False, errors=["%s is not a valid build uuid" % uuid]), 400
+            return jsonify(status=False, errors=[{"id": UNKNOWN_UUID, "msg": "%s is not a valid build uuid" % uuid}]), 400
         elif status["queue_status"] not in ["FINISHED", "FAILED"]:
             return jsonify(status=False, errors=[{"id": BUILD_IN_WRONG_STATE, "msg": "Build %s not in FINISHED or FAILED state." % uuid}]), 400
         else:
@@ -1921,7 +1927,7 @@ def v0_api(api):
 
         status = uuid_status(api.config["COMPOSER_CFG"], uuid)
         if status is None:
-            return jsonify(status=False, errors=["%s is not a valid build uuid" % uuid]), 400
+            return jsonify(status=False, errors=[{"id": UNKNOWN_UUID, "msg": "%s is not a valid build uuid" % uuid}]), 400
         elif status["queue_status"] not in ["FINISHED", "FAILED"]:
             return jsonify(status=False, errors=[{"id": BUILD_IN_WRONG_STATE, "msg": "Build %s not in FINISHED or FAILED state." % uuid}]), 400
         else:
@@ -1941,7 +1947,7 @@ def v0_api(api):
 
         status = uuid_status(api.config["COMPOSER_CFG"], uuid)
         if status is None:
-            return jsonify(status=False, errors=["%s is not a valid build uuid" % uuid]), 400
+            return jsonify(status=False, errors=[{"id": UNKNOWN_UUID, "msg": "%s is not a valid build uuid" % uuid}]), 400
         elif status["queue_status"] not in ["FINISHED", "FAILED"]:
             return jsonify(status=False, errors=[{"id": BUILD_IN_WRONG_STATE, "msg": "Build %s not in FINISHED or FAILED state." % uuid}]), 400
         else:
@@ -1972,7 +1978,7 @@ def v0_api(api):
 
         status = uuid_status(api.config["COMPOSER_CFG"], uuid)
         if status is None:
-            return jsonify(status=False, errors=["%s is not a valid build uuid" % uuid]), 400
+            return jsonify(status=False, errors=[{"id": UNKNOWN_UUID, "msg": "%s is not a valid build uuid" % uuid}]), 400
         elif status["queue_status"] == "WAITING":
             return jsonify(status=False, errors=[{"id": BUILD_IN_WRONG_STATE, "msg": "Build %s has not started yet. No logs to view" % uuid}])
         try:

--- a/tests/composer/test_utilities.py
+++ b/tests/composer/test_utilities.py
@@ -16,6 +16,7 @@
 #
 import unittest
 
+from pylorax.api.errors import INVALID_CHARS
 from composer.cli.utilities import argify, toml_filename, frozen_toml_filename, packageNEVRA
 from composer.cli.utilities import handle_api_result
 
@@ -53,8 +54,8 @@ class CliUtilitiesTest(unittest.TestCase):
         self.assertEqual(handle_api_result(result, show_json=False), (0, False))
 
     def test_api_result_2(self):
-        """Test a result with errors=["some error"], and no status field"""
-        result = {"foo": "bar", "errors": ["some error"]}
+        """Test a result with errors=[{"id": INVALID_CHARS, "msg": "some error"}], and no status field"""
+        result = {"foo": "bar", "errors": [{"id": INVALID_CHARS, "msg": "some error"}]}
         self.assertEqual(handle_api_result(result, show_json=False), (1, False))
 
     def test_api_result_3(self):
@@ -68,8 +69,8 @@ class CliUtilitiesTest(unittest.TestCase):
         self.assertEqual(handle_api_result(result, show_json=False), (1, True))
 
     def test_api_result_5(self):
-        """Test a result with status=False, and errors=["some error"]"""
-        result = {"status": False, "errors": ["some error"]}
+        """Test a result with status=False, and errors=[{"id": INVALID_CHARS, "msg": "some error"}]"""
+        result = {"status": False, "errors": [{"id": INVALID_CHARS, "msg": "some error"}]}
         self.assertEqual(handle_api_result(result, show_json=False), (1, True))
 
     def test_api_result_6(self):
@@ -78,13 +79,13 @@ class CliUtilitiesTest(unittest.TestCase):
         self.assertEqual(handle_api_result(result, show_json=True), (0, True))
 
     def test_api_result_7(self):
-        """Test a result with show_json=True, status=False, and errors=["some error"]"""
-        result = {"status": False, "errors": ["some error"]}
+        """Test a result with show_json=True, status=False, and errors=[{"id": INVALID_CHARS, "msg": "some error"}]"""
+        result = {"status": False, "errors": [{"id": INVALID_CHARS, "msg": "some error"}]}
         self.assertEqual(handle_api_result(result, show_json=True), (1, True))
 
     def test_api_result_8(self):
-        """Test a result with show_json=True, errors=["some error"], and no status field"""
-        result = {"foo": "bar", "errors": ["some error"]}
+        """Test a result with show_json=True, errors=[{"id": INVALID_CHARS, "msg": "some error"}], and no status field"""
+        result = {"foo": "bar", "errors": [{"id": INVALID_CHARS, "msg": "some error"}]}
         self.assertEqual(handle_api_result(result, show_json=True), (1, True))
 
     def test_api_result_9(self):

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -770,7 +770,7 @@ class ServerTestCase(unittest.TestCase):
         data = json.loads(resp.data)
         self.assertNotEqual(data, None)
         self.assertEqual(data["status"], False, "Failed to fail to start test compose: %s" % data)
-        self.assertEqual(data["errors"], ["Invalid compose type (snakes), must be one of ['ext4-filesystem', 'live-iso', 'partitioned-disk', 'qcow2', 'tar']"],
+        self.assertEqual(data["errors"], [{"id": BAD_COMPOSE_TYPE, "msg": "Invalid compose type (snakes), must be one of ['ext4-filesystem', 'live-iso', 'partitioned-disk', 'qcow2', 'tar']"}],
                                          "Failed to get errors: %s" % data)
 
     def test_compose_03_status_fail(self):

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -27,6 +27,7 @@ import unittest
 from flask import json
 import pytoml as toml
 from pylorax.api.config import configure, make_yum_dirs, make_queue_dirs
+from pylorax.api.errors import *                               # pylint: disable=wildcard-import
 from pylorax.api.queue import start_queue_monitor
 from pylorax.api.recipes import open_or_create_repo, commit_recipe_directory
 from pylorax.api.server import server, GitLock, YumLock
@@ -785,14 +786,15 @@ class ServerTestCase(unittest.TestCase):
         data = json.loads(resp.data)
         self.assertNotEqual(data, None)
         self.assertEqual(data["status"], False, "Failed to get an error for a bad uuid: %s" % data)
-        self.assertEqual(data["errors"], ["NO-UUID-TO-SEE-HERE is not a valid build uuid"], "Failed to get errors: %s" % data)
+        self.assertEqual(data["errors"], [{"id": UNKNOWN_UUID, "msg": "NO-UUID-TO-SEE-HERE is not a valid build uuid"}],
+                                          "Failed to get errors: %s" % data)
 
     def test_compose_05_delete_fail(self):
         """Test that requesting a delete for a bad uuid fails."""
         resp = self.server.delete("/api/v0/compose/delete/NO-UUID-TO-SEE-HERE")
         data = json.loads(resp.data)
         self.assertNotEqual(data, None)
-        self.assertEqual(data["errors"], ["no-uuid-to-see-here is not a valid build uuid"],
+        self.assertEqual(data["errors"], [{"id": UNKNOWN_UUID, "msg": "no-uuid-to-see-here is not a valid build uuid"}],
                          "Failed to get an error for a bad uuid: %s" % data)
 
     def test_compose_06_info_fail(self):
@@ -801,7 +803,7 @@ class ServerTestCase(unittest.TestCase):
         data = json.loads(resp.data)
         self.assertNotEqual(data, None)
         self.assertEqual(data["status"], False, "Failed to get an error for a bad uuid: %s" % data)
-        self.assertEqual(data["errors"], ["NO-UUID-TO-SEE-HERE is not a valid build_id"],
+        self.assertEqual(data["errors"], [{"id": UNKNOWN_UUID, "msg": "NO-UUID-TO-SEE-HERE is not a valid build uuid"}],
                                          "Failed to get errors: %s" % data)
 
     def test_compose_07_metadata_fail(self):
@@ -810,7 +812,7 @@ class ServerTestCase(unittest.TestCase):
         data = json.loads(resp.data)
         self.assertNotEqual(data, None)
         self.assertEqual(data["status"], False, "Failed to get an error for a bad uuid: %s" % data)
-        self.assertEqual(data["errors"], ["NO-UUID-TO-SEE-HERE is not a valid build uuid"],
+        self.assertEqual(data["errors"], [{"id": UNKNOWN_UUID, "msg": "NO-UUID-TO-SEE-HERE is not a valid build uuid"}],
                                          "Failed to get errors: %s" % data)
 
     def test_compose_08_results_fail(self):
@@ -819,7 +821,8 @@ class ServerTestCase(unittest.TestCase):
         data = json.loads(resp.data)
         self.assertNotEqual(data, None)
         self.assertEqual(data["status"], False, "Failed to get an error for a bad uuid: %s" % data)
-        self.assertEqual(data["errors"], ["NO-UUID-TO-SEE-HERE is not a valid build uuid"], "Failed to get errors: %s" % data)
+        self.assertEqual(data["errors"], [{"id": UNKNOWN_UUID, "msg": "NO-UUID-TO-SEE-HERE is not a valid build uuid"}],
+                                          "Failed to get errors: %s" % data)
 
     def test_compose_09_logs_fail(self):
         """Test that requesting logs for a bad uuid fails."""
@@ -827,7 +830,7 @@ class ServerTestCase(unittest.TestCase):
         data = json.loads(resp.data)
         self.assertNotEqual(data, None)
         self.assertEqual(data["status"], False, "Failed to get an error for a bad uuid: %s" % data)
-        self.assertEqual(data["errors"], ["NO-UUID-TO-SEE-HERE is not a valid build uuid"],
+        self.assertEqual(data["errors"], [{"id": UNKNOWN_UUID, "msg": "NO-UUID-TO-SEE-HERE is not a valid build uuid"}],
                                          "Failed to get errors: %s" % data)
 
     def test_compose_10_log_fail(self):
@@ -836,7 +839,7 @@ class ServerTestCase(unittest.TestCase):
         data = json.loads(resp.data)
         self.assertNotEqual(data, None)
         self.assertEqual(data["status"], False, "Failed to get an error for a bad uuid: %s" % data)
-        self.assertEqual(data["errors"], ["NO-UUID-TO-SEE-HERE is not a valid build uuid"],
+        self.assertEqual(data["errors"], [{"id": UNKNOWN_UUID, "msg": "NO-UUID-TO-SEE-HERE is not a valid build uuid"}],
                                          "Failed to get errors: %s" % data)
 
     def test_compose_11_create_failed(self):

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -1026,7 +1026,7 @@ class ServerTestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(data["status"], False)
         self.assertTrue(len(data["errors"]) > 0)
-        self.assertTrue("Invalid characters in" in data["errors"][0])
+        self.assertTrue("Invalid characters in" in data["errors"][0]["msg"])
 
     def test_blueprints_list_branch(self):
         resp = self.server.get("/api/v0/blueprints/list?branch=" + UTF8_TEST_STRING)

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -185,7 +185,7 @@ class ServerTestCase(unittest.TestCase):
         self.assertEqual(data, info_dict_2)
 
         info_dict_3 = {"changes":[],
-                       "errors":["missing-blueprint: No commits for missing-blueprint.toml on the master branch."],
+                       "errors":[{"id": UNKNOWN_BLUEPRINT, "msg": "missing-blueprint: No commits for missing-blueprint.toml on the master branch."}],
                        "blueprints":[]
                       }
         resp = self.server.get("/api/v0/blueprints/info/missing-blueprint")


### PR DESCRIPTION
These give the front end something to key off of instead of doing comparisons on user-visible strings.  Instead, it can use the much shorter strings in the return error type.  These are defined in errors.py and there's a brief comment above each explaining when it should come up.  The hope is to keep the number of these pretty low.