### PR TITLE
Fix directory creation on master

### DIFF
--- a/src/sbin/lorax-composer
+++ b/src/sbin/lorax-composer
@@ -210,6 +210,9 @@ if __name__ == '__main__':
             log.error(e)
         sys.exit(1)
 
+    # Make sure dnf directories are created (owned by user:group)
+    make_dnf_dirs(server.config["COMPOSER_CFG"], uid, gid)
+
     # Did systemd pass any extra fds (for socket activation)?
     try:
         fds = int(os.environ['LISTEN_FDS'])
@@ -240,9 +243,6 @@ if __name__ == '__main__':
     log.debug("user is now %s:%s", os.getresuid(), os.getresgid())
     # Switch to a home directory we can access (libgit2 uses this to look for .gitconfig)
     os.environ["HOME"] = server.config["COMPOSER_CFG"].get("composer", "lib_dir")
-
-    # Make sure dnf directories are created
-    make_dnf_dirs(server.config["COMPOSER_CFG"])
 
     # Get a dnf.Base to share with the requests
     try:

--- a/src/sbin/lorax-composer
+++ b/src/sbin/lorax-composer
@@ -37,7 +37,7 @@ from gevent.pywsgi import WSGIServer
 
 from pylorax import vernum
 from pylorax.api.cmdline import lorax_composer_parser
-from pylorax.api.config import configure, make_dnf_dirs, make_queue_dirs
+from pylorax.api.config import configure, make_dnf_dirs, make_queue_dirs, make_owned_dir
 from pylorax.api.compose import test_templates
 from pylorax.api.dnfbase import DNFLock
 from pylorax.api.queue import start_queue_monitor
@@ -185,12 +185,6 @@ if __name__ == '__main__':
     server.config["COMPOSER_CFG"] = configure(conf_file=opts.config)
     server.config["COMPOSER_CFG"].set("composer", "tmp", opts.tmp)
 
-    # Make sure the git repo can be accessed by the API uid/gid
-    if os.path.exists(opts.BLUEPRINTS):
-        repodir_stat = os.stat(opts.BLUEPRINTS)
-        if repodir_stat.st_gid != gid or repodir_stat.st_uid != uid:
-            subprocess.call(["chown", "-R", "%s:%s" % (opts.user, opts.group), opts.BLUEPRINTS])
-
     # If the user passed in a releasever set it in the configuration
     if opts.releasever:
         server.config["COMPOSER_CFG"].set("composer", "releasever", opts.releasever)
@@ -212,6 +206,14 @@ if __name__ == '__main__':
 
     # Make sure dnf directories are created (owned by user:group)
     make_dnf_dirs(server.config["COMPOSER_CFG"], uid, gid)
+
+    # Make sure the git repo can be accessed by the API uid/gid
+    if os.path.exists(opts.BLUEPRINTS):
+        repodir_stat = os.stat(opts.BLUEPRINTS)
+        if repodir_stat.st_gid != gid or repodir_stat.st_uid != uid:
+            subprocess.call(["chown", "-R", "%s:%s" % (opts.user, opts.group), opts.BLUEPRINTS])
+    else:
+        make_owned_dir(opts.BLUEPRINTS, uid, gid)
 
     # Did systemd pass any extra fds (for socket activation)?
     try:
@@ -244,6 +246,14 @@ if __name__ == '__main__':
     # Switch to a home directory we can access (libgit2 uses this to look for .gitconfig)
     os.environ["HOME"] = server.config["COMPOSER_CFG"].get("composer", "lib_dir")
 
+    # Setup access to the git repo
+    server.config["REPO_DIR"] = opts.BLUEPRINTS
+    repo = open_or_create_repo(server.config["REPO_DIR"])
+    server.config["GITLOCK"] = GitLock(repo=repo, lock=Lock(), dir=opts.BLUEPRINTS)
+
+    # Import example blueprints
+    commit_recipe_directory(server.config["GITLOCK"].repo, "master", opts.BLUEPRINTS)
+
     # Get a dnf.Base to share with the requests
     try:
         server.config["DNFLOCK"] = DNFLock(server.config["COMPOSER_CFG"])
@@ -254,14 +264,6 @@ if __name__ == '__main__':
     # Depsolve the templates and make a note of the failures for /api/status to report
     with server.config["DNFLOCK"].lock:
         server.config["TEMPLATE_ERRORS"] = test_templates(server.config["DNFLOCK"].dbo, server.config["COMPOSER_CFG"].get("composer", "share_dir"))
-
-    # Setup access to the git repo
-    server.config["REPO_DIR"] = opts.BLUEPRINTS
-    repo = open_or_create_repo(server.config["REPO_DIR"])
-    server.config["GITLOCK"] = GitLock(repo=repo, lock=Lock(), dir=opts.BLUEPRINTS)
-
-    # Import example blueprints
-    commit_recipe_directory(server.config["GITLOCK"].repo, "master", opts.BLUEPRINTS)
 
     log.info("Starting %s on %s with blueprints from %s", VERSION, opts.socket, opts.BLUEPRINTS)
     http_server = WSGIServer(listener, server, log=LogWrapper(server_log))

--- a/tests/pylorax/test_dnfbase.py
+++ b/tests/pylorax/test_dnfbase.py
@@ -42,7 +42,7 @@ use_system_repos = False
 
         # will read the above configuration
         config = configure(conf_file=conf_file, root_dir=self.tmp_dir)
-        make_dnf_dirs(config)
+        make_dnf_dirs(config, os.getuid(), os.getgid())
 
         # will read composer config and store a dnf config file
         self.dbo = get_base_object(config)
@@ -76,7 +76,7 @@ class DnfbaseSystemReposTest(unittest.TestCase):
 
         # will read the above configuration
         config = configure(root_dir=self.tmp_dir)
-        make_dnf_dirs(config)
+        make_dnf_dirs(config, os.getuid(), os.getgid())
 
         # will read composer config and store a dnf config file
         self.dbo = get_base_object(config)
@@ -107,6 +107,6 @@ class CreateDnfDirsTest(unittest.TestCase):
         config = configure(test_config=True, root_dir=self.tmp_dir)
 
         # will create the above directory if missing
-        make_dnf_dirs(config)
+        make_dnf_dirs(config, os.getuid(), os.getgid())
 
         self.assertTrue(os.path.exists(self.tmp_dir + '/var/tmp/composer/dnf/root'))

--- a/tests/pylorax/test_projects.py
+++ b/tests/pylorax/test_projects.py
@@ -49,7 +49,7 @@ class ProjectsTest(unittest.TestCase):
     def setUpClass(self):
         self.tmp_dir = tempfile.mkdtemp(prefix="lorax.test.repo.")
         self.config = configure(root_dir=self.tmp_dir, test_config=True)
-        make_dnf_dirs(self.config)
+        make_dnf_dirs(self.config, os.getuid(), os.getgid())
         self.dbo = get_base_object(self.config)
         os.environ["TZ"] = "UTC"
         time.tzset()

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -71,11 +71,11 @@ class ServerTestCase(unittest.TestCase):
 
         server.config["COMPOSER_CFG"] = configure(root_dir=repo_dir, test_config=True)
         os.makedirs(joinpaths(server.config["COMPOSER_CFG"].get("composer", "share_dir"), "composer"))
-        errors = make_queue_dirs(server.config["COMPOSER_CFG"], 0)
+        errors = make_queue_dirs(server.config["COMPOSER_CFG"], os.getgid())
         if errors:
             raise RuntimeError("\n".join(errors))
 
-        make_dnf_dirs(server.config["COMPOSER_CFG"])
+        make_dnf_dirs(server.config["COMPOSER_CFG"], os.getuid(), os.getgid())
 
         # copy over the test dnf repositories
         dnf_repo_dir = server.config["COMPOSER_CFG"].get("composer", "repo_dir")
@@ -1397,11 +1397,11 @@ class RepoCacheTestCase(unittest.TestCase):
 
         server.config["COMPOSER_CFG"] = configure(root_dir=repo_dir, test_config=True)
         os.makedirs(joinpaths(server.config["COMPOSER_CFG"].get("composer", "share_dir"), "composer"))
-        errors = make_queue_dirs(server.config["COMPOSER_CFG"], 0)
+        errors = make_queue_dirs(server.config["COMPOSER_CFG"], os.getgid())
         if errors:
             raise RuntimeError("\n".join(errors))
 
-        make_dnf_dirs(server.config["COMPOSER_CFG"])
+        make_dnf_dirs(server.config["COMPOSER_CFG"], os.getuid(), os.getgid())
 
         # Modify fedora vs. rawhide tests when running on rawhide
         if os.path.exists("/etc/yum.repos.d/fedora-rawhide.repo"):

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -10,7 +10,12 @@ export top_srcdir=`pwd`
 ./src/sbin/lorax-composer --sharedir ./share/ ./tests/pylorax/blueprints/ &
 
 # wait for the backend to become ready
-until curl --unix-socket /run/weldr/api.socket http://localhost:4000/api/status | grep '"db_supported":true'; do
+tries=0
+until curl -m 15 --unix-socket /run/weldr/api.socket http://localhost:4000/api/status | grep 'db_supported.*true'; do
+    tries=$((tries + 1))
+    if [ $tries -gt 20 ]; then
+        exit 1
+    fi
     sleep 2
     echo "DEBUG: Waiting for backend API to become ready before testing ..."
 done;


### PR DESCRIPTION
It ends up that Python 3.7 changed the behavior of os.makedirs(), the mode argument isn't applied to parent directories. So setting the umask to 0 like we had been doing resulted in o+rw access to various places, like results.

This also fixes a problem I saw with creation of an empty blueprints directory, weldr:weldr cannot make a directory inside /var/lib/lorax/composer/ it needs to be done before dropping root.
