### PR TITLE
WIP: Bring back upgrade initrd images

### DIFF
--- a/share/templates.d/99-generic/aarch64.tmpl
+++ b/share/templates.d/99-generic/aarch64.tmpl
@@ -29,6 +29,9 @@ mkdir ${KERNELDIR}
     ## normal aarch64
     installkernel images-${basearch} ${kernel.path} ${KERNELDIR}/vmlinuz
     installinitrd images-${basearch} ${kernel.initrd.path} ${KERNELDIR}/initrd.img
+    %if doupgrade:
+        installupgradeinitrd images-${basearch} ${kernel.upgrade.path} ${KERNELDIR}/upgrade.img
+    %endif
 %endfor
 
 #FIXME: this will need adjusted when we have a real bootloader.

--- a/share/templates.d/99-generic/arm.tmpl
+++ b/share/templates.d/99-generic/arm.tmpl
@@ -32,9 +32,18 @@ mkdir ${KERNELDIR}
         platforms = platforms + delimiter + kernel.flavor
         delimiter = ','
 %>
+        %if doupgrade:
+            ## install upgrade image
+            installupgradeinitrd images-${kernel.flavor}-${basearch} ${kernel.upgrade.path} ${KERNELDIR}/upgrade-${kernel.flavor}.img
+        %endif
     %else:
         installkernel images-${basearch} ${kernel.path} ${KERNELDIR}/vmlinuz
         installinitrd images-${basearch} ${kernel.initrd.path} ${KERNELDIR}/initrd.img
+
+        %if doupgrade:
+            ## install upgrade image
+            installupgradeinitrd images-${basearch} ${kernel.upgrade.path} ${KERNELDIR}/upgrade.img
+        %endif
     %endif
 %endfor
 

--- a/share/templates.d/99-generic/s390.tmpl
+++ b/share/templates.d/99-generic/s390.tmpl
@@ -29,6 +29,11 @@ replace @INITRD_LOAD_ADDRESS@ ${INITRD_ADDRESS} generic.ins
 installkernel images-${basearch} ${kernel.path} ${KERNELDIR}/kernel.img
 installinitrd images-${basearch} ${kernel.initrd.path} ${KERNELDIR}/initrd.img
 
+%if doupgrade:
+    ## upgrader image
+    installupgradeinitrd images-${basearch} ${kernel.upgrade.path} ${KERNELDIR}/upgrade.img
+%endif
+
 ## s390 needs some extra boot config
 createaddrsize ${INITRD_ADDRESS} ${outroot}/${BOOTDIR}/initrd.img ${outroot}/${BOOTDIR}/initrd.addrsize
 

--- a/share/templates.d/99-generic/x86.tmpl
+++ b/share/templates.d/99-generic/x86.tmpl
@@ -56,18 +56,30 @@ mkdir ${KERNELDIR}
         ## i386 PAE
         installkernel images-xen ${kernel.path} ${KERNELDIR}/vmlinuz-${kernel.flavor}
         installinitrd images-xen ${kernel.initrd.path} ${KERNELDIR}/initrd-${kernel.flavor}.img
+        %if doupgrade:
+            installupgradeinitrd images-xen ${kernel.upgrade.path} ${KERNELDIR}/upgrade-${kernel.flavor}.img
+        %endif
     %else:
         ## normal i386, x86_64
         installkernel images-${basearch} ${kernel.path} ${KERNELDIR}/vmlinuz
         installinitrd images-${basearch} ${kernel.initrd.path} ${KERNELDIR}/initrd.img
+        %if doupgrade:
+            installupgradeinitrd images-${basearch} ${kernel.upgrade.path} ${KERNELDIR}/upgrade.img
+        %endif
     %endif
 %endfor
 
 hardlink ${KERNELDIR}/vmlinuz ${BOOTDIR}
 hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
+%if doupgrade:
+    hardlink ${KERNELDIR}/upgrade.img ${BOOTDIR}
+%endif
 %if basearch == 'x86_64':
     treeinfo images-xen kernel ${KERNELDIR}/vmlinuz
     treeinfo images-xen initrd ${KERNELDIR}/initrd.img
+    %if doupgrade:
+        treeinfo images-xen upgrade ${KERNELDIR}/upgrade.img
+    %endif
 %endif
 
 ## WHeeeeeeee, EFI.

--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -369,6 +369,21 @@ class Lorax(BaseLoraxClass):
         logger.info("anaconda args = %s", anaconda_args)
         treebuilder.rebuild_initrds(add_args=anaconda_args)
 
+        if doupgrade:
+            # Build upgrade.img. It'd be nice if these could coexist in the same
+            # image, but that would increase the size of the anaconda initramfs,
+            # which worries some people (esp. PPC tftpboot). So they're separate.
+            try:
+                # If possible, use the 'redhat-upgrade-tool' plymouth theme
+                themes = runcmd_output(['plymouth-set-default-theme', '--list'],
+                                       root=installroot)
+                if 'leapp-upgrade-tool' in themes.splitlines():
+                    os.environ['PLYMOUTH_THEME_NAME'] = 'leapp-upgrade-tool'
+            except RuntimeError:
+                pass
+            upgrade_args = dracut_args + ["--add", "system-upgrade"]
+            treebuilder.rebuild_initrds(add_args=upgrade_args, prefix="upgrade")
+
         logger.info("populating output tree and building boot images")
         treebuilder.build()
 


### PR DESCRIPTION
While fedup isn't supporting upgrade images anymore a new approach is going to require it for more generic situations. Therefore we'd like to have it back. I mostly attempted to revert the changes made by Will Woods originally while trying to adjust it to the parts that have been changed.

rhel8_branch label suggested