### PR TITLE
Add a pylorax.api.version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 src/pylorax/version.py*
+src/pylorax/api/version.py*
 src/composer/version.py*
 *.swp
 .pylint.d/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON ?= /usr/bin/python
 DESTDIR ?= /
 
-PKGNAME = lorax
+PKGNAME = lorax-composer
 VERSION = $(shell awk '/Version:/ { print $$2 }' $(PKGNAME).spec)
 RELEASE = $(shell awk '/Release:/ { print $$2 }' $(PKGNAME).spec | sed -e 's|%.*$$||g')
 TAG = lorax-$(VERSION)-$(RELEASE)
@@ -17,7 +17,10 @@ src/composer/version.py:
 src/pylorax/version.py:
 	echo "num = '$(VERSION)-$(RELEASE)'" > src/pylorax/version.py
 
-all: src/pylorax/version.py src/composer/version.py
+src/pylorax/api/version.py:
+	echo "num = '$(VERSION)-$(RELEASE)'" > src/pylorax/api/version.py
+
+all: src/pylorax/version.py src/pylorax/api/version.py src/composer/version.py
 	$(PYTHON) setup.py build
 
 install: all
@@ -47,6 +50,7 @@ test: docs
 
 clean:
 	-rm -rf build src/pylorax/version.py
+	-rm -rf build src/pylorax/api/version.py
 	-rm -rf build src/composer/version.py
 
 tag:

--- a/src/pylorax/api/__init__.py
+++ b/src/pylorax/api/__init__.py
@@ -17,5 +17,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from pylorax.api.crossdomain import crossdomain
 
-__all__ = ["crossdomain"]
+# get the lorax-composer api version
+try:
+    from pylorax.api.version import num as vernum
+except ImportError:
+    vernum = "devel"
 
+__all__ = ["crossdomain", "vernum"]

--- a/src/pylorax/api/server.py
+++ b/src/pylorax/api/server.py
@@ -22,7 +22,7 @@ from flask import Flask, jsonify, redirect, send_from_directory
 from glob import glob
 import os
 
-from pylorax import vernum
+from pylorax.api import vernum
 from pylorax.api.crossdomain import crossdomain
 from pylorax.api.v0 import v0_api
 from pylorax.sysutils import joinpaths

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -25,6 +25,7 @@ class LoraxLintConfig(PocketLintConfig):
 
         self.falsePositives = [ FalsePositive(r"No name 'version' in module 'pylorax'"),
                                 FalsePositive(r"Module 'pylorax' has no 'version' member"),
+                                FalsePositive(r"Module 'pylorax.api' has no 'version' member"),
                                 FalsePositive(r"Instance of 'int' has no .* member"),
                                 FalsePositive(r"Catching too general exception Exception"),
                                 FalsePositive(r"^E0712.*: Catching an exception which doesn't inherit from (Base|)Exception: GError$"),


### PR DESCRIPTION
lorax-composer is in a different package than lorax, so we need to use
its version number not lorax's when reporting the API /status/