### PR TITLE
Reproducible image building

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -18,6 +18,7 @@ RUN dnf -y install \
   python3-semantic_version \
   python3-sphinx \
   python3-rpmfluff \
+  python3-librepo \
   beakerlib \
   sudo \
   tito \

--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -362,3 +362,19 @@ removepkg cdparanoia-libs opus libtheora libvisual flac-libs gsm avahi-glib avah
 
 ## metacity requires libvorbis and libvorbisfile, but enc/dec are no longer needed
 removefrom libvorbis --allbut /usr/${libdir}/libvorbisfile.* /usr/${libdir}/libvorbis.*
+
+## make the image more reproducible
+
+## make machine-id empty but present to avoid systemd populating /etc with
+## preset settings
+remove /etc/machine-id
+append /etc/machine-id ""
+## journalctl message catalog, non-deterministic
+remove /var/lib/systemd/catalog/database
+## non-reproducible caches
+remove /var/cache/ldconfig/aux-cache
+remove /etc/pki/ca-trust/extracted/java/cacerts
+
+## sort groups
+runcmd chroot ${root} /bin/sh -c "LC_ALL=C sort /etc/group > /etc/group- && mv /etc/group- /etc/group"
+runcmd chroot ${root} /bin/sh -c "LC_ALL=C sort /etc/gshadow > /etc/gshadow- && mv /etc/gshadow- /etc/gschadow"

--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -5,6 +5,8 @@
 <%
 stubs = ("list-harddrives", "raidstart", "raidstop")
 configdir = configdir + "/common"
+import os, time
+SOURCE_DATE_EPOCH = os.environ.get('SOURCE_DATE_EPOCH', str(int(time.time())))
 %>
 
 ## move_stubs()
@@ -120,6 +122,11 @@ append etc/lvm/lvm.conf "global {\n\tuse_lvmetad = 1\n}\n"
 ## rpm initializes nss, which requires /dev/urandom to be present, hence the mknod
 runcmd chroot ${root} /usr/bin/mknod -m 666 /dev/random c 1 8
 runcmd chroot ${root} /usr/bin/mknod -m 666 /dev/urandom c 1 9
-runcmd chroot ${root} /usr/bin/rpm -qa --pipe "tee /root/lorax-packages.log"
+runcmd chroot ${root} /usr/bin/rpm -qa --pipe "sort | tee /root/lorax-packages.log"
 
 ## TODO: we could run prelink here if we wanted?
+
+## fix fonconfig cache containing timestamps
+runcmd chroot ${root} /usr/bin/find /usr/share/fonts /usr/share/X11/fonts -newermt "@${SOURCE_DATE_EPOCH}" -exec \
+    touch --no-dereference --date="@${SOURCE_DATE_EPOCH}" {} +
+runcmd chroot ${root} /usr/bin/fc-cache -f

--- a/src/pylorax/buildstamp.py
+++ b/src/pylorax/buildstamp.py
@@ -23,6 +23,7 @@ import logging
 logger = logging.getLogger("pylorax.buildstamp")
 
 import datetime
+import os
 
 
 class BuildStamp(object):
@@ -34,7 +35,11 @@ class BuildStamp(object):
         self.isfinal = isfinal
         self.variant = variant
 
-        now = datetime.datetime.now()
+        if 'SOURCE_DATE_EPOCH' in os.environ:
+            now = datetime.datetime.utcfromtimestamp(
+                int(os.environ['SOURCE_DATE_EPOCH']))
+        else:
+            now = datetime.datetime.now()
         now = now.strftime("%Y%m%d%H%M")
         self.uuid = "{0}.{1}".format(now, buildarch)
 

--- a/src/pylorax/discinfo.py
+++ b/src/pylorax/discinfo.py
@@ -22,6 +22,7 @@
 import logging
 logger = logging.getLogger("pylorax.discinfo")
 
+import os
 import time
 
 
@@ -32,8 +33,13 @@ class DiscInfo(object):
         self.basearch = basearch
 
     def write(self, outfile):
+        if 'SOURCE_DATE_EPOCH' in os.environ:
+            timestamp = int(os.environ['SOURCE_DATE_EPOCH'])
+        else:
+            timestamp = time.time()
+
         logger.info("writing .discinfo file")
         with open(outfile, "w") as fobj:
-            fobj.write("{0:f}\n".format(time.time()))
+            fobj.write("{0:f}\n".format(timestamp))
             fobj.write("{0.release}\n".format(self))
             fobj.write("{0.basearch}\n".format(self))

--- a/src/pylorax/imgutils.py
+++ b/src/pylorax/imgutils.py
@@ -484,8 +484,12 @@ def mkfsimage(fstype, rootdir, outfile, size=None, mkfsargs=None, mountargs="", 
 # convenience functions with useful defaults
 def mkdosimg(rootdir, outfile, size=None, label="", mountargs="shortname=winnt,umask=0077", graft=None):
     graft = graft or {}
+    mkfsargs = ["-n", label]
+    if 'SOURCE_DATE_EPOCH' in os.environ:
+        mkfsargs.extend(["-i",
+                "{:x}".format(int(os.environ['SOURCE_DATE_EPOCH']))])
     mkfsimage("msdos", rootdir, outfile, size, mountargs=mountargs,
-              mkfsargs=["-n", label], graft=graft)
+              mkfsargs=mkfsargs, graft=graft)
 
 def mkext4img(rootdir, outfile, size=None, label="", mountargs="", graft=None):
     graft = graft or {}

--- a/src/pylorax/imgutils.py
+++ b/src/pylorax/imgutils.py
@@ -284,7 +284,7 @@ def copytree(src, dest, preserve=True):
     If preserve is False, uses cp -R (useful for modeless filesystems)
     raises CalledProcessError if copy fails.'''
     logger.debug("copytree %s %s", src, dest)
-    cp = ["cp", "-a"] if preserve else ["cp", "-R", "-L"]
+    cp = ["cp", "-a"] if preserve else ["cp", "-R", "-L", "--preserve=timestamps"]
     cp += [join(src, "."), os.path.abspath(dest)]
     runcmd(cp)
 

--- a/src/pylorax/treeinfo.py
+++ b/src/pylorax/treeinfo.py
@@ -23,6 +23,7 @@ import logging
 logger = logging.getLogger("pylorax.treeinfo")
 
 import configparser
+import os
 import time
 
 
@@ -33,8 +34,13 @@ class TreeInfo(object):
 
         self.c = configparser.ConfigParser()
 
+        if 'SOURCE_DATE_EPOCH' in os.environ:
+            timestamp = os.environ['SOURCE_DATE_EPOCH']
+        else:
+            timestamp = str(time.time())
+
         section = "general"
-        data = {"timestamp": str(time.time()),
+        data = {"timestamp": timestamp,
                 "family": product,
                 "version": version,
                 "name": "%s-%s" % (product, version),

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -122,6 +122,9 @@ def main():
             raise ValueError("Missing '=' for key=value in " % kv)
         parsed_add_arch_template_vars[k] = v
 
+    if 'SOURCE_DATE_EPOCH' in os.environ:
+        log.info("Using SOURCE_DATE_EPOCH=%s as the current time.", os.environ["SOURCE_DATE_EPOCH"])
+
     # run lorax
     lorax = pylorax.Lorax()
     lorax.configure(conf_file=opts.config)


### PR DESCRIPTION
As part of [Reproducible Builds effort](https://reproducible-builds.org/), make the images produced by lorax reproducible, given the same set of inputs (packages, configuration, [SOURCE_DATE_EPOCH](https://reproducible-builds.org/specs/source-date-epoch/) variable).
See individual commits for explanation of specific changes.

The last commit require matching anaconda change, as it change image layout. It should be possible to make anaconda support both old and new format. Is there any actual reason why ext4 image is packaged into squashfs instead of using squashfs directly? I imagine historically it could be lack of overlayfs in vanilla kernel and the need to use dm-snapshot. But it is no longer the case. Anything else?

One thing not solved here is `efiboot.img`, because I didn't managed to reproducibly build FAT filesystem. Even after eliminating obvious metadata differences (volume ID, file mtimes, files order), there are still some differences near the end of the image, which I didn't identified.