### PR TITLE
Fix up and document tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tests/pylint/.pylint.d/
 __pycache__/
 .coverage
 pylint-log
+.pytest_cache/

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,31 @@
+# Hacking on Lorax
+
+Here's where to get the code:
+
+    $ git clone https://github.com/weldr/lorax
+    $ cd lorax/
+
+How to build it:
+
+    $ make
+
+## How to run the tests
+
+To run the tests you need the following dependencies installed:
+
+    $ yum install python3-nose python3-pytest-mock python3-pocketlint \
+		python3-mock
+
+Run the basic linting tests like this:
+
+    $ make check
+
+
+To run the broader unit and integration tests we use:
+
+    $ make test
+
+Some of the tests will be skipped unless a lorax-composer process is running
+and listening on an accessible socket. Either run lorax-composer from the
+checkout, or the installed version.
+

--- a/tests/pylorax/blueprints/example-glusterfs.toml
+++ b/tests/pylorax/blueprints/example-glusterfs.toml
@@ -11,4 +11,4 @@ version = "4.1.*"
 
 [[packages]]
 name = "samba"
-version = "4.9.*"
+version = "4.*.*"

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -177,7 +177,7 @@ class ServerTestCase(unittest.TestCase):
                                    "modules":[{"name":"glusterfs", "version":"4.1.*"},
                                               {"name":"glusterfs-cli", "version":"4.1.*"}],
                                    "name":"example-glusterfs",
-                                   "packages":[{"name":"samba", "version":"4.9.*"}],
+                                   "packages":[{"name":"samba", "version":"4.*.*"}],
                                    "groups": [],
                                    "version": "0.0.1"},
                                   {"description":"An example http server with PHP and MySQL support.",
@@ -242,7 +242,7 @@ class ServerTestCase(unittest.TestCase):
                        "version": "0.2.0",
                        "modules":[{"name":"glusterfs", "version":"4.1.*"},
                                   {"name":"glusterfs-cli", "version":"4.1.*"}],
-                       "packages":[{"name":"samba", "version":"4.9.*"},
+                       "packages":[{"name":"samba", "version":"4.*.*"},
                                    {"name":"tmux", "version":"2.7"}],
                        "groups": []}
 
@@ -293,7 +293,7 @@ class ServerTestCase(unittest.TestCase):
                        "version": "0.3.0",
                        "modules":[{"name":"glusterfs", "version":"4.1.*"},
                                   {"name":"glusterfs-cli", "version":"4.1.*"}],
-                       "packages":[{"name":"samba", "version":"4.9.*"},
+                       "packages":[{"name":"samba", "version":"4.*.*"},
                                    {"name":"tmux", "version":"2.7"}],
                        "groups": []}
 
@@ -320,7 +320,7 @@ class ServerTestCase(unittest.TestCase):
                        "version": "0.4.0",
                        "modules":[{"name":"glusterfs", "version":"4.1.*"},
                                   {"name":"glusterfs-cli", "version":"4.1.*"}],
-                       "packages":[{"name":"samba", "version":"4.9.*"},
+                       "packages":[{"name":"samba", "version":"4.*.*"},
                                    {"name":"tmux", "version":"2.7"}],
                        "groups": []}
 
@@ -452,7 +452,7 @@ class ServerTestCase(unittest.TestCase):
                        "version": "0.3.0",
                        "modules":[{"name":"glusterfs", "version":"4.1.*"},
                                   {"name":"glusterfs-cli", "version":"4.1.*"}],
-                       "packages":[{"name":"samba", "version":"4.9.*"},
+                       "packages":[{"name":"samba", "version":"4.*.*"},
                                    {"name":"tmux", "version":"2.7"}]}
 
         resp = self.server.post("/api/v0/blueprints/workspace",
@@ -729,7 +729,7 @@ class ServerTestCase(unittest.TestCase):
                        "version": "0.2.0",
                        "modules":[{"name":"glusterfs", "version":"4.1.*"},
                                   {"name":"glusterfs-cli", "version":"4.1.*"}],
-                       "packages":[{"name":"samba", "version":"4.9.*"},
+                       "packages":[{"name":"samba", "version":"4.*.*"},
                                    {"name":"tmux", "version":"2.7"}],
                        "groups": []}
 


### PR DESCRIPTION
Broaden the match for Samba in the glusterfs blueprint so it can work on Fedora 28. 

In addition add a HACKING.md file to document how to run the tests. Further content can go into this file.
