### PR TITLE
Check for metadata changes when building an image

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -8,10 +8,9 @@ RUN yum -y install --nogpgcheck epel-release && \
                     python-coverage libselinux-python sudo \
                     pykickstart python2-pytoml python-sphinx \
                     python2-mock python-semantic_version \
-                    anaconda-tui && \
+                    anaconda-tui python-rpmfluff && \
     yum clean all && \
     rm -rf /var/cache/yum
-
 
 RUN mkdir /lorax
 COPY . /lorax

--- a/src/pylorax/api/compose.py
+++ b/src/pylorax/api/compose.py
@@ -296,7 +296,8 @@ def start_build(cfg, yumlock, gitlock, branch, recipe_name, compose_type, test_m
     projects = sorted(set(module_nver+package_nver), key=lambda p: p[0].lower())
     deps = []
     try:
-        with yumlock.lock:
+        # This can possibly update repodata and reset the YumBase object.
+        with yumlock.lock_check:
             (installed_size, deps) = projects_depsolve_with_size(yumlock.yb, projects, recipe.group_names, with_core=False)
     except ProjectsError as e:
         log.error("start_build depsolve: %s", str(e))

--- a/src/pylorax/api/server.py
+++ b/src/pylorax/api/server.py
@@ -28,7 +28,6 @@ from pylorax.api.v0 import v0_api
 from pylorax.sysutils import joinpaths
 
 GitLock = namedtuple("GitLock", ["repo", "lock", "dir"])
-YumLock = namedtuple("YumLock", ["yb", "lock"])
 
 server = Flask(__name__)
 

--- a/src/sbin/lorax-composer
+++ b/src/sbin/lorax-composer
@@ -40,8 +40,8 @@ from pylorax.api.config import configure, make_yum_dirs, make_queue_dirs
 from pylorax.api.compose import test_templates
 from pylorax.api.queue import start_queue_monitor
 from pylorax.api.recipes import open_or_create_repo, commit_recipe_directory
-from pylorax.api.server import server, GitLock, YumLock
-from pylorax.api.yumbase import get_base_object
+from pylorax.api.server import server, GitLock
+from pylorax.api.yumbase import YumLock
 
 VERSION = "{0}-{1}".format(os.path.basename(sys.argv[0]), vernum)
 
@@ -283,14 +283,14 @@ if __name__ == '__main__':
 
     # Get a YumBase to share with the requests
     try:
-        yb = get_base_object(server.config["COMPOSER_CFG"])
+        server.config["YUMLOCK"] = YumLock(server.config["COMPOSER_CFG"])
     except RuntimeError:
         # Error has already been logged. Just exit cleanly.
         sys.exit(1)
-    server.config["YUMLOCK"] = YumLock(yb=yb, lock=Lock())
 
     # Depsolve the templates and make a note of the failures for /api/status to report
-    server.config["TEMPLATE_ERRORS"] = test_templates(yb, server.config["COMPOSER_CFG"].get("composer", "share_dir"))
+    with server.config["YUMLOCK"].lock:
+        server.config["TEMPLATE_ERRORS"] = test_templates(server.config["YUMLOCK"].yb, server.config["COMPOSER_CFG"].get("composer", "share_dir"))
 
     # Setup access to the git repo
     server.config["REPO_DIR"] = opts.BLUEPRINTS

--- a/tests/pylorax/test_projects.py
+++ b/tests/pylorax/test_projects.py
@@ -31,7 +31,7 @@ from pylorax.api.projects import api_time, api_changelog, yaps_to_project, yaps_
 from pylorax.api.projects import tm_to_dep, yaps_to_module, projects_list, projects_info, projects_depsolve
 from pylorax.api.projects import modules_list, modules_info, ProjectsError, dep_evra, dep_nevra
 from pylorax.api.projects import repo_to_source, get_repo_sources, delete_repo_source, source_to_repo
-from pylorax.api.projects import yum_repo_to_file_repo, filterVersionGlob
+from pylorax.api.projects import yum_repo_to_file_repo, filterVersionGlob, projects_depsolve_with_size
 from pylorax.api.yumbase import get_base_object
 
 
@@ -217,6 +217,14 @@ class ProjectsTest(unittest.TestCase):
     def test_projects_depsolve_glob(self):
         """Test that depsolving with a '*' version glob doesn't glob package names"""
         deps = projects_depsolve(self.yb, [("python", "*")], [])
+        self.assertTrue(len(deps) > 1)
+        self.assertTrue("python" in [dep["name"] for dep in deps])
+        self.assertTrue("python-blivet" not in [dep["name"] for dep in deps])
+
+    def test_projects_size_depsolve_glob(self):
+        """Test that depsolving with a '*' version glob doesn't glob package names"""
+        size, deps = projects_depsolve_with_size(self.yb, [("python", "*")], [], with_core=False)
+        self.assertTrue(size > 0)
         self.assertTrue(len(deps) > 1)
         self.assertTrue("python" in [dep["name"] for dep in deps])
         self.assertTrue("python-blivet" not in [dep["name"] for dep in deps])

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -17,7 +17,9 @@
 #
 import os
 from ConfigParser import SafeConfigParser, NoOptionError
+from contextlib import contextmanager
 from glob import glob
+from rpmfluff import SimpleRpmBuild, expectedArch
 import shutil
 import tempfile
 import time
@@ -30,8 +32,8 @@ from pylorax.api.config import configure, make_yum_dirs, make_queue_dirs
 from pylorax.api.errors import *                               # pylint: disable=wildcard-import
 from pylorax.api.queue import start_queue_monitor
 from pylorax.api.recipes import open_or_create_repo, commit_recipe_directory
-from pylorax.api.server import server, GitLock, YumLock
-from pylorax.api.yumbase import get_base_object
+from pylorax.api.server import server, GitLock
+from pylorax.api.yumbase import YumLock
 from pylorax.sysutils import joinpaths
 
 # Used for testing UTF-8 input support
@@ -58,7 +60,6 @@ def get_system_repo():
     return "base"
 
 class ServerTestCase(unittest.TestCase):
-
     @classmethod
     def setUpClass(self):
         repo_dir = tempfile.mkdtemp(prefix="lorax.test.repo.")
@@ -87,8 +88,7 @@ class ServerTestCase(unittest.TestCase):
             shutil.rmtree("/tmp/lorax-empty-repo/")
             raise RuntimeError("Problem running createrepo_c, is it installed")
 
-        yb = get_base_object(server.config["COMPOSER_CFG"])
-        server.config["YUMLOCK"] = YumLock(yb=yb, lock=Lock())
+        server.config["YUMLOCK"] = YumLock(server.config["COMPOSER_CFG"])
 
         # Include a message in /api/status output
         server.config["TEMPLATE_ERRORS"] = ["Test message"]
@@ -1354,3 +1354,159 @@ class ServerTestCase(unittest.TestCase):
         """Test the compose/log input character checking"""
         resp = self.server.get("/api/v0/compose/log/" + UTF8_TEST_STRING)
         self.assertInputError(resp)
+
+@contextmanager
+def in_tempdir(prefix='tmp'):
+    """Execute a block of code with chdir in a temporary location"""
+    oldcwd = os.getcwd()
+    tmpdir = tempfile.mkdtemp(prefix=prefix)
+    os.chdir(tmpdir)
+    yield
+    os.chdir(oldcwd)
+    shutil.rmtree(tmpdir)
+
+def makeFakeRPM(repo_dir, name, epoch, version, release):
+    """Make a fake rpm file in repo_dir"""
+    p = SimpleRpmBuild(name, version, release)
+    if epoch:
+        p.epoch = epoch
+    p.add_simple_payload_file_random()
+    with in_tempdir("lorax-test-rpms."):
+        p.make()
+        rpmfile = p.get_built_rpm(expectedArch)
+        shutil.move(rpmfile, repo_dir)
+
+class RepoCacheTestCase(unittest.TestCase):
+    """Test to make sure that changes to the repository are picked up immediately."""
+    @classmethod
+    def setUpClass(self):
+        repo_dir = tempfile.mkdtemp(prefix="lorax.test.repo.")
+        server.config["REPO_DIR"] = repo_dir
+        repo = open_or_create_repo(server.config["REPO_DIR"])
+        server.config["GITLOCK"] = GitLock(repo=repo, lock=Lock(), dir=repo_dir)
+
+        server.config["COMPOSER_CFG"] = configure(root_dir=repo_dir, test_config=True)
+        os.makedirs(joinpaths(server.config["COMPOSER_CFG"].get("composer", "share_dir"), "composer"))
+        errors = make_queue_dirs(server.config["COMPOSER_CFG"], 0)
+        if errors:
+            raise RuntimeError("\n".join(errors))
+
+        make_yum_dirs(server.config["COMPOSER_CFG"])
+
+        # Create an extra repo to use for checking the metadata expire handling
+        os.makedirs("/tmp/lorax-test-repo/")
+        makeFakeRPM("/tmp/lorax-test-repo/", "fake-milhouse", 0, "1.0.0", "1")
+        os.system("createrepo_c /tmp/lorax-test-repo/")
+
+        server.config["YUMLOCK"] = YumLock(server.config["COMPOSER_CFG"], expire_secs = 10)
+
+        # Include a message in /api/status output
+        server.config["TEMPLATE_ERRORS"] = ["Test message"]
+
+        server.config['TESTING'] = True
+        self.server = server.test_client()
+        self.repo_dir = repo_dir
+
+        # Copy the shared files over to the directory tree we are using
+        share_path = "./share/composer/"
+        for f in glob(joinpaths(share_path, "*")):
+            shutil.copy(f, joinpaths(server.config["COMPOSER_CFG"].get("composer", "share_dir"), "composer"))
+
+        start_queue_monitor(server.config["COMPOSER_CFG"], 0, 0)
+
+    @classmethod
+    def tearDownClass(self):
+        shutil.rmtree(server.config["REPO_DIR"])
+        shutil.rmtree("/tmp/lorax-test-repo/")
+
+    def add_new_source(self, repo_dir):
+        json_source = """{"name": "new-repo-1", "url": "file:///tmp/lorax-test-repo/", "type": "yum-baseurl",
+                          "check_ssl": false, "check_gpg": false}"""
+        self.assertTrue(len(json_source) > 0)
+        resp = self.server.post("/api/v0/projects/source/new",
+                                data=json_source,
+                                content_type="application/json")
+        data = json.loads(resp.data)
+        self.assertEqual(data, {"status":True})
+
+    def add_blueprint(self):
+        test_blueprint = {"description": "Metadata expire test blueprint",
+                          "name":"milhouse-test",
+                          "version": "0.0.1",
+                          "modules":[],
+                          "packages":[{"name":"fake-milhouse", "version":"1.*.*"}],
+                          "groups": []}
+
+        resp = self.server.post("/api/v0/blueprints/new",
+                                data=json.dumps(test_blueprint),
+                                content_type="application/json")
+        data = json.loads(resp.data)
+        self.assertEqual(data, {"status":True})
+
+    def test_metadata_expires(self):
+        """Ensure that metadata expire settings pick up changes to the repo when expected"""
+
+        # Metadata can change at any time, but checking for that is expensive. So we only want
+        # to check when the timeout has expired, OR when starting a new compose
+        # Add a new repository at /tmp/lorax-test-repo/
+        self.add_new_source("/tmp/lorax-test-repo")
+
+        # Add a new blueprint with fake-milhouse in it
+        self.add_blueprint()
+
+        # Depsolve the blueprint
+        resp = self.server.get("/api/v0/blueprints/depsolve/milhouse-test")
+        data = json.loads(resp.data)
+        self.assertNotEqual(data, None)
+        blueprints = data.get("blueprints")
+        self.assertNotEqual(blueprints, None)
+        self.assertEqual(len(blueprints), 1)
+        self.assertEqual(blueprints[0]["blueprint"]["name"], "milhouse-test")
+        deps = blueprints[0]["dependencies"]
+        print(deps)
+        self.assertTrue(any([True for d in deps if d["name"] == "fake-milhouse" and d["version"] == "1.0.0"]))
+        self.assertFalse(data.get("errors"))
+
+        # Make a new version of fake-milhouse
+        makeFakeRPM("/tmp/lorax-test-repo/", "fake-milhouse", 0, "1.0.1", "1")
+        os.system("createrepo_c /tmp/lorax-test-repo/")
+
+        # Expire time has been set to 10 seconds, so wait 11 and try it.
+        time.sleep(11)
+
+        resp = self.server.get("/api/v0/blueprints/depsolve/milhouse-test")
+        data = json.loads(resp.data)
+        self.assertNotEqual(data, None)
+        blueprints = data.get("blueprints")
+        self.assertNotEqual(blueprints, None)
+        self.assertEqual(len(blueprints), 1)
+        self.assertEqual(blueprints[0]["blueprint"]["name"], "milhouse-test")
+        deps = blueprints[0]["dependencies"]
+        print(deps)
+        self.assertTrue(any([True for d in deps if d["name"] == "fake-milhouse" and d["version"] == "1.0.1"]))
+        self.assertFalse(data.get("errors"))
+
+        # Make a new version of fake-milhouse
+        makeFakeRPM("/tmp/lorax-test-repo/", "fake-milhouse", 0, "1.0.2", "1")
+        os.system("createrepo_c /tmp/lorax-test-repo/")
+
+        test_compose = {"blueprint_name": "milhouse-test",
+                        "compose_type": "tar",
+                        "branch": "master"}
+
+        resp = self.server.post("/api/v0/compose?test=2",
+                                data=json.dumps(test_compose),
+                                content_type="application/json")
+        data = json.loads(resp.data)
+        self.assertNotEqual(data, None)
+        self.assertEqual(data["status"], True, "Failed to start test compose: %s" % data)
+
+        build_id = data["build_id"]
+
+        # Check to see which version was used for the compose, should be 1.0.2
+        resp = self.server.get("/api/v0/compose/info/%s" % build_id)
+        data = json.loads(resp.data)
+        self.assertNotEqual(data, None)
+        pkg_deps = data["deps"]["packages"]
+        print(pkg_deps)
+        self.assertTrue(any([True for d in pkg_deps if d["name"] == "fake-milhouse" and d["version"] == "1.0.2"]))


### PR DESCRIPTION
Keeping the metadata in sync is more tricky than you would expect. Add a
test that makes sure that changing the repo contents is picked up after
the short (10s) expiration timeout, and another to test that a new
package is picked up when starting a new build.

This depends on rpmfluff which is available from Fedora or EPEL repos.

Related: rhbz#1628114