### PR TITLE
Export OS_PROJECT_NAME variable in openstack cleanup script

### DIFF
--- a/tests/cleanup/remove_old_objects_openstack.sh
+++ b/tests/cleanup/remove_old_objects_openstack.sh
@@ -24,6 +24,9 @@ rlJournalStart
             rlLogInfo "OS_PASSWORD is configured"
         fi
 
+        export OS_PROJECT_NAME="${OS_PROJECT_NAME:-$OS_USERNAME}"
+        rlLogInfo "OS_PROJECT_NAME=$OS_PROJECT_NAME"
+
         # VMs older than HOURS_LIMIT will be deleted
         HOURS_LIMIT="${HOURS_LIMIT:-24}"
         export TIMESTAMP=`date -u -d "$HOURS_LIMIT hours ago" '+%FT%T'`

--- a/tests/cli/test_build_and_deploy_openstack.sh
+++ b/tests/cli/test_build_and_deploy_openstack.sh
@@ -26,8 +26,8 @@ rlJournalStart
             rlLogInfo "OS_USERNAME=$OS_USERNAME"
         fi
 
-        export OS_TENANT_NAME="${OS_TENANT_NAME:-$OS_USERNAME}"
-        rlLogInfo "OS_TENANT_NAME=$OS_TENANT_NAME"
+        export OS_PROJECT_NAME="${OS_PROJECT_NAME:-$OS_USERNAME}"
+        rlLogInfo "OS_PROJECT_NAME=$OS_PROJECT_NAME"
 
         if [ -z "$OS_PASSWORD" ]; then
             rlFail "OS_PASSWORD is empty!"


### PR DESCRIPTION
The OS_PROJECT_NAME (or OS_TENANT_NAME) environment variable needs to be defined.
Use the OS_PROJECT_NAME, since it is recommended in the documentation instead of
the older OS_TENANT_NAME.