### PR TITLE
Azure: Use existing storage account and record date/time of VM creation

### DIFF
--- a/tests/cli/test_build_and_deploy_azure.sh
+++ b/tests/cli/test_build_and_deploy_azure.sh
@@ -98,6 +98,8 @@ rlJournalStart
         rlRun -t -c "ssh-keygen -t rsa -N '' -f $SSH_KEY_DIR/id_rsa"
         SSH_PUB_KEY=`cat $SSH_KEY_DIR/id_rsa.pub`
 
+        now=$(date -u '+%FT%T')
+
         TMP_DIR=`mktemp -d /tmp/composer-azure.XXXXX`
         cat > $TMP_DIR/azure-playbook.yaml << __EOF__
 ---
@@ -118,6 +120,8 @@ rlJournalStart
         image:
           name: $OS_IMAGE_NAME
           resource_group: $AZURE_RESOURCE_GROUP
+        tags:
+          "first_seen": "$now"
 __EOF__
 
         rlRun -t -c "ansible-playbook $TMP_DIR/azure-playbook.yaml"

--- a/tests/cli/test_build_and_deploy_azure.sh
+++ b/tests/cli/test_build_and_deploy_azure.sh
@@ -122,6 +122,7 @@ rlJournalStart
           resource_group: $AZURE_RESOURCE_GROUP
         tags:
           "first_seen": "$now"
+        storage_account_name: $AZURE_STORAGE_ACCOUNT
 __EOF__
 
         rlRun -t -c "ansible-playbook $TMP_DIR/azure-playbook.yaml"


### PR DESCRIPTION
--- Description of proposed changes ---

Related: rhbz#1673012



--- Merge policy ---

- [x] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
