### PR TITLE
Fix `make check` and add it to CI

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,12 +1,27 @@
 FROM registry.fedoraproject.org/fedora:rawhide
 
-RUN dnf -y install make libgit2-glib tito python3-pylint  \
-                    python3-nose python3-mako python3-flask \
-                    python3-coverage libselinux-python3 sudo \
-                    pykickstart python3-pytoml python3-sphinx \
-                    python3-semantic_version \
-                    anaconda-tui python3-gevent beakerlib && \
-    useradd weldr
+RUN dnf -y install \
+  anaconda-tui \
+  libgit2-glib \
+  libselinux-python3 \
+  make \
+  pykickstart \
+  python3-coverage \
+  python3-coveralls \
+  python3-flask \
+  python3-gevent \
+  python3-mako \
+  python3-nose \
+  python3-pocketlint \
+  python3-pylint \
+  python3-pytoml \
+  python3-semantic_version \
+  python3-sphinx \
+  sudo \
+  tito \
+  which
+
+RUN useradd weldr
 
 RUN mkdir /lorax
 COPY . /lorax
@@ -15,4 +30,4 @@ COPY . /lorax
 RUN find /lorax -name "*.pyc" -exec rm -f {} \;
 
 WORKDIR /lorax
-RUN make test
+RUN make check test

--- a/src/bin/composer
+++ b/src/bin/composer
@@ -23,9 +23,11 @@ log = logging.getLogger("composer")
 import os
 import sys
 
-from composer import vernum
-from composer.cli import main
-from composer.cli.cmdline import composer_cli_parser
+# Disable pylint warnings for these, because it cannot deal with this file and
+# the module both being called "composer"
+from composer import vernum                             # pylint: disable=import-self
+from composer.cli import main                           # pylint: disable=no-name-in-module
+from composer.cli.cmdline import composer_cli_parser    # pylint: disable=no-name-in-module
 
 VERSION = "{0}-{1}".format(os.path.basename(sys.argv[0]), vernum)
 

--- a/src/pylorax/executils.py
+++ b/src/pylorax/executils.py
@@ -115,6 +115,7 @@ def startProgram(argv, root='/', stdin=None, stdout=subprocess.PIPE, stderr=subp
     if env_add:
         env.update(env_add)
 
+    # pylint: disable=subprocess-popen-preexec-fn
     return subprocess.Popen(argv,
                             stdin=stdin,
                             stdout=stdout,

--- a/src/pylorax/imgutils.py
+++ b/src/pylorax/imgutils.py
@@ -196,10 +196,7 @@ def loop_attach(outfile):
 
             # Sometimes the loop device isn't ready yet, make extra sure before returning
             loop_waitfor(dev, outfile)
-        except CalledProcessError:
-            # Problems running losetup are always errors, raise immediately
-            raise
-        except RuntimeError as e:
+        except RuntimeError:
             # Try to setup the loop device 3 times
             if retries == 3:
                 logger.error("loop_attach failed, retries exhausted.")

--- a/src/pylorax/ltmpl.py
+++ b/src/pylorax/ltmpl.py
@@ -248,10 +248,10 @@ class LoraxTemplateRunner(object):
                 # skip the bit about "ltmpl.py, in _run()" - we know that
                 exclines.pop(1)
                 # log the "ErrorType: this is what happened" line
-                logger.error("  " + exclines[-1].strip())
+                logger.error("  %s", exclines[-1].strip())
                 # and log the entire traceback to the debug log
                 for _line in ''.join(exclines).splitlines():
-                    logger.debug("  " + _line)
+                    logger.debug("  %s", _line)
                 if self.fatalerrors:
                     raise
 

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -9,9 +9,6 @@ class LoraxLintConfig(PocketLintConfig):
         PocketLintConfig.__init__(self)
 
         self.falsePositives = [ FalsePositive(r"Module 'pylorax' has no 'version' member"),
-                                # threading.Lock() is a factory function which returns an
-                                # instance of the Lock class that is supported by the platform
-                                FalsePositive(r"Context manager 'lock' doesn't implement __enter__ and __exit__"),
                                 FalsePositive(r"Catching too general exception Exception"),
                                 FalsePositive(r"^E0712.*: Catching an exception which doesn't inherit from (Base|)Exception: GError$"),
                                 FalsePositive(r"Module 'composer' has no 'version' member"),


### PR DESCRIPTION
See individual commits.

The container that's used is not rebuilt on every pull request anymore, but pulled from docker hub instead. I've used my own user (larskarlitski) for that for now, because I don't have access to the welder one. If we decide to go forward with this, I can change it.

- [ ] change docker image from `larskarlitski/lorax-tests` to `welder/lorax-tests`