### PR TITLE
Kickstart tweaks

### DIFF
--- a/share/composer/ami.ks
+++ b/share/composer/ami.ks
@@ -31,6 +31,10 @@ services --enabled=sshd,chronyd,cloud-init
 # Remove random-seed
 rm /var/lib/systemd/random-seed
 
+# Clear /etc/machine-id
+rm /etc/machine-id
+touch /etc/machine-id
+
 # tell cloud-init to create the ec2-user account
 sed -i 's/cloud-user/ec2-user/' /etc/cloud/cloud.cfg
 %end

--- a/share/composer/ext4-filesystem.ks
+++ b/share/composer/ext4-filesystem.ks
@@ -24,6 +24,10 @@ bootloader --location=none
 %post
 # Remove random-seed
 rm /var/lib/systemd/random-seed
+
+# Clear /etc/machine-id
+rm /etc/machine-id
+touch /etc/machine-id
 %end
 
 # NOTE Do NOT add any other sections after %packages

--- a/share/composer/partitioned-disk.ks
+++ b/share/composer/partitioned-disk.ks
@@ -24,6 +24,10 @@ bootloader --location=mbr
 %post
 # Remove random-seed
 rm /var/lib/systemd/random-seed
+
+# Clear /etc/machine-id
+rm /etc/machine-id
+touch /etc/machine-id
 %end
 
 %packages

--- a/share/composer/qcow2.ks
+++ b/share/composer/qcow2.ks
@@ -24,6 +24,10 @@ bootloader --location=mbr
 %post
 # Remove random-seed
 rm /var/lib/systemd/random-seed
+
+# Clear /etc/machine-id
+rm /etc/machine-id
+touch /etc/machine-id
 %end
 
 %packages

--- a/share/composer/tar.ks
+++ b/share/composer/tar.ks
@@ -24,6 +24,10 @@ bootloader --location=none
 %post
 # Remove random-seed
 rm /var/lib/systemd/random-seed
+
+# Clear /etc/machine-id
+rm /etc/machine-id
+touch /etc/machine-id
 %end
 
 # NOTE Do NOT add any other sections after %packages

--- a/share/composer/vhd.ks
+++ b/share/composer/vhd.ks
@@ -30,6 +30,10 @@ services --enabled=sshd,chronyd,waagent
 %post
 # Remove random-seed
 rm /var/lib/systemd/random-seed
+
+# Clear /etc/machine-id
+rm /etc/machine-id
+touch /etc/machine-id
 %end
 
 %packages

--- a/share/composer/vhd.ks
+++ b/share/composer/vhd.ks
@@ -25,7 +25,7 @@ timezone  US/Eastern
 bootloader --location=mbr --append="no_timer_check console=ttyS0,115200n8 console=tty1 net.ifnames=0"
 
 # Basic services
-services --enabled=sshd,chronyd,waagent
+services --enabled=sshd,chronyd,waagent,cloud-init
 
 %post
 # Remove random-seed
@@ -43,6 +43,7 @@ kernel
 grub2
 
 chrony
+cloud-init
 
 # Uninstall NetworkManager, install WALinuxAgent
 -NetworkManager

--- a/share/composer/vmdk.ks
+++ b/share/composer/vmdk.ks
@@ -27,6 +27,10 @@ services --enabled=sshd,chronyd,vmtoolsd
 %post
 # Remove random-seed
 rm /var/lib/systemd/random-seed
+
+# Clear /etc/machine-id
+rm /etc/machine-id
+touch /etc/machine-id
 %end
 
 %packages


### PR DESCRIPTION
Add back one of the useful parts of fedora-kickstart's %post, and make cloud-init mandatory for a couple more image types.