### PR TITLE
Include python3-pyatspi on boot.iso (#1506595)

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -169,6 +169,7 @@ installpkg google-noto-sans-cjk-ttc-fonts
 installpkg gdb-gdbserver
 installpkg libreport-plugin-bugzilla libreport-plugin-reportuploader
 installpkg fpaste
+installpkg python3-pyatspi
 
 ## extra tools not required by anaconda
 installpkg vim-minimal strace lsof dump xz less eject


### PR DESCRIPTION
Including this makes it easier for dogtail tests to be run on the
various releases.