### PR TITLE
Add --no-system-repos to lorax-composer

### DIFF
--- a/src/pylorax/api/cmdline.py
+++ b/src/pylorax/api/cmdline.py
@@ -55,6 +55,8 @@ def lorax_composer_parser():
                         help="Top level temporary directory")
     parser.add_argument("--proxy", default=None, metavar="PROXY",
                         help="Set proxy for DNF, overrides configuration file setting.")
+    parser.add_argument("--no-system-repos", action="store_true", default=False,
+                        help="Do not copy over system repos from /etc/yum.repos.d/ at startup")
     parser.add_argument("BLUEPRINTS", metavar="BLUEPRINTS",
                         help="Path to the blueprints")
 

--- a/src/sbin/lorax-composer
+++ b/src/sbin/lorax-composer
@@ -203,6 +203,10 @@ if __name__ == '__main__':
     if opts.proxy:
         server.config["COMPOSER_CFG"].set("dnf", "proxy", opts.proxy)
 
+    # Override using system repos
+    if opts.no_system_repos:
+        server.config["COMPOSER_CFG"].set("repos", "use_system_repos", "0")
+
     # Make sure the queue paths are setup correctly, exit on errors
     errors = make_queue_dirs(server.config["COMPOSER_CFG"], gid)
     if errors:


### PR DESCRIPTION
Running lorax-composer --no-system-repos will prevent it from copying
the dnf repositories from /etc/yum.repos.d/ into the lorax-composer repo
directory. It will *only* use repositories setup using the sources api
or written to /var/lib/lorax/composer/repos.d/

If lorax-composer has previously been run without this switch the system
repos will need to be removed from the composer/repos.d/ directory. It
would also be a good idea to remove the cached metadata in
/var/tmp/composer/

Resolves: rhbz#1650363