### PR TITLE
Replace CJK fonts with Google Noto CJK

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -205,6 +205,7 @@ removefrom gmp /usr/${libdir}/libgmpxx.* /usr/${libdir}/libmp.*
 removefrom gnome-bluetooth-libs /usr/${libdir}/libgnome-bluetooth*
 removefrom gnome-bluetooth-libs /usr/share/*
 removefrom gnutls /usr/share/locale/*
+removefrom google-noto-sans-cjk-ttc-fonts /usr/share/fonts/google-noto-cjk/NotoSansCJK-{Black,Bold,*Light,Medium,Thin}.ttc
 removefrom grep /etc/* /usr/share/locale/*
 removefrom gstreamer /usr/bin/* /usr/${libdir}/gstreamer-0.10/*
 removefrom gstreamer /usr/${libdir}/libgst* /usr/libexec/* /usr/share/locale/*
@@ -276,7 +277,6 @@ removefrom nfs-utils /usr/sbin/rpc.svcgssd /usr/sbin/rpcdebug
 removefrom nfs-utils /usr/sbin/showmount /usr/sbin/sm-notify
 removefrom nfs-utils /usr/sbin/start-statd /var/lib/nfs/etab
 removefrom nfs-utils /var/lib/nfs/rmtab /var/lib/nfs/state /var/lib/nfs/xtab
-removefrom nhn-nanum-gothic-fonts /usr/share/fonts/nhn-nanum/NanumGothic*Bold.ttf
 removefrom nss-softokn /usr/${libdir}/nss/*
 removefrom openldap /etc/openldap/* /usr/${libdir}/libldap_r-*
 removefrom openssh /usr/libexec/*

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -153,11 +153,8 @@ installpkg lohit-odia-fonts
 installpkg lohit-tamil-fonts
 installpkg lohit-telugu-fonts
 installpkg madan-fonts
-installpkg nhn-nanum-gothic-fonts
 installpkg smc-meera-fonts
 installpkg thai-scalable-waree-fonts
-installpkg vlgothic-fonts
-installpkg wqy-microhei-fonts
 installpkg sil-abyssinica-fonts
 installpkg xorg-x11-fonts-misc
 installpkg aajohan-comfortaa-fonts
@@ -166,6 +163,7 @@ installpkg sil-scheherazade-fonts
 installpkg jomolhari-fonts
 installpkg khmeros-base-fonts
 installpkg sil-padauk-fonts
+installpkg google-noto-sans-cjk-ttc-fonts
 
 ## debugging/bug reporting tools
 installpkg gdb-gdbserver


### PR DESCRIPTION
As we've proposed the changes of default fonts for CJK to Google Noto, that would be nice to see this change on boot.iso too.