### PR TITLE
installer: Run anaconda in a mount and pid namespace

### DIFF
--- a/src/pylorax/installer.py
+++ b/src/pylorax/installer.py
@@ -382,7 +382,8 @@ def novirt_install(opts, disk_img, disk_size, cancel_func=None):
     # Make sure anaconda has the right product and release
     log.info("Running anaconda.")
     try:
-        for line in execReadlines("anaconda", args, reset_lang=False,
+        unshare_args = [ "--pid", "--kill-child", "--mount", "--propagation", "unchanged", "anaconda" ] + args
+        for line in execReadlines("unshare", unshare_args, reset_lang=False,
                                   env_add={"ANACONDA_PRODUCTNAME": opts.project,
                                            "ANACONDA_PRODUCTVERSION": opts.releasever},
                                   callback=lambda p: not novirt_cancel_check(cancel_funcs, p)):


### PR DESCRIPTION
Anaconda can leave child processes and mounts around when it crashes or
is canceled before finishing. It also sometimes unmounts unrelated file
systems (https://github.com/rhinstaller/anaconda/issues/1791).

Run it in a mount and pid namespace to clean up after it.