### PR TITLE
Set TCP listen backlog for API socket to SOMAXCONN

### DIFF
--- a/src/sbin/lorax-composer
+++ b/src/sbin/lorax-composer
@@ -230,7 +230,7 @@ if __name__ == '__main__':
         listener.bind(opts.socket)
         os.chmod(opts.socket, 0o660)
         os.chown(opts.socket, 0, gid)
-        listener.listen(1)
+        listener.listen(socket.SOMAXCONN)
 
     start_queue_monitor(server.config["COMPOSER_CFG"], uid, gid)
 


### PR DESCRIPTION
A value of 1 is too low for heavy users of the API, such as the weldr-web interface.

This is also systemd's default for sockets it opens. Using lorax-composer with socket activation already results in a backlog of SOMAXCONN connections.

I noticed this when I started `lorax-composer.service` directly instead of the socket unit. weldr-web opens a lot of connections on startup, most of which fail with `EAGAIN` when the backlog is set to 1. (It should probably not do that, but that's an unrelated issue.)