### PR TITLE
Bring back import-state.service (#1615332)

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -64,6 +64,9 @@ installpkg plymouth
 ## extra dracut modules
 installpkg anaconda-dracut dracut-network dracut-config-generic dracut-fips
 
+## import-state.service for switchroot
+installpkg initscripts
+
 ## rescue needs this
 installpkg cryptsetup
 


### PR DESCRIPTION
The service is a part of initscripts package which is no more pulled in as a
transitive dependcy so we have to require it explicitly.