### PR TITLE
Provide a compatibility to dnf-3.5+

### DIFF
--- a/src/pylorax/api/dnfbase.py
+++ b/src/pylorax/api/dnfbase.py
@@ -56,7 +56,8 @@ def get_base_object(conf):
     dbc.reposdir = [repodir]
     dbc.install_weak_deps = False
     dbc.prepend_installroot('persistdir')
-    dbc.tsflags.append('nodocs')
+    # tsflags is append option therefor the action result in append operation into tsflags
+    dbc.tsflags = ('nodocs', )
 
     if conf.get_default("dnf", "proxy", None):
         dbc.proxy = conf.get("dnf", "proxy")

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -212,7 +212,8 @@ def get_dnf_base_object(installroot, sources, mirrorlists=None, repos=None,
     conf.releasever = releasever
     conf.installroot = installroot
     conf.prepend_installroot('persistdir')
-    conf.tsflags.append('nodocs')
+    # tsflags is append option therefor the action result in append operation into tsflags
+    conf.tsflags = ('nodocs',)
 
     if proxy:
         conf.proxy = proxy


### PR DESCRIPTION
Dnf in version 3 has a new config parser. In cases like
conf.tsflags.append('nodocs'), it only modify copy of tsflags values
(dnf-3.5.1), but there is no change in original object. To detect this
hidden problem DNF return a tuple that directly prevent from
modification (from dnf-3.6.1).