### PR TITLE
cli: Clarify error message for unprivileged access

### DIFF
--- a/src/bin/composer
+++ b/src/bin/composer
@@ -79,10 +79,9 @@ if __name__ == '__main__':
     errors = []
 
     # Check to see if the socket exists and can be accessed
-    if not os.path.exists(opts.socket):
-        errors.append("%s does not exist" % opts.socket)
-    elif not os.access(opts.socket, os.R_OK|os.W_OK):
-        errors.append("This user cannot access %s" % opts.socket)
+    if not os.access(opts.socket, os.R_OK|os.W_OK):
+        errors.append("Cannot access '%s'. Is lorax-composer running and "
+                      "this user allowed to access it?" % opts.socket)
 
     # No point in continuing if there are errors
     if errors:


### PR DESCRIPTION
`os.path.exists("/run/weldr/api.socket")` returns False for users which have no
access. This leads to composer printing that the file does not exist, which is
misleading.

Since it's no possible to distinguish the two cases, fix this problem by
combining them and showing a single error message.