### PR TITLE
Add a Makefile target for building html docs using a CentOS7 environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,10 @@ local:
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 
 test-in-docker:
-	sudo docker build -t welder/lorax-composer:latest -f Dockerfile.test .
+	sudo docker build -t welder/lorax-composer:7 -f Dockerfile.test .
+
+docs-in-docker:
+	sudo docker run -it --rm -v `pwd`/docs/html/:/lorax/docs/html/ --security-opt label=disable welder/lorax-composer:7 make docs
 
 ci: check test
 

--- a/docs/html/README
+++ b/docs/html/README
@@ -1,0 +1,5 @@
+To build the docs for this branch run:
+make test-in-docker
+make docs-in-docker
+
+If you already have a welder/lorax-composer:7 docker image you can skip running 'test-in-docker'.


### PR DESCRIPTION
This makes it easier to generate new documentation for
http://weldr.io/lorax/lorax-composer/

It requires havinga current welder/lorax-composer:7 image (created with
the test-in-docker target), then run docs-in-docker to rerun sphinx with
the docs/html directory mounted from the container.