### PR TITLE
New test: build and deploy images on vSphere

### DIFF
--- a/tests/cli/test_build_and_deploy_vmware.sh
+++ b/tests/cli/test_build_and_deploy_vmware.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Note: execute this file from the project root directory
+
+#####
+#
+# Make sure we can build an image and deploy it inside vSphere!
+#
+#####
+
+. /usr/share/beakerlib/beakerlib.sh
+
+CLI="./src/bin/composer-cli"
+
+
+rlJournalStart
+    rlPhaseStartSetup
+        if [ -z "$V_HOST" ]; then
+            rlFail "V_HOST is empty!"
+        else
+            rlLogInfo "V_HOST=$V_HOST"
+        fi
+
+        if [ -z "$V_USERNAME" ]; then
+            rlFail "V_USERNAME is empty!"
+        else
+            rlLogInfo "V_USERNAME=$V_USERNAME"
+        fi
+
+        if [ -z "$V_PASSWORD" ]; then
+            rlFail "V_PASSWORD is empty!"
+        else
+            rlLogInfo "V_PASSWORD is configured"
+        fi
+
+        V_DATACENTER="${V_DATACENTER:-RH_Engineering}"
+        rlLogInfo "V_DATACENTER=$V_DATACENTER"
+
+        V_CLUSTER="${V_CLUSTER:-SysMgmt_vMotion}"
+        rlLogInfo "V_CLUSTER=$V_CLUSTER"
+
+        V_NETWORK="${V_NETWORK:-CEE_VM_Network}"
+        rlLogInfo "V_NETWORK=$V_NETWORK"
+
+        V_DATASTORE="${V_DATASTORE:-NFS-Synology-1-RDU}"
+        rlLogInfo "V_DATASTORE=$V_DATASTORE"
+
+        V_FOLDER="${V_FOLDER:-Composer}"
+        rlLogInfo "V_FOLDER=$V_FOLDER"
+
+        if ! rlCheckRpm "python3-pip"; then
+            rlRun -t -c "dnf -y install python3-pip"
+            rlAssertRpm python3-pip
+        fi
+
+        rlRun -t -c "pip3 install pyvmomi"
+
+        TMP_DIR=`mktemp -d /tmp/composer-vmware.XXXXX`
+        SAMPLES="$TMP_DIR/pyvmomi-community-samples/samples/"
+        if [ ! -d "$SAMPLES" ]; then
+            rlRun -t -c "git clone https://github.com/weldr/pyvmomi-community-samples $TMP_DIR"
+            pushd $SAMPLES && git checkout composer_testing && popd
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartTest "compose start"
+        if [ ! -f ~/.ssh/id_rsa.pub ]; then
+            rlRun -t -c "ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa"
+        fi
+
+        PUB_KEY=`cat ~/.ssh/id_rsa.pub`
+
+        cat > $TMP_DIR/vmware.toml << __EOF__
+name = "vmware"
+description = "HTTP image for vmware"
+version = "0.0.1"
+
+[[modules]]
+name = "httpd"
+version = "*"
+
+[[customizations.user]]
+name = "root"
+key = "$PUB_KEY"
+__EOF__
+
+        rlRun -t -c "$CLI blueprints push vmware.toml"
+
+        UUID=`$CLI compose start vmware vmdk`
+        rlAssertEquals "exit code should be zero" $? 0
+
+        UUID=`echo $UUID | cut -f 2 -d' '`
+    rlPhaseEnd
+
+    rlPhaseStartTest "compose finished"
+        if [ -n "$UUID" ]; then
+            until $CLI compose info $UUID | grep FINISHED; do
+                rlLogInfo "Waiting for compose to finish ..."
+                sleep 30
+            done;
+        else
+            rlFail "Compose UUID is empty!"
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartTest "Upload vmdk image in vCenter"
+        rlRun -t -c "$CLI compose image $UUID"
+        IMAGE="$UUID-disk.vmdk"
+
+        python3 $SAMPLES/upload_file_to_datastore.py -S -s $V_HOST -u $V_USERNAME -p $V_PASSWORD \
+                -d $V_DATASTORE -l `readlink -f $IMAGE` -r $IMAGE
+        rlAssert0 "Image upload successfull" $?
+    rlPhaseEnd
+
+    rlPhaseStartTest "Start VM instance"
+        VM_NAME="Composer-Auto-VM-$UUID774"
+        INSTANCE_UUID=`python3 $SAMPLES/create_vm.py -S -s $V_HOST -u $V_USERNAME -p $V_PASSWORD \
+                        --datacenter $V_DATACENTER -c $V_CLUSTER -f $V_FOLDER -d $V_DATASTORE \
+                        --portgroup $V_NETWORK -v $IMAGE -m 2048 -g rhel7_64Guest -n $VM_NAME \
+                        --power-on`
+
+        if [ -z "$INSTANCE_UUID" ]; then
+            rlFail "INSTANCE_UUID is empty!"
+        else
+            rlLogInfo "INSTANCE_UUID=$INSTANCE_UUID"
+        fi
+
+        # wait for instance to become running and had assigned a public IP
+        IP_ADDRESS="None"
+        while [ "$IP_ADDRESS" == "None" ]; do
+            rlLogInfo "IP_ADDRESS is not assigned yet ..."
+            sleep 30
+            IP_ADDRESS=`python3 $SAMPLES/find_by_uuid.py -S -s $V_HOST -u $V_USERNAME -p $V_PASSWORD \
+                            --uuid $INSTANCE_UUID | grep 'ip address' | tr -d ' ' | cut -f2 -d:`
+        done
+
+        rlLogInfo "Running instance IP_ADDRESS=$IP_ADDRESS"
+
+        rlLogInfo "Waiting 30sec for instance to initialize ..."
+        sleep 30
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify VM instance"
+        # verify we can login into that instance
+        rlRun -t -c "ssh -oStrictHostKeyChecking=no root@$IP_ADDRESS 'cat /etc/redhat-release'"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        # note: vmdk disk is removed when destroying the VM
+        python3 $SAMPLES/destroy_vm.py -S -s $V_HOST -u $V_USERNAME -p $V_PASSWORD --uuid $INSTANCE_UUID
+        rlAssert0 "VM destroyed" $?
+        rlRun -t -c "$CLI compose delete $UUID"
+        rlRun -t -c "rm -rf $AMI $TMP_DIR"
+    rlPhaseEnd
+
+rlJournalEnd
+rlJournalPrintText


### PR DESCRIPTION
Uses our own fork of vmware/pyvmomi-community-samples, which contains scripts and patches to do what we need. 

Then follows the same steps as the script for AWS images:
- builds an image
- uploads it to vCenter
- creates a VM from that image
- verifies the VM
- clean up
