### PR TITLE
Expand parameters as separate words

### DIFF
--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -35,7 +35,7 @@ if [ -z "$*" ]; then
 else
     # execute other cli tests which need more adjustments in the calling environment
     # or can't be executed inside Travis CI
-    for TEST in "$*"; do
+    for TEST in "$@"; do
         ./$TEST
     done
 fi


### PR DESCRIPTION
This is needed in case the script is executed with more parameters, the parameters need to be expanded as separate strings.