### PR TITLE
Keep OpenStack VMs with Tag keep_me

### DIFF
--- a/tests/cleanup/remove_old_objects_openstack.sh
+++ b/tests/cleanup/remove_old_objects_openstack.sh
@@ -65,9 +65,9 @@ rlJournalStart
       name: "{{item.id}}"
       state: absent
     loop: "{{openstack_servers}}"
-    when: item.created < lookup('env','TIMESTAMP')
+    when: item.created < lookup('env','TIMESTAMP') and (item.metadata.Tag is not defined or item.metadata.Tag != "keep_me")
     loop_control:
-      label: "{{item.name}} (id: {{item.id}} created: {{item.created}})"
+      label: "{{item.name}} (id: {{item.id}} created: {{item.created}} metadata: {{item.metadata}})"
 __EOF__
 
         rlLogInfo "Removing VMs created before $TIMESTAMP"


### PR DESCRIPTION
--- Description of proposed changes ---

Keeps some VMs around so we can have some systems for debugging. The user has to mark them with metadata Tag == keep_me.

@jstodola please review


--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
