### PR TITLE
Add ability to create ISOs on ARMv7

### DIFF
--- a/share/templates.d/99-generic/arm.tmpl
+++ b/share/templates.d/99-generic/arm.tmpl
@@ -15,6 +15,16 @@ delimiter = ''
 from os.path import basename
 %>
 
+## Test ${runtime_img} to see if udf is needed
+<%
+    import os
+    from pylorax.sysutils import joinpaths
+    if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
+        udfargs = "-allow-limited-size"
+    else:
+        udfargs = ""
+%>
+
 mkdir images
 install ${runtime_img} ${STAGE2IMG}
 treeinfo stage2 mainimage ${STAGE2IMG}
@@ -38,21 +48,57 @@ mkdir ${KERNELDIR}
     %endif
 %endfor
 
+<% efiargs=""; efigraft="" %>
+%if exists("boot/efi/EFI/*/gcdaa64.efi"):
+    <%
+    efiarch32 = ARM
+    efiarch64 = None
+    efigraft="EFI/BOOT={0}/EFI/BOOT".format(outroot)
+    images = ["images/efiboot.img"]
+    %>
+    %for img in images:
+        <%
+        efiargs += " -eltorito-alt-boot -e {0} -no-emul-boot".format(img)
+        efigraft += " {0}={1}/{0}".format(img,outroot)
+        %>
+        treeinfo images-${basearch} ${img|basename} ${img}
+    %endfor
+    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch32=efiarch32, efiarch64=efiarch64, isolabel=isolabel"/>
+%endif
+
 # add platform to treeinfo for Beaker support
 treeinfo ${basearch} platforms ${platforms}
 
 # Create optional product.img and updates.img
-<% images=["product", "updates"] %>
+<% filegraft=""; images=["product", "updates"] %>
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg --xz -9 --memlimit-compress=3700MiB ${LORAXDIR}/${img}/ images/${img}.img
         treeinfo images-${basearch} ${img}.img images/${img}.img
+        <% filegraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor
+
+# Inherit iso-graft/ if it exists from external templates
+<%
+    import os
+    if os.path.exists(workdir + "/iso-graft"):
+        filegraft += " " + workdir + "/iso-graft"
+%>
 
 # Add the license files
 %for f in glob("/usr/share/licenses/*-release/*"):
     install ${f} ${f|basename}
+    <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor
 
-## FIXME: ARM may need some extra boot config
+%if exists("boot/efi/EFI/*/gcdarm.efi"):
+## make boot.iso
+runcmd mkisofs -o ${outroot}/images/boot.iso \
+       ${efiargs} -R -J -V '${isolabel}' -T ${udfargs} \
+       -graft-points \
+       ${KERNELDIR}=${outroot}/${KERNELDIR} \
+       ${STAGE2IMG}=${outroot}/${STAGE2IMG} \
+       ${efigraft} ${filegraft}
+treeinfo images-${basearch} boot.iso images/boot.iso
+%endif


### PR DESCRIPTION
Last missing piece for the changes to ARMv7. Tested with an ostree compose running on and ARMv7 doing an IoT compose. Also adds the missing ostree dependency to the spec discovered in testing it.