### PR TITLE
Drop auth from the kickstart examples

### DIFF
--- a/docs/rhel-container.ks
+++ b/docs/rhel-container.ks
@@ -8,8 +8,6 @@ network  --bootproto=dhcp --device=link --activate
 
 # Root password
 rootpw --plaintext removethispw
-# System authorization information
-auth --useshadow --passalgo=sha512
 # System keyboard
 keyboard --xlayouts=us --vckeymap=us
 # System language

--- a/docs/rhel-livemedia.ks
+++ b/docs/rhel-livemedia.ks
@@ -15,8 +15,6 @@ repo --name=appstream --baseurl="http://URL-TO-APPSTREAM"
 # Network information
 network  --bootproto=dhcp --device=link --activate
 
-# System authorization information
-auth --useshadow --passalgo=sha512
 # SELinux configuration
 selinux --enforcing
 

--- a/docs/rhel-minimal.ks
+++ b/docs/rhel-minimal.ks
@@ -10,8 +10,6 @@ network  --bootproto=dhcp --device=link --activate
 
 # Root password
 rootpw --plaintext removethispw
-# System authorization information
-auth --useshadow --passalgo=sha512
 # System keyboard
 keyboard --xlayouts=us --vckeymap=us
 # System language

--- a/docs/rhel-minimized.ks
+++ b/docs/rhel-minimized.ks
@@ -10,8 +10,6 @@ network  --bootproto=dhcp --device=link --activate
 
 # Root password
 rootpw --plaintext removethispw
-# System authorization information
-auth --useshadow --passalgo=sha512
 # System keyboard
 keyboard --xlayouts=us --vckeymap=us
 # System language

--- a/docs/rhel-openstack.ks
+++ b/docs/rhel-openstack.ks
@@ -10,8 +10,6 @@ network  --bootproto=dhcp --device=link --activate
 
 # Root password
 rootpw --plaintext replace-this-pw
-# System authorization information
-auth --useshadow --passalgo=sha512
 # System keyboard
 keyboard --xlayouts=us --vckeymap=us
 # System language

--- a/docs/rhel-vagrant.ks
+++ b/docs/rhel-vagrant.ks
@@ -16,8 +16,6 @@ rootpw --lock
 user --name=vagrant
 sshkey --username=vagrant "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key"
 
-# System authorization information
-auth --useshadow --passalgo=sha512
 # System keyboard
 keyboard --xlayouts=us --vckeymap=us
 # System language


### PR DESCRIPTION
System defaults should be sufficient these days.

Resolves: rhbz#1672583