### PR TITLE
Minor package fixes for aarch64/ARMv7

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -30,15 +30,15 @@ installpkg glibc-all-langpacks
 
 ## arch-specific packages (bootloaders etc.)
 %if basearch == "aarch64":
-    installpkg grub2-tools-efi
     installpkg efibootmgr
     installpkg grub2-efi-aa64-cdboot shim-aa64
+    installpkg uboot-tools
 %endif
 %if basearch in ("arm", "armhfp"):
-    installpkg grub2-tools-efi
     installpkg efibootmgr
     installpkg grub2-efi-arm-cdboot
     installpkg kernel-lpae
+    installpkg uboot-tools
 %endif
 %if basearch == "i386":
     installpkg gpart


### PR DESCRIPTION
The grub2-tools-efi is Mac specific, we still need uboot-tools in some corner cases.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>