### PR TITLE
Revert "Rename composer-cli to composer"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ install: all
 	install -m 644 docs/man/lorax.1 $(DESTDIR)/$(mandir)/man1
 	install -m 644 docs/man/livemedia-creator.1 $(DESTDIR)/$(mandir)/man1
 	mkdir -p $(DESTDIR)/etc/bash_completion.d
-	install -m 644 etc/bash_completion.d/composer $(DESTDIR)/etc/bash_completion.d
+	install -m 644 etc/bash_completion.d/composer-cli $(DESTDIR)/etc/bash_completion.d
 
 check:
 	@echo "*** Running pylint ***"

--- a/docs/composer-cli.rst
+++ b/docs/composer-cli.rst
@@ -1,54 +1,54 @@
-composer
-========
+composer-cli
+============
 
 :Authors:
     Brian C. Lane <bcl@redhat.com>
 
-``composer`` is used to interact with the ``lorax-composer`` API server, managing blueprints, exploring available packages, and building new images.
+``composer-cli`` is used to interact with the ``lorax-composer`` API server, managing blueprints, exploring available packages, and building new images.
 
 It requires `lorax-composer <lorax-composer.html>`_ to be installed on the
 local system, and the user running it needs to be a member of the ``weldr``
 group. They do not need to be root, but all of the `security precautions
 <lorax-composer.html#security>`_ apply.
 
-composer cmdline arguments
---------------------------
+composer-cli cmdline arguments
+------------------------------
 
 .. argparse::
    :ref: composer.cli.cmdline.composer_cli_parser
-   :prog: composer
+   :prog: composer-cli
 
 Edit a Blueprint
 ----------------
 
-Start out by listing the available blueprints using ``composer blueprints
-list``, pick one and save it to the local directory by running ``composer
+Start out by listing the available blueprints using ``composer-cli blueprints
+list``, pick one and save it to the local directory by running ``composer-cli
 blueprints save http-server``. If there are no blueprints available you can
 copy one of the examples `from the test suite
 <https://github.com/weldr/lorax/tree/master/tests/pylorax/blueprints/>`_.
 
 Edit the file (it will be saved with a .toml extension) and change the
 description, add a package or module to it. Send it back to the server by
-running ``composer blueprints push http-server.toml``. You can verify that it was
-saved by viewing the changelog - ``composer blueprints changes http-server``.
+running ``composer-cli blueprints push http-server.toml``. You can verify that it was
+saved by viewing the changelog - ``composer-cli blueprints changes http-server``.
 
 Build an image
 ----------------
 
-Build a ``qcow2`` disk image from this blueprint by running ``composer
+Build a ``qcow2`` disk image from this blueprint by running ``composer-cli
 compose start http-server qcow2``. It will print a UUID that you can use to
 keep track of the build. You can also cancel the build if needed.
 
-The available types of images is displayed by ``composer compose types``.
+The available types of images is displayed by ``composer-cli compose types``.
 Currently this consists of: ami, ext4-filesystem, live-iso, partitioned-disk,
 qcow2, tar, vhd, vmdk
 
 Monitor the build status
 ------------------------
 
-Monitor it using ``composer compose status``, which will show the status of
+Monitor it using ``composer-cli compose status``, which will show the status of
 all the builds on the system. You can view the end of the anaconda build logs
-once it is in the ``RUNNING`` state using ``composer compose log UUID``
+once it is in the ``RUNNING`` state using ``composer-cli compose log UUID``
 where UUID is the UUID returned by the start command.
 
 Once the build is in the ``FINISHED`` state you can download the image.
@@ -56,7 +56,7 @@ Once the build is in the ``FINISHED`` state you can download the image.
 Download the image
 ------------------
 
-Downloading the final image is done with ``composer compose image UUID`` and it will
+Downloading the final image is done with ``composer-cli compose image UUID`` and it will
 save the qcow2 image as ``UUID-disk.qcow2`` which you can then use to boot a VM like this::
 
     qemu-kvm --name test-image -m 1024 -hda ./UUID-disk.qcow2

--- a/docs/lorax-composer.rst
+++ b/docs/lorax-composer.rst
@@ -29,13 +29,13 @@ Installation
 ------------
 
 The best way to install ``lorax-composer`` is to use ``sudo dnf install
-lorax-composer composer``, this will setup the weldr user and install the
+lorax-composer composer-cli``, this will setup the weldr user and install the
 systemd socket activation service. You will then need to enable it with ``sudo
 systemctl enable lorax-composer.socket && sudo systemctl start
 lorax-composer.socket``. This will leave the server off until the first request
 is made. Systemd will then launch the server and it will remain running until
 the system is rebooted. This will cause some delay in responding to the first
-request from the UI or `composer`.
+request from the UI or `composer-cli`.
 
 .. note::
 
@@ -114,7 +114,7 @@ Composing Images
 The `welder-web <https://github.com/weldr/welder-web/>`_ GUI project can be used to construct
 blueprints and create composes using a web browser.
 
-Or use the command line with `composer <composer-cli.html>`_.
+Or use the command line with `composer-cli <composer-cli.html>`_.
 
 Blueprints
 ----------
@@ -346,7 +346,7 @@ system repo files with a configuration file pointing to the DVD.
 
 * Remove all the cached repo files from ``/var/lib/lorax/composer/repos/``
 * Restart the ``lorax-composer.service``
-* Check the output of ``composer status show`` for any output specific depsolve errors.
+* Check the output of ``composer-cli status show`` for any output specific depsolve errors.
   For example, the DVD usually does not include ``grub2-efi-*-cdboot-*`` so the live-iso image
   type will not be available.
 

--- a/etc/bash_completion.d/composer-cli
+++ b/etc/bash_completion.d/composer-cli
@@ -1,4 +1,4 @@
-# bash completion for composer
+# bash completion for composer-cli
 
 __composer_cli_flags="-h --help -j --json -s --socket --log -a --api --test -V"
 
@@ -16,19 +16,19 @@ __composer_socket_ok() {
 }
 
 __composer_blueprints() {
-    __composer_socket_ok && composer blueprints list
+    __composer_socket_ok && composer-cli blueprints list
 }
 
 __composer_sources() {
-    __composer_socket_ok && composer sources list
+    __composer_socket_ok && composer-cli sources list
 }
 
 __composer_compose_types() {
-    __composer_socket_ok && composer compose types
+    __composer_socket_ok && composer-cli compose types
 }
 
 __composer_composes() {
-    __composer_socket_ok && composer compose list $@ | while read id rest; do echo $id; done
+    __composer_socket_ok && composer-cli compose list $@ | while read id rest; do echo $id; done
 }
 
 __word_in_list() {
@@ -39,7 +39,7 @@ __word_in_list() {
     return 1
 }
 
-_composer() {
+_composer_cli() {
     local cur="${COMP_WORDS[COMP_CWORD]}" prev="${COMP_WORDS[COMP_CWORD-1]}"
     local w="" wi=0 cmd="__NONE__" subcmd="__NONE__" cmd_cword=0
 
@@ -140,4 +140,4 @@ _composer() {
     fi
 }
 
-complete -F _composer composer
+complete -F _composer_cli composer-cli

--- a/lorax.spec
+++ b/lorax.spec
@@ -225,9 +225,9 @@ getent passwd weldr >/dev/null 2>&1 || useradd -r -g weldr -d / -s /sbin/nologin
 %attr(0771, weldr, weldr) %{_sharedstatedir}/lorax/composer/blueprints/*
 
 %files -n composer-cli
-%{_bindir}/composer
+%{_bindir}/composer-cli
 %{python3_sitelib}/composer/*
-%{_sysconfdir}/bash_completion.d/composer
+%{_sysconfdir}/bash_completion.d/composer-cli
 
 %changelog
 * Fri Oct 05 2018 Brian C. Lane <bcl@redhat.com> 30.2-1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ data_files.append(("/usr/sbin", ["src/sbin/lorax", "src/sbin/mkefiboot",
                                  "src/sbin/livemedia-creator", "src/sbin/lorax-composer"]))
 data_files.append(("/usr/bin",  ["src/bin/image-minimizer",
                                  "src/bin/mk-s390-cdboot",
-                                 "src/bin/composer"]))
+                                 "src/bin/composer-cli"]))
 
 # get the version
 sys.path.insert(0, "src")

--- a/src/bin/composer-cli
+++ b/src/bin/composer-cli
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# composer
+# composer-cli
 #
 # Copyright (C) 2018  Red Hat, Inc.
 #
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import logging
-log = logging.getLogger("composer")
+log = logging.getLogger("composer-cli")
 
 import os
 import sys

--- a/src/composer/__init__.py
+++ b/src/composer/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# composer
+# composer-cli
 #
 # Copyright (C) 2018  Red Hat, Inc.
 #

--- a/src/composer/cli/__init__.py
+++ b/src/composer/cli/__init__.py
@@ -1,5 +1,5 @@
 #
-# composer
+# composer-cli
 #
 # Copyright (C) 2018  Red Hat, Inc.
 #
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import logging
-log = logging.getLogger("composer")
+log = logging.getLogger("composer-cli")
 
 from composer.cli.blueprints import blueprints_cmd
 from composer.cli.modules import modules_cmd
@@ -44,7 +44,7 @@ def main(opts):
     """
 
     # Making sure opts.args is not empty (thus, has a command and subcommand)
-    # is already handled in src/bin/composer.
+    # is already handled in src/bin/composer-cli.
     if opts.args[0] not in command_map:
         log.error("Unknown command %s", opts.args[0])
         return 1

--- a/src/composer/cli/blueprints.py
+++ b/src/composer/cli/blueprints.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import logging
-log = logging.getLogger("composer")
+log = logging.getLogger("composer-cli")
 
 import os
 

--- a/src/composer/cli/cmdline.py
+++ b/src/composer/cli/cmdline.py
@@ -24,7 +24,7 @@ from composer.cli.help import epilog
 VERSION = "{0}-{1}".format(os.path.basename(sys.argv[0]), vernum)
 
 def composer_cli_parser():
-    """ Return the ArgumentParser for composer"""
+    """ Return the ArgumentParser for composer-cli"""
 
     parser = argparse.ArgumentParser(description="Lorax Composer commandline tool",
                                      epilog=epilog,
@@ -36,7 +36,7 @@ def composer_cli_parser():
     parser.add_argument("-s", "--socket", default="/run/weldr/api.socket", metavar="SOCKET",
                         help="Path to the socket file to listen on")
     parser.add_argument("--log", dest="logfile", default=None, metavar="LOG",
-                        help="Path to logfile (./composer.log)")
+                        help="Path to logfile (./composer-cli.log)")
     parser.add_argument("-a", "--api", dest="api_version", default="0", metavar="APIVER",
                         help="API Version to use")
     parser.add_argument("--test", dest="testmode", default=0, type=int, metavar="TESTMODE",

--- a/src/composer/cli/compose.py
+++ b/src/composer/cli/compose.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import logging
-log = logging.getLogger("composer")
+log = logging.getLogger("composer-cli")
 
 from datetime import datetime
 import sys
@@ -186,7 +186,7 @@ def compose_types(socket_path, api_version, args, show_json=False, testmode=0):
     :param testmode: unused in this function
     :type testmode: int
 
-    Add additional details to types that are known to composer. Raw JSON output does not
+    Add additional details to types that are known to composer-cli. Raw JSON output does not
     include this extra information.
     """
     api_route = client.api_url(api_version, "/compose/types")

--- a/src/composer/cli/modules.py
+++ b/src/composer/cli/modules.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import logging
-log = logging.getLogger("composer")
+log = logging.getLogger("composer-cli")
 
 from composer import http_client as client
 from composer.cli.help import modules_help

--- a/src/composer/cli/projects.py
+++ b/src/composer/cli/projects.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import logging
-log = logging.getLogger("composer")
+log = logging.getLogger("composer-cli")
 
 import textwrap
 

--- a/src/composer/cli/sources.py
+++ b/src/composer/cli/sources.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import logging
-log = logging.getLogger("composer")
+log = logging.getLogger("composer-cli")
 
 import os
 

--- a/src/composer/cli/status.py
+++ b/src/composer/cli/status.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import logging
-log = logging.getLogger("composer")
+log = logging.getLogger("composer-cli")
 
 from composer import http_client as client
 from composer.cli.help import status_help

--- a/src/composer/cli/utilities.py
+++ b/src/composer/cli/utilities.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import logging
-log = logging.getLogger("composer")
+log = logging.getLogger("composer-cli")
 
 import json
 

--- a/src/composer/http_client.py
+++ b/src/composer/http_client.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import logging
-log = logging.getLogger("composer")
+log = logging.getLogger("composer-cli")
 
 import os
 import sys

--- a/tests/cli/test_blueprints_sanity.sh
+++ b/tests/cli/test_blueprints_sanity.sh
@@ -3,7 +3,7 @@
 
 . /usr/share/beakerlib/beakerlib.sh
 
-CLI="./src/bin/composer"
+CLI="./src/bin/composer-cli"
 
 
 rlJournalStart

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -3,7 +3,7 @@
 
 . /usr/share/beakerlib/beakerlib.sh
 
-CLI="./src/bin/composer"
+CLI="./src/bin/composer-cli"
 
 
 rlJournalStart


### PR DESCRIPTION
This reverts commit c9be91c8791cea20f8600b5769928fe180ea7cb8.

It conflicts with the PHP dependency manager project named 'composer'