### PR TITLE
[Request for Comments] Split image creation into modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ data_files.append(("/usr/sbin", ["src/sbin/lorax", "src/sbin/mkefiboot",
 data_files.append(("/usr/bin",  ["src/bin/image-minimizer",
                                  "src/bin/mk-s390-cdboot",
                                  "src/bin/composer-cli"]))
+data_files.append(("/usr/lib/lorax", ["src/modules/io.weldr.rpm",
+                                      "src/modules/io.weldr.anaconda",
+                                      "src/modules/io.weldr.fsimage"]))
 
 # get the version
 sys.path.insert(0, "src")

--- a/src/modules/io.weldr.anaconda
+++ b/src/modules/io.weldr.anaconda
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+options = SimpleNamespace(**json.loads(sys.stdin.read()))
+
+with tempfile.NamedTemporaryFile('w', suffix='.ks') as f:
+    f.write(options.kickstart)
+    f.flush()
+
+    cmd = [
+        'anaconda',
+        '-d', '--cmdline',
+        '--skippackages',
+        '--kickstart', f.name,
+        '--dirinstall', options.tree
+    ]
+
+    subprocess.run(cmd, check=True)

--- a/src/modules/io.weldr.fsimage
+++ b/src/modules/io.weldr.fsimage
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+
+from contextlib import contextmanager
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+import json
+import os
+import subprocess
+import sys
+
+options = SimpleNamespace(**json.loads(sys.stdin.read()))
+
+@contextmanager
+def mountloop(image, path):
+    try:
+        subprocess.run(['mount', '-o', 'loop', image, path], check=True)
+        yield
+    finally:
+        subprocess.run(['umount', path], check=True)
+
+
+subprocess.run(['truncate', '--size', '2G', options.target], check=True)
+subprocess.run(['mkfs.ext4', '-F', options.target], check=True)
+
+with TemporaryDirectory() as d, mountloop(options.target, d):
+    subprocess.run(['cp', '-a', os.path.join(options.tree, '.'), d], check=True)

--- a/src/modules/io.weldr.rpm
+++ b/src/modules/io.weldr.rpm
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+
+from configparser import ConfigParser
+from contextlib import contextmanager
+from types import SimpleNamespace
+import json
+import os
+import subprocess
+import sys
+
+options = SimpleNamespace(**json.loads(sys.stdin.read()))
+
+@contextmanager
+def bindmount(source, dest):
+    os.makedirs(source, 0o755, True)
+    os.makedirs(dest, 0o755, True)
+    subprocess.run(['mount', '--bind', source, dest], check=True)
+    try:
+        yield
+    finally:
+        subprocess.run(['umount', dest], check=True)
+
+
+# TODO check for existing config
+dnfconf = ConfigParser()
+for repoid, properties in options.repos.items():
+    dnfconf[repoid] = properties
+
+os.makedirs(f'{options.tree}/etc/dnf', True)
+with open(f'{options.tree}/etc/dnf/dnf.conf', 'w') as f:
+    dnfconf.write(f)
+
+
+with bindmount('/proc', f'{options.tree}/proc'), \
+     bindmount('/dev', f'{options.tree}/dev'), \
+     bindmount('/sys', f'{options.tree}/sys'):
+
+    cmd = ['dnf', '-yv',
+           f'--installroot={options.tree}',
+           '--releasever=29',
+           '--setopt=reposdir=None',     # don't use repos from the host
+           'install', 'chrony', 'firewalld'] + options.packages
+
+    subprocess.run(cmd, check=True)

--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -23,6 +23,7 @@ import subprocess
 import shutil
 import hashlib
 import glob
+import json
 
 # Use Mako templates for appliance builder descriptions
 from mako.template import Template
@@ -712,3 +713,10 @@ def run_creator(opts, callback_func=None):
         result_dir = None
 
     return (result_dir, disk_img)
+
+def run_modules(config, logdir):
+    for i, module in enumerate(config, start=1):
+        options = json.dumps(module['options']).encode('utf-8')
+
+        with open(os.path.join(logdir, str(i).zfill(4) + '-' + module['name']), 'w') as log:
+            subprocess.run(['/usr/lib/lorax/' + module['name']], input=options, stdout=log, stderr=log, check=True)


### PR DESCRIPTION
NOTE: This is a very crude first version of this idea to validate it and
gather early feedback. I've done just enough to make this work, with
lots of code commented out and (of course) nothing working like it did
before. It's quite a change in architecture and I'd like to discuss
before putting more work into it.

Image builds are now pipelines of modules. Each module is an executable
that takes a json object as configuration on stdin. This object contains
the path to a directory containing an os tree. The module can do
anything to that tree.

The first three modules are:

- io.weldr.rpm: installs rpm packages from arbitrary sources
- io.weldr.anaconda: runs anaconda with a kickstart file on that tree,
assuming that all packages are already installed (needs skippackages
patch in anaconda)
- io.weldr.fsimage: create an ext4 image out of that tree

The pipeline is hard coded in compose.py right now. The idea is that
there will be different pipelines for various input/output formats that
live as configuration in the file system.

Going forward, this allows us to:

- test more thoroughly, as we have smaller testable units
- diff the file system tree after each module is run (useful for
debugging, auditing, figuring out what anaconda is doing exactly)
- allow more experimentation, because the pipeline of creating images
becomes configuration
- modules are pluggable and can come from other sources - this is why
they're are prefixed with reverse domain names