### PR TITLE
lorax: Only run depmod on the installed kernels

### DIFF
--- a/src/pylorax/treebuilder.py
+++ b/src/pylorax/treebuilder.py
@@ -209,11 +209,11 @@ class RuntimeBuilder(object):
     def generate_module_data(self):
         root = self.vars.root
         moddir = joinpaths(root, "lib/modules/")
-        for kver in os.listdir(moddir):
-            ksyms = joinpaths(root, "boot/System.map-%s" % kver)
-            logger.info("doing depmod and module-info for %s", kver)
-            runcmd(["depmod", "-a", "-F", ksyms, "-b", root, kver])
-            generate_module_info(moddir+kver, outfile=moddir+"module-info")
+        for kernel in findkernels(root=root):
+            ksyms = joinpaths(root, "boot/System.map-%s" % kernel.version)
+            logger.info("doing depmod and module-info for %s", kernel.version)
+            runcmd(["depmod", "-a", "-F", ksyms, "-b", root, kernel.version])
+            generate_module_info(moddir+kernel.version, outfile=moddir+"module-info")
 
     def create_runtime(self, outfile="/var/tmp/squashfs.img", compression="xz", compressargs=None, size=2):
         # make live rootfs image - must be named "LiveOS/rootfs.img" for dracut


### PR DESCRIPTION
In the near-future there may be /lib/modules/ directories for older
kernels with weak dependencies listed. These may not match the installed
kernel(s) so we cannot depend on them to drive generate_module_data.

Instead use the existing findkernels() function to get the list of
installed kernels and iterate those, running depmod on them.

Resolves: rhbz#1622213