### PR TITLE
Allow customizations to be specified as a toml list

### DIFF
--- a/src/pylorax/api/compose.py
+++ b/src/pylorax/api/compose.py
@@ -231,6 +231,10 @@ def add_customizations(f, recipe):
         return
     customizations = recipe["customizations"]
 
+    # allow customizations to be incorrectly specified as [[customizations]] instead of [customizations]
+    if isinstance(customizations, list):
+        customizations = customizations[0]
+
     if "hostname" in customizations:
         f.write("network --hostname=%s\n" % customizations["hostname"])
 


### PR DESCRIPTION
Support both

  [customizations]
  hostname = "whatever"

and

  [[customizations]]
  hostname = "whatever"

in the blueprint data. The [[ syntax matches the other customization
directives (user, group, sshkey), and as such it's easy to accidentally
use it for the hostname without even realizing it's specifying something
different.

Add some tests for converting customizations to kickstarts.

Fixes https://github.com/weldr/lorax/issues/556