### PR TITLE
Don't exclude /dev from the `setfiles` in `novirt_install`

### DIFF
--- a/src/pylorax/installer.py
+++ b/src/pylorax/installer.py
@@ -389,7 +389,7 @@ def novirt_install(opts, disk_img, disk_size, cancel_func=None):
             log.info(line)
 
         # Make sure the new filesystem is correctly labeled
-        setfiles_args = ["-e", "/proc", "-e", "/sys", "-e", "/dev",
+        setfiles_args = ["-e", "/proc", "-e", "/sys",
                          "/etc/selinux/targeted/contexts/files/file_contexts", "/"]
 
         if "--dirinstall" in args:


### PR DESCRIPTION
After a novirt disk image install, we run `setfiles` in the
install root to ensure some SELinux contexts are correct. /dev
is currently excluded from this run. However, as reported and
discussed in https://bugzilla.redhat.com/show_bug.cgi?id=1663040
it seems that with a recent systemd change, startup of many
services will fail if /dev itself is incorrectly labelled, and
in current Rawhide live images, it *is* incorrectly labelled.
Including `/dev` in this setfiles command appears to resolve the
problem in my testing.

Resolves: rhbz#1663040

Signed-off-by: Adam Williamson <awilliam@redhat.com>