### PR TITLE
templates/generic: disable creation of default wired connections by NM

### DIFF
--- a/share/templates.d/99-generic/config_files/common/93-anaconda-no-auto-default.conf
+++ b/share/templates.d/99-generic/config_files/common/93-anaconda-no-auto-default.conf
@@ -1,0 +1,3 @@
+# Disable creation of "Wired connection ..." for Wired devices
+[main]
+no-auto-default=*

--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -76,6 +76,7 @@ mkdir etc/NetworkManager/conf.d
 install ${configdir}/91-anaconda-autoconnect-slaves.conf etc/NetworkManager/conf.d
 install ${configdir}/vconsole.conf etc
 install ${configdir}/92-anaconda-loglevel-debug.conf etc/NetworkManager/conf.d
+install ${configdir}/93-anaconda-no-auto-default.conf etc/NetworkManager/conf.d
 
 ## set up sshd
 install ${configdir}/sshd_config.anaconda etc/ssh


### PR DESCRIPTION
NetworkManager by default connects all wired devices it sees. This is
not nice in the installer. Current Anaconda solution is to create
placeholder connections that don't connect by default, and that is sort
of ugly (and also seems broken).