### PR TITLE
Add PR template with instructions for repo members

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+--- Description of proposed changes ---
+
+
+
+
+--- Merge policy ---
+
+- [ ] Travis CI PASS
+- [ ] `*-aws-runtest` PASS
+- [ ] `*-azure-runtest` PASS
+- [ ] `*-images-runtest` PASS
+- [ ] `*-openshift-runtest` PASS
+- [ ] `*-vmware-runtest` PASS
+
+--- Jenkins commands ---
+
+- `ok to test` to accept this pull request for testing
+- `test this please` for a one time test run
+- `retest this please` to start a new build


### PR DESCRIPTION
this will serve as a reminder that sometimes Jenkins jobs can be
missing or failing and also lists the comments which team members
can use to trigger Jenkins jobs, especially for PRs from
non-members.