### PR TITLE
composer-cli should not log to a file by default

### DIFF
--- a/src/bin/composer-cli
+++ b/src/bin/composer-cli
@@ -43,8 +43,8 @@ def get_parser():
                         help="Output the raw JSON response instead of the normal output.")
     parser.add_argument("-s", "--socket", default="/run/weldr/api.socket", metavar="SOCKET",
                         help="Path to the socket file to listen on")
-    parser.add_argument("--log", dest="logfile", default="./composer-cli.log", metavar="LOG",
-                        help="Path to logfile (./composer-cli.log)")
+    parser.add_argument("--log", dest="logfile", default=None, metavar="LOG",
+                        help="Path to optional logfile")
     parser.add_argument("-a", "--api", dest="api_version", default="0", metavar="APIVER",
                         help="API Version to use")
     parser.add_argument("--test", dest="testmode", default=0, type=int, metavar="TESTMODE",
@@ -58,8 +58,12 @@ def get_parser():
 
     return parser
 
-def setup_logging(logfile):
-    # Setup logging to console and to logfile
+def setup_logging(logfile=None):
+    """ Setup logging to console and to an optional logfile
+
+    :param logfile: Optional path to file to store logs in
+    :type logfile: None or str
+    """
     log.setLevel(logging.DEBUG)
 
     sh = logging.StreamHandler()
@@ -68,11 +72,12 @@ def setup_logging(logfile):
     sh.setFormatter(fmt)
     log.addHandler(sh)
 
-    fh = logging.FileHandler(filename=logfile)
-    fh.setLevel(logging.DEBUG)
-    fmt = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
-    fh.setFormatter(fmt)
-    log.addHandler(fh)
+    if logfile != None:
+        fh = logging.FileHandler(filename=logfile)
+        fh.setLevel(logging.DEBUG)
+        fmt = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+        fh.setFormatter(fmt)
+        log.addHandler(fh)
 
 if __name__ == '__main__':
     # parse the arguments
@@ -83,9 +88,10 @@ if __name__ == '__main__':
         print(VERSION)
         sys.exit(0)
 
-    logpath = os.path.abspath(os.path.dirname(opts.logfile))
-    if not os.path.isdir(logpath):
-        os.makedirs(logpath)
+    if opts.logfile != None:
+        logpath = os.path.abspath(os.path.dirname(opts.logfile))
+        if not os.path.isdir(logpath):
+            os.makedirs(logpath)
     setup_logging(opts.logfile)
     log.debug("opts=%s", opts)
 


### PR DESCRIPTION
The user can pass --log /path/to/logfile.log if they want logging
enabled.