### PR TITLE
lorax-composer: Check for CDN only repos

### DIFF
--- a/src/pylorax/api/compose.py
+++ b/src/pylorax/api/compose.py
@@ -44,6 +44,7 @@ from uuid import uuid4
 from pykickstart.parser import KickstartParser
 from pykickstart.version import makeVersion
 
+from pylorax.api.dnfbase import check_repos
 from pylorax.api.projects import projects_depsolve, projects_depsolve_with_size, dep_nevra
 from pylorax.api.projects import ProjectsError
 from pylorax.api.recipes import read_recipe_and_id
@@ -295,6 +296,11 @@ def start_build(cfg, dnflock, gitlock, branch, recipe_name, compose_type, test_m
 
     with gitlock.lock:
         (commit_id, recipe) = read_recipe_and_id(gitlock.repo, branch, recipe_name)
+
+    # Make sure non-CDN repos are enabled
+    with dnflock.lock_check:
+        if not check_repos(dnflock.dbo):
+            raise RuntimeError("Compose requires non-CDN repos to be enabled")
 
     # Combine modules and packages and depsolve the list
     # TODO include the version/glob in the depsolving

--- a/src/sbin/lorax-composer
+++ b/src/sbin/lorax-composer
@@ -38,7 +38,7 @@ from pylorax import vernum, log_selinux_state
 from pylorax.api.cmdline import lorax_composer_parser
 from pylorax.api.config import configure, make_dnf_dirs, make_queue_dirs
 from pylorax.api.compose import test_templates
-from pylorax.api.dnfbase import DNFLock
+from pylorax.api.dnfbase import DNFLock, check_repos
 from pylorax.api.queue import start_queue_monitor
 from pylorax.api.recipes import open_or_create_repo, commit_recipe_directory
 from pylorax.api.server import server, GitLock
@@ -256,6 +256,8 @@ if __name__ == '__main__':
     # Depsolve the templates and make a note of the failures for /api/status to report
     with server.config["DNFLOCK"].lock:
         server.config["TEMPLATE_ERRORS"] = test_templates(server.config["DNFLOCK"].dbo, server.config["COMPOSER_CFG"].get("composer", "share_dir"))
+        if not check_repos(server.config["DNFLOCK"].dbo):
+            server.config["TEMPLATE_ERRORS"].append("Compose needs non-CDN repos enabled. Anaconda will fail to run.")
 
     # Setup access to the git repo
     server.config["REPO_DIR"] = opts.BLUEPRINTS


### PR DESCRIPTION
Anaconda is currently not able to handle cdn repo urls in the kickstart.
Add a new function that checks for extra repos and returns True.

Related: rhbz#1655623