### PR TITLE
lorax-composer: Handle packages with multiple builds

### DIFF
--- a/src/pylorax/api/bisect.py
+++ b/src/pylorax/api/bisect.py
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+def insort_left(a, x, key=None, lo=0, hi=None):
+    """Insert item x in list a, and keep it sorted assuming a is sorted.
+
+    :param a: sorted list
+    :type a: list
+    :param x: item to insert into the list
+    :type x: object
+    :param key: Function to use to compare items in the list
+    :type key: function
+    :returns: index where the item was inserted
+    :rtype: int
+
+    If x is already in a, insert it to the left of the leftmost x.
+    Optional args lo (default 0) and hi (default len(a)) bound the
+    slice of a to be searched.
+
+    This is a modified version of bisect.insort_left that can use a
+    function for the compare, and returns the index position where it
+    was inserted.
+    """
+    if key is None:
+        key = lambda i: i
+
+    if lo < 0:
+        raise ValueError('lo must be non-negative')
+    if hi is None:
+        hi = len(a)
+    while lo < hi:
+        mid = (lo+hi)//2
+        if key(a[mid]) < key(x): lo = mid+1
+        else: hi = mid
+    a.insert(lo, x)
+    return lo

--- a/src/pylorax/api/compose.py
+++ b/src/pylorax/api/compose.py
@@ -44,6 +44,7 @@ from uuid import uuid4
 from pykickstart.parser import KickstartParser
 from pykickstart.version import makeVersion
 
+from pylorax.api.dnfbase import check_repos
 from pylorax.api.projects import projects_depsolve, projects_depsolve_with_size, dep_nevra
 from pylorax.api.projects import ProjectsError
 from pylorax.api.recipes import read_recipe_and_id
@@ -295,6 +296,11 @@ def start_build(cfg, dnflock, gitlock, branch, recipe_name, compose_type, test_m
 
     with gitlock.lock:
         (commit_id, recipe) = read_recipe_and_id(gitlock.repo, branch, recipe_name)
+
+    # Make sure non-CDN repos are enabled
+    with dnflock.lock_check:
+        if not check_repos(dnflock.dbo):
+            raise RuntimeError("Compose requires non-CDN repos to be enabled")
 
     # Combine modules and packages and depsolve the list
     # TODO include the version/glob in the depsolving

--- a/src/pylorax/api/projects.py
+++ b/src/pylorax/api/projects.py
@@ -355,7 +355,7 @@ def dnf_repo_to_file_repo(repo):
     it ouputs baseurl and gpgkey as python lists which DNF cannot read. So do this manually with
     only the attributes we care about.
     """
-    repo_str = "[%s]\n" % repo.id
+    repo_str = "[%s]\nname = %s\n" % (repo.id, repo.name)
     if repo.metalink:
         repo_str += "metalink = %s\n" % repo.metalink
     elif repo.mirrorlist:
@@ -430,7 +430,7 @@ def repo_to_source(repo, system_source):
         source["check_gpg"] = True
 
     if repo.gpgkey:
-        source["gpgkey_urls"] = repo.gpgkey
+        source["gpgkey_urls"] = list(repo.gpgkey)
 
     return source
 
@@ -484,7 +484,7 @@ def source_to_repo(source, dnf_conf):
         repo.gpgcheck = False
 
     if "gpgkey_urls" in source:
-        repo.gpgkey = ",".join(source["gpgkey_urls"])
+        repo.gpgkey = tuple(source["gpgkey_urls"])
 
     repo.enable()
 

--- a/src/pylorax/api/projects.py
+++ b/src/pylorax/api/projects.py
@@ -17,11 +17,13 @@
 import logging
 log = logging.getLogger("lorax-composer")
 
-import os
 from configparser import ConfigParser
 import dnf
 from glob import glob
+import os
 import time
+
+from pylorax.api.bisect import insort_left
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
@@ -75,6 +77,32 @@ def pkg_to_project(pkg):
             "upstream_vcs": "UPSTREAM_VCS"}
 
 
+def pkg_to_build(pkg):
+    """Extract the build details from a hawkey.Package object
+
+    :param pkg: hawkey.Package object with package details
+    :type pkg: hawkey.Package
+    :returns: A dict with the build details, epoch, release, arch, build_time, changelog, ...
+    :rtype: dict
+
+    metadata entries are hard-coded to {}
+
+    Note that this only returns the build dict, it does not include the name, description, etc.
+    """
+    return {"epoch":      pkg.epoch,
+            "release":    pkg.release,
+            "arch":       pkg.arch,
+            "build_time": api_time(pkg.buildtime),
+            "changelog":  "CHANGELOG_NEEDED",                  # XXX Not in hawkey.Package
+            "build_config_ref": "BUILD_CONFIG_REF",
+            "build_env_ref":    "BUILD_ENV_REF",
+            "metadata":    {},
+            "source":      {"license":    pkg.license,
+                            "version":    pkg.version,
+                            "source_ref": "SOURCE_REF",
+                            "metadata":   {}}}
+
+
 def pkg_to_project_info(pkg):
     """Extract the details from a hawkey.Package object
 
@@ -85,25 +113,12 @@ def pkg_to_project_info(pkg):
 
     metadata entries are hard-coded to {}
     """
-    build = {"epoch":      pkg.epoch,
-             "release":    pkg.release,
-             "arch":       pkg.arch,
-             "build_time": api_time(pkg.buildtime),
-             "changelog":  "CHANGELOG_NEEDED",                  # XXX Not in hawkey.Package
-             "build_config_ref": "BUILD_CONFIG_REF",
-             "build_env_ref":    "BUILD_ENV_REF",
-             "metadata":    {},
-             "source":      {"license":    pkg.license,
-                             "version":    pkg.version,
-                             "source_ref": "SOURCE_REF",
-                             "metadata":   {}}}
-
     return {"name":         pkg.name,
             "summary":      pkg.summary,
             "description":  pkg.description,
             "homepage":     pkg.url,
             "upstream_vcs": "UPSTREAM_VCS",
-            "builds":       [build]}
+            "builds":       [pkg_to_build(pkg)]}
 
 
 def pkg_to_dep(pkg):
@@ -180,7 +195,24 @@ def projects_info(dbo, project_names):
         pkgs = dbo.sack.query().available().filter(name__glob=project_names)
     else:
         pkgs = dbo.sack.query().available()
-    return sorted(map(pkg_to_project_info, pkgs), key=lambda p: p["name"].lower())
+
+    # iterate over pkgs
+    # - if pkg.name isn't in the results yet, add pkg_to_project_info in sorted position
+    # - if pkg.name is already in results, get its builds. If the build for pkg is different
+    #   in any way (version, arch, etc.) add it to the entry's builds list. If it is the same,
+    #   skip it.
+    results = []
+    results_names = {}
+    for p in pkgs:
+        if p.name.lower() not in results_names:
+            idx = insort_left(results, pkg_to_project_info(p), key=lambda p: p["name"].lower())
+            results_names[p.name.lower()] = idx
+        else:
+            build = pkg_to_build(p)
+            if build not in results[results_names[p.name.lower()]]["builds"]:
+                results[results_names[p.name.lower()]]["builds"].append(build)
+
+    return results
 
 def _depsolve(dbo, projects, groups):
     """Add projects to a new transaction
@@ -321,9 +353,29 @@ def modules_list(dbo, module_names):
 
     """
     # TODO - Figure out what to do with this for Fedora 'modules'
-    projs = projects_info(dbo, module_names)
-    return sorted(map(proj_to_module, projs), key=lambda p: p["name"].lower())
+    projs = _unique_dicts(projects_info(dbo, module_names), key=lambda p: p["name"].lower())
+    return list(map(proj_to_module, projs))
 
+def _unique_dicts(lst, key):
+    """Return a new list of dicts, only including one match of key(d)
+
+    :param lst: list of dicts
+    :type lst: list
+    :param key: key function to match lst entries
+    :type key: function
+    :returns: list of the unique lst entries
+    :rtype: list
+
+    Uses key(d) to test for duplicates in the returned list, creating a
+    list of unique return values.
+    """
+    result = []
+    result_keys = []
+    for d in lst:
+        if key(d) not in result_keys:
+            result.append(d)
+            result_keys.append(key(d))
+    return result
 
 def modules_info(dbo, module_names):
     """Return details about a module, including dependencies

--- a/src/sbin/lorax-composer
+++ b/src/sbin/lorax-composer
@@ -38,7 +38,7 @@ from pylorax import vernum, log_selinux_state
 from pylorax.api.cmdline import lorax_composer_parser
 from pylorax.api.config import configure, make_dnf_dirs, make_queue_dirs
 from pylorax.api.compose import test_templates
-from pylorax.api.dnfbase import DNFLock
+from pylorax.api.dnfbase import DNFLock, check_repos
 from pylorax.api.queue import start_queue_monitor
 from pylorax.api.recipes import open_or_create_repo, commit_recipe_directory
 from pylorax.api.server import server, GitLock
@@ -256,6 +256,8 @@ if __name__ == '__main__':
     # Depsolve the templates and make a note of the failures for /api/status to report
     with server.config["DNFLOCK"].lock:
         server.config["TEMPLATE_ERRORS"] = test_templates(server.config["DNFLOCK"].dbo, server.config["COMPOSER_CFG"].get("composer", "share_dir"))
+        if not check_repos(server.config["DNFLOCK"].dbo):
+            server.config["TEMPLATE_ERRORS"].append("Compose needs non-CDN repos enabled. Anaconda will fail to run.")
 
     # Setup access to the git repo
     server.config["REPO_DIR"] = opts.BLUEPRINTS

--- a/tests/pylorax/repos/baseurl-test.repo
+++ b/tests/pylorax/repos/baseurl-test.repo
@@ -1,0 +1,5 @@
+[fake-repo-baseurl]
+name = A fake repo with a baseurl
+baseurl = https://fake-repo.base.url
+sslverify = True
+gpgcheck = True

--- a/tests/pylorax/repos/gpgkey-test.repo
+++ b/tests/pylorax/repos/gpgkey-test.repo
@@ -1,0 +1,6 @@
+[fake-repo-gpgkey]
+name = A fake repo with a gpgkey
+baseurl = https://fake-repo.base.url
+sslverify = True
+gpgcheck = True
+gpgkey = https://fake-repo.gpgkey

--- a/tests/pylorax/repos/metalink-test.repo
+++ b/tests/pylorax/repos/metalink-test.repo
@@ -1,0 +1,5 @@
+[fake-repo-metalink]
+name = A fake repo with a metalink
+metalink = https://fake-repo.metalink
+sslverify = True
+gpgcheck = True

--- a/tests/pylorax/repos/mirrorlist-test.repo
+++ b/tests/pylorax/repos/mirrorlist-test.repo
@@ -1,0 +1,5 @@
+[fake-repo-mirrorlist]
+name = A fake repo with a mirrorlist
+mirrorlist = https://fake-repo.mirrorlist
+sslverify = True
+gpgcheck = True

--- a/tests/pylorax/repos/proxy-test.repo
+++ b/tests/pylorax/repos/proxy-test.repo
@@ -1,0 +1,6 @@
+[fake-repo-proxy]
+name = A fake repo with a proxy
+baseurl = https://fake-repo.base.url
+proxy = https://fake-repo.proxy
+sslverify = True
+gpgcheck = True

--- a/tests/pylorax/test_bisect.py
+++ b/tests/pylorax/test_bisect.py
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import unittest
+
+from pylorax.api.bisect import insort_left
+
+
+class BisectTest(unittest.TestCase):
+    def test_insort_left_nokey(self):
+        results = []
+        for x in range(0, 10):
+            insort_left(results, x)
+        self.assertEqual(results, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    def test_insort_left_key_strings(self):
+        unsorted = ["Maggie", "Homer", "Bart", "Marge"]
+        results = []
+        for x in unsorted:
+            insort_left(results, x, key=lambda p: p.lower())
+        self.assertEqual(results, ["Bart", "Homer", "Maggie", "Marge"])
+
+    def test_insort_left_key_dict(self):
+        unsorted = [{"name":"Maggie"}, {"name":"Homer"}, {"name":"Bart"}, {"name":"Marge"}]
+        results = []
+        for x in unsorted:
+            insort_left(results, x, key=lambda p: p["name"].lower())
+        self.assertEqual(results, [{"name":"Bart"}, {"name":"Homer"}, {"name":"Maggie"}, {"name":"Marge"}])

--- a/tests/pylorax/test_projects.py
+++ b/tests/pylorax/test_projects.py
@@ -395,7 +395,7 @@ class SourceTest(unittest.TestCase):
     def test_source_to_repo_gpgkey(self):
         """Test creating a dnf.Repo with a proxy"""
         repo = source_to_repo(fakerepo_gpgkey(), self.dbo.conf)
-        self.assertEqual(repo.gpgkey, fakerepo_gpgkey()["gpgkey_urls"])
+        self.assertEqual(repo.gpgkey[0], fakerepo_gpgkey()["gpgkey_urls"][0])
 
     def test_drtfr_baseurl(self):
         """Test creating a dnf .repo file from a baseurl Repo object"""


### PR DESCRIPTION
When the repository has multiple arches, eg. i686 and x86_64, it should
add a new entry to the project's builds list, not create a new project
in the list.

This handles that by adding a modified insort_left function and
examining the packages returned from dnf to make sure they aren't
already listed in the results. It also handles adding them in sorted
order so that no further sorting needs to be done on the results.

Resolves: rhbz#1656642