### PR TITLE
Don't try to append to DNF config value that can't take it

### DIFF
--- a/src/pylorax/api/dnfbase.py
+++ b/src/pylorax/api/dnfbase.py
@@ -56,7 +56,10 @@ def get_base_object(conf):
     dbc.reposdir = [repodir]
     dbc.install_weak_deps = False
     dbc.prepend_installroot('persistdir')
-    dbc.tsflags.append('nodocs')
+    # this is a weird 'AppendOption' thing that, when you set it,
+    # actually appends. Doing this adds 'nodocs' to the existing list
+    # of values, over in libdnf, it does not replace the existing values.
+    dbc.tsflags = ['nodocs']
 
     if conf.get_default("dnf", "proxy", None):
         dbc.proxy = conf.get("dnf", "proxy")

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -212,7 +212,10 @@ def get_dnf_base_object(installroot, sources, mirrorlists=None, repos=None,
     conf.releasever = releasever
     conf.installroot = installroot
     conf.prepend_installroot('persistdir')
-    conf.tsflags.append('nodocs')
+    # this is a weird 'AppendOption' thing that, when you set it,
+    # actually appends. Doing this adds 'nodocs' to the existing list
+    # of values, over in libdnf, it does not replace the existing values.
+    conf.tsflags = ['nodocs']
 
     if proxy:
         conf.proxy = proxy


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1595917 and
https://github.com/rpm-software-management/dnf/pull/1200 for
more on this. Briefly, DNF before 3.0 presented this config
value as a list...and mutating it worked. DNF from 3.0 until
3.6 presented it as a list...mutating it didn't work, but also
didn't *fail*, so this has actually not been doing anything on
DNF 3.x but we haven't noticed.

In DNF 3.6 values like this are presented as tuples instead of
lists, to try and catch usages like this, and it worked! We
need to change this one.

There is an additional weirdness here. tsflags is actually, in
libdnf terms, an OptionStringListAppend option: that means that
when something tries to *set* its value, the new value is just
appended to the existing list of values. This is very weird
behaviour when you're interacting with it like this, but
happens to be quite useful, as we can just 'set' the value to
a list like this and it will actually get appended (which is
what we want), and this one syntax happens to work correctly in
DNF 2.x, 3.0 through 3.5.1, and 3.6.

Signed-off-by: Adam Williamson <awilliam@redhat.com>