### PR TITLE
Update docs with info about ssh keys

### DIFF
--- a/docs/lorax-composer.rst
+++ b/docs/lorax-composer.rst
@@ -192,6 +192,10 @@ Set an existing user's ssh key in the final image::
 
 The key will be added to the user's authorized_keys file.
 
+.. warning::
+
+    ``key`` expects the entire content of ``~/.ssh/id_rsa.pub``
+
 
 [[customizations.user]]
 ***********************
@@ -212,6 +216,10 @@ All fields for this section are optional except for the ``name``, here is a comp
 
 If the password starts with ``$6$``, ``$5$``, or ``$2b$`` it will be stored as
 an encrypted password. Otherwise it will be treated as a plain text password.
+
+.. warning::
+
+    ``key`` expects the entire content of ``~/.ssh/id_rsa.pub``
 
 
 [[customizations.group]]

--- a/docs/man/lorax-composer.1
+++ b/docs/man/lorax-composer.1
@@ -301,7 +301,8 @@ key = "PUBLIC SSH KEY"
 .UNINDENT
 .UNINDENT
 .sp
-The key will be added to the user\(aqs authorized_keys file.
+The key will be added to the user\(aqs authorized_keys file. Expected value is the content
+of ~/.ssh/id_rsa.pub.
 .SS [[customizations.user]]
 .sp
 Add a user to the image, and/or set their ssh key.
@@ -327,7 +328,8 @@ gid = 1200
 .UNINDENT
 .sp
 If the password starts with \fB$6$\fP, \fB$5$\fP, or \fB$2b$\fP it will be stored as
-an encrypted password. Otherwise it will be treated as a plain text password.
+an encrypted password. Otherwise it will be treated as a plain text password. For
+ssh keys the expected value is the content of ~/.ssh/id_rsa.pub.
 .SS [[customizations.group]]
 .sp
 Add a group to the image. \fBname\fP is required and \fBgid\fP is optional:


### PR DESCRIPTION
it looks like the key value expects the entire content of ~/.ssh/id_rsa.pub


Note: I haven't updated the resulting HTML files. Do I need to do it? 