### PR TITLE
Expand parameters as separate words

### DIFF
--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -35,7 +35,7 @@ if [ -z "$*" ]; then
 else
     # execute other cli tests which need more adjustments in the calling environment
     # or can't be executed inside Travis CI
-    for TEST in "$*"; do
+    for TEST in "$@"; do
         ./$TEST
     done
 fi


### PR DESCRIPTION
Related rhbz#1656105, credit @jstodola

--- Description of proposed changes ---

without this test_images is not executing all test scripts.


--- Merge policy ---

- [x] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openshift-runtest` PASS
- [ ] `*-vmware-runtest` PASS

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
