### PR TITLE
Turn on signed tags when using tito.

### DIFF
--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -3,3 +3,4 @@ builder = tito.builder.Builder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
+sign_tag = 1


### PR DESCRIPTION
This requires a patched version of tito at the moment, and doesn't hurt
to have it set -- it will just continue not signing the tags.