### PR TITLE
Add --squashfs-only option to drop inner rootfs.img layer

### DIFF
--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -186,7 +186,8 @@ class Lorax(BaseLoraxClass):
             add_arch_templates=None,
             add_arch_template_vars=None,
             verify=True,
-            user_dracut_args=None):
+            user_dracut_args=None,
+            squashfs_only=False):
 
         assert self._configured
 
@@ -332,9 +333,16 @@ class Lorax(BaseLoraxClass):
                 compressargs += ["-Xbcj", self.arch.bcj]
             else:
                 logger.info("no BCJ filter for arch %s", self.arch.basearch)
-        rb.create_runtime(joinpaths(installroot,runtime),
-                          compression=compression, compressargs=compressargs,
-                          size=size)
+        if squashfs_only:
+            # Create an ext4 rootfs.img and compress it with squashfs
+            rb.create_squashfs_runtime(joinpaths(installroot,runtime),
+                compression=compression, compressargs=compressargs,
+                size=size)
+        else:
+            # Create an ext4 rootfs.img and compress it with squashfs
+            rb.create_ext4_runtime(joinpaths(installroot,runtime),
+                compression=compression, compressargs=compressargs,
+                size=size)
         rb.finished()
 
         logger.info("preparing to build output tree and boot images")

--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -109,6 +109,8 @@ def lorax_parser(dracut_default=""):
                           help="Do not verify SSL certificates")
     optional.add_argument("--dnfplugin", action="append", default=[], dest="dnfplugins",
                           help="Enable a DNF plugin by name/glob, or * to enable all of them.")
+    optional.add_argument("--squashfs-only", action="store_true", default=False,
+                          help="Use a plain squashfs filesystem for the runtime.")
 
     # dracut arguments
     dracut_group = parser.add_argument_group("dracut arguments")

--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -203,7 +203,7 @@ def make_runtime(opts, mount_dir, work_dir, size=None):
     rb = RuntimeBuilder(product, arch, fake_dbo)
     compression, compressargs = squashfs_args(opts)
     log.info("Creating runtime")
-    rb.create_runtime(joinpaths(work_dir, RUNTIME), size=size,
+    rb.create_ext4_runtime(joinpaths(work_dir, RUNTIME), size=size,
                       compression=compression, compressargs=compressargs)
 
 

--- a/src/pylorax/treebuilder.py
+++ b/src/pylorax/treebuilder.py
@@ -215,7 +215,16 @@ class RuntimeBuilder(object):
             runcmd(["depmod", "-a", "-F", ksyms, "-b", root, kernel.version])
             generate_module_info(moddir+kernel.version, outfile=moddir+"module-info")
 
-    def create_runtime(self, outfile="/var/tmp/squashfs.img", compression="xz", compressargs=None, size=2):
+    def create_squashfs_runtime(self, outfile="/var/tmp/squashfs.img", compression="xz", compressargs=None, size=2):
+        """Create a plain squashfs runtime"""
+        compressargs = compressargs or []
+        os.makedirs(os.path.dirname(outfile))
+
+        # squash the rootfs
+        imgutils.mksquashfs(self.vars.root, outfile, compression, compressargs)
+
+    def create_ext4_runtime(self, outfile="/var/tmp/squashfs.img", compression="xz", compressargs=None, size=2):
+        """Create a squashfs compressed ext4 runtime"""
         # make live rootfs image - must be named "LiveOS/rootfs.img" for dracut
         compressargs = compressargs or []
         workdir = joinpaths(os.path.dirname(outfile), "runtime-workdir")

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -145,7 +145,8 @@ def main():
               add_arch_templates=opts.add_arch_templates,
               add_arch_template_vars=parsed_add_arch_template_vars,
               remove_temp=True, verify=opts.verify,
-              user_dracut_args=opts.dracut_args)
+              user_dracut_args=opts.dracut_args,
+              squashfs_only=opts.squashfs_only)
 
 
 def get_dnf_base_object(installroot, sources, mirrorlists=None, repos=None,


### PR DESCRIPTION
Make runtime directly into squashfs image. This reduces largely
unreproducible ext4 layer, but requires anaconda's dracut module
modification to properly mount the image.