### PR TITLE
New CLI test for building compose with SELinux in enforcing mode

### DIFF
--- a/tests/cli/test_build_and_deploy_aws.sh
+++ b/tests/cli/test_build_and_deploy_aws.sh
@@ -71,6 +71,7 @@ __EOF__
     rlPhaseEnd
 
     rlPhaseStartTest "compose start"
+        rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
         UUID=`$CLI compose start example-http-server ami`
         rlAssertEquals "exit code should be zero" $? 0
 

--- a/tests/cli/test_build_and_deploy_azure.sh
+++ b/tests/cli/test_build_and_deploy_azure.sh
@@ -56,6 +56,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose start"
+        rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
         UUID=`$CLI compose start example-http-server vhd`
         rlAssertEquals "exit code should be zero" $? 0
 

--- a/tests/cli/test_build_and_deploy_openstack.sh
+++ b/tests/cli/test_build_and_deploy_openstack.sh
@@ -44,6 +44,8 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose start"
+        rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
+
         # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1639326
         cat > $TMP_DIR/http-with-rng.toml << __EOF__
 name = "http-with-rng"

--- a/tests/cli/test_build_and_deploy_vmware.sh
+++ b/tests/cli/test_build_and_deploy_vmware.sh
@@ -64,6 +64,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose start"
+        rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
         SSH_KEY_DIR=`mktemp -d /tmp/composer-ssh-keys.XXXXXX`
         rlRun -t -c "ssh-keygen -t rsa -N '' -f $SSH_KEY_DIR/id_rsa"
         PUB_KEY=`cat $SSH_KEY_DIR/id_rsa.pub`

--- a/tests/cli/test_compose_ext4-filesystem.sh
+++ b/tests/cli/test_compose_ext4-filesystem.sh
@@ -16,6 +16,7 @@ CLI="./src/bin/composer-cli"
 
 rlJournalStart
     rlPhaseStartTest "compose start"
+        rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
         UUID=`$CLI compose start example-http-server ext4-filesystem`
         rlAssertEquals "exit code should be zero" $? 0
 

--- a/tests/cli/test_compose_partitioned-disk.sh
+++ b/tests/cli/test_compose_partitioned-disk.sh
@@ -16,6 +16,7 @@ CLI="./src/bin/composer-cli"
 
 rlJournalStart
     rlPhaseStartTest "compose start"
+        rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
         UUID=`$CLI compose start example-http-server partitioned-disk`
         rlAssertEquals "exit code should be zero" $? 0
 


### PR DESCRIPTION
New test to check that composer can work with SELinux in enforcing mode on the host system.
