### PR TITLE
Pass dnf's ssl options to anaconda to enable RHEL subscription content

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -47,7 +47,7 @@ Requires:       kpartx
 # Python modules
 Requires:       libselinux-python3
 Requires:       python3-mako
-Requires:       python3-kickstart
+Requires:       python3-kickstart >= 3.19
 Requires:       python3-dnf >= 3.2.0
 Requires:       python3-librepo
 

--- a/src/pylorax/api/cmdline.py
+++ b/src/pylorax/api/cmdline.py
@@ -22,6 +22,9 @@ import argparse
 
 from pylorax import vernum
 
+DEFAULT_USER  = "root"
+DEFAULT_GROUP = "weldr"
+
 version = "{0}-{1}".format(os.path.basename(sys.argv[0]), vernum)
 
 def lorax_composer_parser():
@@ -32,9 +35,9 @@ def lorax_composer_parser():
 
     parser.add_argument("--socket", default="/run/weldr/api.socket", metavar="SOCKET",
                         help="Path to the socket file to listen on")
-    parser.add_argument("--user", default="weldr", metavar="USER",
+    parser.add_argument("--user", default=DEFAULT_USER, metavar="USER",
                         help="User to use for reduced permissions")
-    parser.add_argument("--group", default="weldr", metavar="GROUP",
+    parser.add_argument("--group", default=DEFAULT_GROUP, metavar="GROUP",
                         help="Group to set ownership of the socket to")
     parser.add_argument("--log", dest="logfile", default="/var/log/lorax-composer/composer.log", metavar="LOG",
                         help="Path to logfile (/var/log/lorax-composer/composer.log)")

--- a/src/pylorax/api/compose.py
+++ b/src/pylorax/api/compose.py
@@ -110,6 +110,13 @@ def repo_to_ks(r, url="url"):
     if not r.sslverify:
         cmd += '--noverifyssl'
 
+    if r.sslcacert:
+        cmd += ' --sslcacert="%s"' % r.sslcacert
+    if r.sslclientcert:
+        cmd += ' --sslclientcert="%s"' % r.sslclientcert
+    if r.sslclientkey:
+        cmd += ' --sslclientkey="%s"' % r.sslclientkey
+
     return cmd
 
 

--- a/src/sbin/lorax-composer
+++ b/src/sbin/lorax-composer
@@ -244,7 +244,8 @@ if __name__ == '__main__':
 
     start_queue_monitor(server.config["COMPOSER_CFG"], uid, gid)
 
-    # Drop root privileges on the main process
+    # Change user and group on the main process.  Note that this still happens even if
+    # --user and --group were passed in, but changing to the same user should be fine.
     os.setgid(gid)
     os.setuid(uid)
     log.debug("user is now %s:%s", os.getresuid(), os.getresgid())


### PR DESCRIPTION
This makes the [reposync workaround](https://weldr.io/Running-Composer-on-RHEL/) unnecessary when creating images from RHEL systems.

See individual commits for explanation.

Depends on https://github.com/dcantrell/pykickstart/pull/250 and https://github.com/rhinstaller/anaconda/pull/1745/files

Before merging, let's
- [ ] figure out if we can talk to subscription-manager without being root