### PR TITLE
Execute bash tests for composer-cli

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -5,10 +5,14 @@ RUN dnf -y install make libgit2-glib tito python3-pylint  \
                     python3-coverage libselinux-python3 sudo \
                     pykickstart python3-pytoml python3-sphinx \
                     python3-semantic_version \
-                    anaconda-tui
+                    anaconda-tui python3-gevent beakerlib && \
+    useradd weldr
 
 RUN mkdir /lorax
 COPY . /lorax
+# remove byte-compiled files to avoid issues between Python 2/3
+# this can happen when you switch between rhel7 and master branches
+RUN find /lorax -name "*.pyc" -exec rm -f {} \;
 
 WORKDIR /lorax
 RUN make test

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ test:
 
 	coverage3 report -m
 	[ -f "/usr/bin/coveralls" ] && [ -n "$(COVERALLS_REPO_TOKEN)" ] && coveralls || echo
+	
+	./tests/test_cli.sh
+
 
 
 clean:

--- a/tests/cli/test_blueprints_sanity.sh
+++ b/tests/cli/test_blueprints_sanity.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Note: execute this file from the project root directory
+
+. /usr/share/beakerlib/beakerlib.sh
+
+CLI="./src/bin/composer"
+
+
+rlJournalStart
+    rlPhaseStartTest "blueprints list"
+        for bp in example-http-server example-development example-atlas; do
+            rlAssertEquals "blueprint list finds $bp" \
+                "`$CLI blueprints list | grep $bp`" "$bp"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartTest "blueprints save"
+        rlRun -t -c "$CLI blueprints save example-http-server"
+        rlAssertExists "example-http-server.toml"
+        rlAssertGrep "example-http-server" "example-http-server.toml"
+        rlAssertGrep "httpd" "example-http-server.toml"
+
+        # non-existing blueprint
+# enable test for https://github.com/weldr/lorax/issues/460
+#        rlRun -t -c "$CLI blueprints save non-existing-bp" 1
+#        rlAssertNotExists "non-existing-bp.toml"
+    rlPhaseEnd
+
+    rlPhaseStartTest "blueprints push"
+
+        cat > beakerlib.toml << __EOF__
+name = "beakerlib"
+description = "Start building tests with beakerlib."
+version = "0.0.1"
+
+[[modules]]
+name = "beakerlib"
+version = "*"
+__EOF__
+
+        rlRun -t -c "$CLI blueprints push beakerlib.toml"
+        rlAssertEquals "pushed bp is found via list" "`$CLI blueprints list | grep beakerlib`" "beakerlib"
+    rlPhaseEnd
+
+rlJournalEnd
+rlJournalPrintText

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Note: execute this file from the project root directory
+
+# setup
+
+export TESTRESULT_BEAKERLIB_DIR=`mktemp -d /var/tmp/beakerlib-composer-XXXXXX`
+export top_srcdir=`pwd`
+. ./tests/testenv.sh
+
+# start the lorax-composer daemon
+./src/sbin/lorax-composer ./tests/pylorax/blueprints/ &
+
+# wait for the backend to become ready
+until curl --unix-socket /run/weldr/api.socket http://localhost:4000/api/status | grep '"db_supported":true'; do
+    sleep 2
+    echo "DEBUG: Waiting for backend API to become ready before testing ..."
+done;
+
+# invoke cli/ tests
+./tests/cli/test_blueprints_sanity.sh
+
+
+# look for failures
+grep RESULT_STRING $TESTRESULT_BEAKERLIB_DIR/TestResults | grep -v PASS && exit 1
+
+# explicit return code for Makefile
+exit 0


### PR DESCRIPTION
these are built on top of beakerlib and we use its internal
protocol to figure out the result without relying on the full
test runner that is tipically used inside of a RHEL environment!