### PR TITLE
Install grubby-deprecated package for ARMv7

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -37,6 +37,7 @@ installpkg glibc-all-langpacks
 %if basearch in ("arm", "armhfp"):
     installpkg efibootmgr
     installpkg grub2-efi-arm-cdboot
+    installpkg grubby-deprecated
     installpkg kernel-lpae
     installpkg uboot-tools
 %endif


### PR DESCRIPTION
Most bootloaders used in Fedora already have BootLoaderSpec but extlinux
doesn't yet. So when using extlinux the old grubby must to be installed.

Resolves: rhbz#1649778

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>