### PR TITLE
Fix reporting of coverage results to coverall.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 .coverage
 pylint-log
 .pytest_cache/
+.test-results/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ script:
 after_success:
   - |
 
-        sudo docker create --name results-cont welder/lorax /bin/echo
-        sudo docker cp results-cont:/lorax/.coverage .coverage.docker
-        sudo docker rm results-cont
+        cp .test-results/.coverage ./.coverage.docker
 
         pip install coverage coveralls
         coverage combine

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -32,5 +32,6 @@ RUN  dnf -y install \
   which && \
   touch /.in-container
 RUN useradd weldr
-VOLUME /lorax
-WORKDIR /lorax
+VOLUME /lorax-ro
+VOLUME /test-results
+WORKDIR /lorax-ro

--- a/Makefile
+++ b/Makefile
@@ -77,12 +77,13 @@ local:
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 
 test-in-copy:
-	rsync -aP --exclude=.git /lorax/ /lorax-test/
-	make -C /lorax-test/ check test
+	rsync -aP --exclude=.git /lorax-ro/ /lorax/
+	make -C /lorax/ check test
+	cp /lorax/.coverage /test-results/
 
 test-in-docker:
 	sudo $(DOCKER) build -t welder/lorax-tests:$(IMAGE_RELEASE) -f Dockerfile.test .
-	sudo $(DOCKER) run --rm -it -v `pwd`:/lorax:ro --security-opt label=disable welder/lorax-tests:$(IMAGE_RELEASE) make test-in-copy
+	sudo $(DOCKER) run --rm -it -v `pwd`/.test-results/:/test-results -v `pwd`:/lorax-ro:ro --security-opt label=disable welder/lorax-tests:$(IMAGE_RELEASE) make test-in-copy
 
 docs-in-docker:
 	sudo $(DOCKER) run -it --rm -v `pwd`/docs/html/:/lorax/docs/html/ --security-opt label=disable welder/lorax-tests:$(IMAGE_RELEASE) make docs


### PR DESCRIPTION
When I re-arranged the test-in-docker I didn't realize how .travis.yml
was extracting the results. This should fix it.

Fixes #522 