### PR TITLE
Make the lorax-composer ks templates more generic

### DIFF
--- a/share/composer/ami.ks
+++ b/share/composer/ami.ks
@@ -36,11 +36,13 @@ touch /etc/machine-id
 
 # tell cloud-init to create the ec2-user account
 sed -i 's/cloud-user/ec2-user/' /etc/cloud/cloud.cfg
+
+# Remove the rescue kernel and image to save space
+rm -f /boot/*-rescue*
 %end
 
 %packages
 kernel
--dracut-config-rescue
 selinux-policy-targeted
 
 chrony

--- a/share/composer/ami.ks
+++ b/share/composer/ami.ks
@@ -1,8 +1,5 @@
 # Lorax Composer AMI output kickstart template
 
-# Add a separate /boot partition
-part /boot --size=1024
-
 # Firewall configuration
 firewall --enabled
 
@@ -24,7 +21,7 @@ timezone  US/Eastern
 # System bootloader configuration
 bootloader --location=mbr --append="no_timer_check console=ttyS0,115200n8 console=tty1 net.ifnames=0"
 # Add platform specific partitions
-reqpart
+reqpart --add-boot
 
 # Basic services
 services --enabled=sshd,chronyd,cloud-init

--- a/share/composer/ami.ks
+++ b/share/composer/ami.ks
@@ -23,6 +23,8 @@ shutdown
 timezone  US/Eastern
 # System bootloader configuration
 bootloader --location=mbr --append="no_timer_check console=ttyS0,115200n8 console=tty1 net.ifnames=0"
+# Add platform specific partitions
+reqpart
 
 # Basic services
 services --enabled=sshd,chronyd,cloud-init
@@ -43,7 +45,6 @@ sed -i 's/cloud-user/ec2-user/' /etc/cloud/cloud.cfg
 kernel
 -dracut-config-rescue
 selinux-policy-targeted
-grub2
 
 chrony
 

--- a/share/composer/ext4-filesystem.ks
+++ b/share/composer/ext4-filesystem.ks
@@ -28,6 +28,9 @@ rm /var/lib/systemd/random-seed
 # Clear /etc/machine-id
 rm /etc/machine-id
 touch /etc/machine-id
+
+# Remove the rescue kernel and image to save space
+rm -f /boot/*-rescue*
 %end
 
 # NOTE Do NOT add any other sections after %packages

--- a/share/composer/live-iso.ks
+++ b/share/composer/live-iso.ks
@@ -351,22 +351,9 @@ EOF
 # Packages requires to support this output format go here
 isomd5sum
 kernel
-memtest86+
-syslinux
--dracut-config-rescue
 dracut-config-generic
 dracut-live
-generic-logos
+system-logos
 selinux-policy-targeted
-
-# This package is needed to boot the iso on UEFI
-shim
-shim-ia32
-grub2
-grub2-efi
-grub2-efi-*-cdboot
-grub2-efi-ia32
-efibootmgr
-
 
 # NOTE lorax-composer will add the blueprint packages below here, including the final %end%packages

--- a/share/composer/openstack.ks
+++ b/share/composer/openstack.ks
@@ -33,11 +33,13 @@ rm /var/lib/systemd/random-seed
 # Clear /etc/machine-id
 rm /etc/machine-id
 touch /etc/machine-id
+
+# Remove the rescue kernel and image to save space
+rm -f /boot/*-rescue*
 %end
 
 %packages
 kernel
--dracut-config-rescue
 selinux-policy-targeted
 
 # Make sure virt guest agents are installed

--- a/share/composer/openstack.ks
+++ b/share/composer/openstack.ks
@@ -20,6 +20,8 @@ shutdown
 timezone  US/Eastern
 # System bootloader configuration
 bootloader --location=mbr --append="no_timer_check console=ttyS0,115200n8 console=tty1 net.ifnames=0"
+# Add platform specific partitions
+reqpart
 
 # Start sshd and cloud-init at boot time
 services --enabled=sshd,cloud-init,cloud-init-local,cloud-config,cloud-final
@@ -37,7 +39,6 @@ touch /etc/machine-id
 kernel
 -dracut-config-rescue
 selinux-policy-targeted
-grub2
 
 # Make sure virt guest agents are installed
 qemu-guest-agent

--- a/share/composer/openstack.ks
+++ b/share/composer/openstack.ks
@@ -21,7 +21,7 @@ timezone  US/Eastern
 # System bootloader configuration
 bootloader --location=mbr --append="no_timer_check console=ttyS0,115200n8 console=tty1 net.ifnames=0"
 # Add platform specific partitions
-reqpart
+reqpart --add-boot
 
 # Start sshd and cloud-init at boot time
 services --enabled=sshd,cloud-init,cloud-init-local,cloud-config,cloud-final

--- a/share/composer/partitioned-disk.ks
+++ b/share/composer/partitioned-disk.ks
@@ -20,6 +20,8 @@ shutdown
 timezone  US/Eastern
 # System bootloader configuration
 bootloader --location=mbr
+# Add platform specific partitions
+reqpart
 
 %post
 # Remove random-seed
@@ -34,6 +36,5 @@ touch /etc/machine-id
 kernel
 -dracut-config-rescue
 selinux-policy-targeted
-grub2
 
 # NOTE lorax-composer will add the blueprint packages below here, including the final %end

--- a/share/composer/partitioned-disk.ks
+++ b/share/composer/partitioned-disk.ks
@@ -30,11 +30,13 @@ rm /var/lib/systemd/random-seed
 # Clear /etc/machine-id
 rm /etc/machine-id
 touch /etc/machine-id
+
+# Remove the rescue kernel and image to save space
+rm -f /boot/*-rescue*
 %end
 
 %packages
 kernel
--dracut-config-rescue
 selinux-policy-targeted
 
 # NOTE lorax-composer will add the blueprint packages below here, including the final %end

--- a/share/composer/partitioned-disk.ks
+++ b/share/composer/partitioned-disk.ks
@@ -21,7 +21,7 @@ timezone  US/Eastern
 # System bootloader configuration
 bootloader --location=mbr
 # Add platform specific partitions
-reqpart
+reqpart --add-boot
 
 %post
 # Remove random-seed

--- a/share/composer/qcow2.ks
+++ b/share/composer/qcow2.ks
@@ -20,6 +20,8 @@ shutdown
 timezone  US/Eastern
 # System bootloader configuration
 bootloader --location=mbr
+# Add platform specific partitions
+reqpart
 
 %post
 # Remove random-seed
@@ -34,7 +36,6 @@ touch /etc/machine-id
 kernel
 -dracut-config-rescue
 selinux-policy-targeted
-grub2
 
 # Make sure virt guest agents are installed
 qemu-guest-agent

--- a/share/composer/qcow2.ks
+++ b/share/composer/qcow2.ks
@@ -30,11 +30,13 @@ rm /var/lib/systemd/random-seed
 # Clear /etc/machine-id
 rm /etc/machine-id
 touch /etc/machine-id
+
+# Remove the rescue kernel and image to save space
+rm -f /boot/*-rescue*
 %end
 
 %packages
 kernel
--dracut-config-rescue
 selinux-policy-targeted
 
 # Make sure virt guest agents are installed

--- a/share/composer/qcow2.ks
+++ b/share/composer/qcow2.ks
@@ -21,7 +21,7 @@ timezone  US/Eastern
 # System bootloader configuration
 bootloader --location=mbr
 # Add platform specific partitions
-reqpart
+reqpart --add-boot
 
 %post
 # Remove random-seed

--- a/share/composer/tar.ks
+++ b/share/composer/tar.ks
@@ -28,6 +28,9 @@ rm /var/lib/systemd/random-seed
 # Clear /etc/machine-id
 rm /etc/machine-id
 touch /etc/machine-id
+
+# Remove the rescue kernel and image to save space
+rm -f /boot/*-rescue*
 %end
 
 # NOTE Do NOT add any other sections after %packages

--- a/share/composer/vhd.ks
+++ b/share/composer/vhd.ks
@@ -1,8 +1,5 @@
 # Lorax Composer VHD (Azure, Hyper-V) output kickstart template
 
-# Add a separate /boot partition
-part /boot --size=1024
-
 # Firewall configuration
 firewall --enabled
 
@@ -24,7 +21,7 @@ timezone  US/Eastern
 # System bootloader configuration
 bootloader --location=mbr --append="no_timer_check console=ttyS0,115200n8 earlyprintk=ttyS0,115200 rootdelay=300 net.ifnames=0"
 # Add platform specific partitions
-reqpart
+reqpart --add-boot
 
 # Basic services
 services --enabled=sshd,chronyd,waagent

--- a/share/composer/vhd.ks
+++ b/share/composer/vhd.ks
@@ -23,6 +23,8 @@ shutdown
 timezone  US/Eastern
 # System bootloader configuration
 bootloader --location=mbr --append="no_timer_check console=ttyS0,115200n8 earlyprintk=ttyS0,115200 rootdelay=300 net.ifnames=0"
+# Add platform specific partitions
+reqpart
 
 # Basic services
 services --enabled=sshd,chronyd,waagent
@@ -62,7 +64,6 @@ dracut -f -v --persistent-policy by-uuid
 kernel
 -dracut-config-rescue
 selinux-policy-targeted
-grub2
 
 chrony
 

--- a/share/composer/vhd.ks
+++ b/share/composer/vhd.ks
@@ -34,6 +34,9 @@ rm /var/lib/systemd/random-seed
 rm /etc/machine-id
 touch /etc/machine-id
 
+# Remove the rescue kernel and image to save space
+rm -f /boot/*-rescue*
+
 # This file is required by waagent in RHEL, but compatible with NetworkManager
 cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
 DEVICE=eth0
@@ -59,7 +62,6 @@ dracut -f -v --persistent-policy by-uuid
 
 %packages
 kernel
--dracut-config-rescue
 selinux-policy-targeted
 
 chrony

--- a/share/composer/vmdk.ks
+++ b/share/composer/vmdk.ks
@@ -21,7 +21,7 @@ timezone  US/Eastern
 # System bootloader configuration
 bootloader --location=mbr
 # Add platform specific partitions
-reqpart
+reqpart --add-boot
 
 # Basic services
 services --enabled=sshd,chronyd,vmtoolsd

--- a/share/composer/vmdk.ks
+++ b/share/composer/vmdk.ks
@@ -33,11 +33,13 @@ rm /var/lib/systemd/random-seed
 # Clear /etc/machine-id
 rm /etc/machine-id
 touch /etc/machine-id
+
+# Remove the rescue kernel and image to save space
+rm -f /boot/*-rescue*
 %end
 
 %packages
 kernel
--dracut-config-rescue
 selinux-policy-targeted
 
 chrony

--- a/share/composer/vmdk.ks
+++ b/share/composer/vmdk.ks
@@ -20,6 +20,8 @@ shutdown
 timezone  US/Eastern
 # System bootloader configuration
 bootloader --location=mbr
+# Add platform specific partitions
+reqpart
 
 # Basic services
 services --enabled=sshd,chronyd,vmtoolsd
@@ -37,7 +39,6 @@ touch /etc/machine-id
 kernel
 -dracut-config-rescue
 selinux-policy-targeted
-grub2
 
 chrony
 open-vm-tools

--- a/share/templates.d/99-generic/live/live-install.tmpl
+++ b/share/templates.d/99-generic/live/live-install.tmpl
@@ -1,0 +1,32 @@
+## livemedia-creator: Install packages needed for iso creation using per-arch templates
+<%page args="basearch"/>
+
+## arch-specific bootloader packages
+%if basearch == "aarch64":
+    installpkg efibootmgr
+    installpkg grub2-efi-aa64-cdboot shim-aa64
+    installpkg uboot-tools
+%endif
+%if basearch in ("arm", "armhfp"):
+    installpkg efibootmgr
+    installpkg grub2-efi-arm-cdboot
+    installpkg uboot-tools
+%endif
+%if basearch == "x86_64":
+    installpkg grub2-tools-efi
+    installpkg efibootmgr
+    installpkg shim-x64 grub2-efi-x64-cdboot
+    installpkg shim-ia32 grub2-efi-ia32-cdboot
+%endif
+%if basearch in ("i386", "x86_64"):
+    installpkg biosdevname memtest86+ syslinux
+    installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
+%endif
+%if basearch in ("ppc64le"):
+    installpkg powerpc-utils
+    installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
+    installpkg grub2-${basearch}
+%endif
+%if basearch == "s390x":
+    installpkg s390utils-base
+%endif

--- a/share/templates.d/99-generic/live/ppc64le.tmpl
+++ b/share/templates.d/99-generic/live/ppc64le.tmpl
@@ -1,0 +1,87 @@
+<%page args="kernels, runtime_img, basearch, libdir, inroot, outroot, product, isolabel"/>
+<%
+configdir="tmp/config_files/ppc"
+BOOTDIR="ppc"
+GRUBDIR="boot/grub"
+LIVEDIR="LiveOS"
+LORAXDIR="usr/share/lorax/"
+
+## NOTE: yaboot freaks out and stops parsing its config if it sees a '\',
+## so we can't use the udev escape sequences in the root arg.
+## Instead we'll just replace any non-ASCII characters in the isolabel
+## with '_', which means we won't need any udev escapes.
+isolabel = ''.join(ch if ch.isalnum() else '_' for ch in isolabel)
+
+from os.path import basename
+%>
+
+mkdir ${LIVEDIR}
+install ${runtime_img} ${LIVEDIR}/squashfs.img
+treeinfo stage2 mainimage ${LIVEDIR}/squashfs.img
+
+## install the bootloaders
+##   ppc/chrp: for normal PPC systems.
+##             uses /ppc/bootinfo.txt   in the iso root
+##             uses /boot/grub/grub.cfg in the iso root
+mkdir ${BOOTDIR}
+## boot stuff for normal (CHRP/PREP) PPC systems
+install ${configdir}/bootinfo.txt ${BOOTDIR}
+
+mkdir ${GRUBDIR}/powerpc-ieee1275
+## "()" means the current device to grub2
+runcmd grub2-mkimage --format=powerpc-ieee1275 --directory=/usr/lib/grub/powerpc-ieee1275 --prefix="()/"${GRUBDIR} \
+--output=${outroot}/${GRUBDIR}/powerpc-ieee1275/core.elf iso9660 ext2 ofnet net tftp http
+install /usr/lib/grub/powerpc-ieee1275/*.mod ${GRUBDIR}/powerpc-ieee1275
+install /usr/lib/grub/powerpc-ieee1275/*.lst ${GRUBDIR}/powerpc-ieee1275
+
+install ${configdir}/grub.cfg.in     ${GRUBDIR}/grub.cfg
+replace @PRODUCT@ '${product.name}'  ${GRUBDIR}/grub.cfg
+replace @VERSION@ ${product.version} ${GRUBDIR}/grub.cfg
+replace @ROOT@ 'root=live:CDLABEL=${isolabel|udev}' ${GRUBDIR}/grub.cfg
+
+## Install kernel and bootloader config (in separate places for each arch)
+%for kernel in kernels:
+    <%
+      bits = 64
+      ## separate dirs/images for each arch
+      KERNELDIR=BOOTDIR+"/ppc%s" % bits
+    %>
+    ## install kernel
+    mkdir ${KERNELDIR}
+    installkernel images-${kernel.arch} ${kernel.path} ${KERNELDIR}/vmlinuz
+    installinitrd images-${kernel.arch} ${kernel.initrd.path} ${KERNELDIR}/initrd.img
+
+    treeinfo images-${kernel.arch} zimage
+%endfor
+
+# Create optional product.img and updates.img
+<% filegraft=""; images=["product", "updates"] %>
+%for img in images:
+    %if exists("%s/%s/" % (LORAXDIR, img)):
+        installimg ${LORAXDIR}/${img}/ images/${img}.img
+        treeinfo images-${basearch} ${img}.img images/${img}.img
+        <% filegraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
+    %endif
+%endfor
+
+# Add the license files
+%for f in glob("/usr/share/licenses/*-release/*"):
+    install ${f} ${f|basename}
+    <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
+%endfor
+
+## make boot.iso
+runcmd xorrisofs -v -U -J -R \
+        -o ${outroot}/images/boot.iso \
+        -r -l -sysid PPC \
+        -A "${product.name} ${product.version}" -V '${isolabel}' \
+        -volset "${product.version}" -volset-size 1 -volset-seqno 1 \
+        -chrp-boot \
+        -graft-points \
+        ${BOOTDIR}=${outroot}/${BOOTDIR} \
+        ${GRUBDIR}=${outroot}/${GRUBDIR} \
+        ${LIVEDIR}=${outroot}/${LIVEDIR} ${filegraft}
+
+%for kernel in kernels:
+    treeinfo images-${kernel.arch} boot.iso images/boot.iso
+%endfor

--- a/src/pylorax/api/compose.py
+++ b/src/pylorax/api/compose.py
@@ -44,11 +44,14 @@ from uuid import uuid4
 from pykickstart.parser import KickstartParser
 from pykickstart.version import makeVersion
 
+from pylorax import ArchData, find_templates, get_buildarch
 from pylorax.api.projects import projects_depsolve, projects_depsolve_with_size, dep_nevra
 from pylorax.api.projects import ProjectsError
 from pylorax.api.recipes import read_recipe_and_id
 from pylorax.api.timestamp import TS_CREATED, write_timestamp
+from pylorax.base import DataHolder
 from pylorax.imgutils import default_image_name
+from pylorax.ltmpl import LiveTemplateRunner
 from pylorax.sysutils import joinpaths, flatconfig
 
 
@@ -283,6 +286,40 @@ def add_customizations(f, recipe):
     if not wrote_rootpw:
         f.write('rootpw --lock\n')
 
+
+def get_extra_pkgs(dbo, share_dir, compose_type):
+    """Return extra packages needed for the output type
+
+    :param dbo: dnf base object
+    :type dbo: dnf.Base
+    :param share_dir: Path to the top level share directory
+    :type share_dir: str
+    :param compose_type: The type of output to create from the recipe
+    :type compose_type: str
+    :returns: List of package names (name only, not NEVRA)
+    :rtype: list
+
+    Currently this is only needed by live-iso, it reads ./live/live-install.tmpl and
+    processes only the installpkg lines. It lists the packages needed to complete creation of the
+    iso using the templates such as x86.tmpl
+
+    Keep in mind that the live-install.tmpl is shared between livemedia-creator and lorax-composer,
+    even though the results are applied differently.
+    """
+    if compose_type != "live-iso":
+        return []
+
+    # get the arch information to pass to the runner
+    arch = ArchData(get_buildarch(dbo))
+    defaults = DataHolder(basearch=arch.basearch)
+    templatedir = joinpaths(find_templates(share_dir), "live")
+    runner = LiveTemplateRunner(dbo, templatedir=templatedir, defaults=defaults)
+    runner.run("live-install.tmpl")
+    log.debug("extra pkgs = %s", runner.pkgs)
+
+    return runner.pkgnames
+
+
 def start_build(cfg, dnflock, gitlock, branch, recipe_name, compose_type, test_mode=0):
     """ Start the build
 
@@ -304,15 +341,22 @@ def start_build(cfg, dnflock, gitlock, branch, recipe_name, compose_type, test_m
     if compose_type not in compose_types(share_dir):
         raise RuntimeError("Invalid compose type (%s), must be one of %s" % (compose_type, compose_types(share_dir)))
 
+    # Some image types (live-iso) need extra packages for composer to execute the output template
+    with dnflock.lock:
+        extra_pkgs = get_extra_pkgs(dnflock.dbo, share_dir, compose_type)
+    log.debug("Extra packages needed for %s: %s", compose_type, extra_pkgs)
+
     with gitlock.lock:
         (commit_id, recipe) = read_recipe_and_id(gitlock.repo, branch, recipe_name)
 
     # Combine modules and packages and depsolve the list
-    # TODO include the version/glob in the depsolving
     module_nver = recipe.module_nver
     package_nver = recipe.package_nver
+    package_nver.extend([(name, '*') for name in extra_pkgs])
+
     projects = sorted(set(module_nver+package_nver), key=lambda p: p[0].lower())
     deps = []
+    log.info("depsolving %s", recipe["name"])
     try:
         # This can possibly update repodata and reset the YumBase object.
         with dnflock.lock_check:

--- a/src/pylorax/ltmpl.py
+++ b/src/pylorax/ltmpl.py
@@ -811,6 +811,7 @@ class LiveTemplateRunner(TemplateRunner):
     def __init__(self, dbo, fatalerrors=True, templatedir=None, defaults=None):
         self.dbo = dbo
         self.pkgs = []
+        self.pkgnames = []
 
         super(LiveTemplateRunner, self).__init__(fatalerrors, templatedir, defaults)
 
@@ -871,6 +872,7 @@ class LiveTemplateRunner(TemplateRunner):
                     logger.info("installpkg: %s expands to %s", p, ",".join(pkgnvrs))
 
                 self.pkgs.extend(pkgnvrs)
+                self.pkgnames.extend([pkg.name for pkg in pkgnames])
             except Exception as e: # pylint: disable=broad-except
                 logger.error("installpkg %s failed: %s", p, str(e))
                 errors = True

--- a/src/pylorax/ltmpl.py
+++ b/src/pylorax/ltmpl.py
@@ -796,3 +796,84 @@ class LoraxTemplateRunner(TemplateRunner):
                 runcmd(cmd)
             except CalledProcessError:
                 pass
+
+class LiveTemplateRunner(TemplateRunner):
+    """
+    This class parses and executes a limited Lorax template. Sample usage:
+
+      # install a bunch of packages
+      runner = LiveTemplateRunner(dbo, templatedir, defaults)
+      runner.run("live-install.tmpl")
+
+      It is meant to be used with the live-install.tmpl which lists the per-arch
+      pacages needed to build the live-iso output.
+    """
+    def __init__(self, dbo, fatalerrors=True, templatedir=None, defaults=None):
+        self.dbo = dbo
+        self.pkgs = []
+
+        super(LiveTemplateRunner, self).__init__(fatalerrors, templatedir, defaults)
+
+    def installpkg(self, *pkgs):
+        '''
+        installpkg [--required|--optional] [--except PKGGLOB [--except PKGGLOB ...]] PKGGLOB [PKGGLOB ...]
+          Request installation of all packages matching the given globs.
+          Note that this is just a *request* - nothing is *actually* installed
+          until the 'run_pkg_transaction' command is given.
+
+          --required is now the default. If the PKGGLOB can be missing pass --optional
+        '''
+        if pkgs[0] == '--optional':
+            pkgs = pkgs[1:]
+            required = False
+        elif pkgs[0] == '--required':
+            pkgs = pkgs[1:]
+            required = True
+        else:
+            required = True
+
+        excludes = []
+        while '--except' in pkgs:
+            idx = pkgs.index('--except')
+            if len(pkgs) == idx+1:
+                raise ValueError("installpkg needs an argument after --except")
+
+            excludes.append(pkgs[idx+1])
+            pkgs = pkgs[:idx] + pkgs[idx+2:]
+
+        errors = False
+        for p in pkgs:
+            try:
+                # Start by using Subject to generate a package query, which will
+                # give us a query object similar to what dbo.install would select,
+                # minus the handling for multilib. This query may contain
+                # multiple arches. Pull the package names out of that, filter any
+                # that match the excludes patterns, and pass those names back to
+                # dbo.install to do the actual, arch and version and multilib
+                # aware, package selction.
+
+                # dnf queries don't have a concept of negative globs which is why
+                # the filtering is done the hard way.
+
+                pkgnames = [pkg for pkg in dnf.subject.Subject(p).get_best_query(self.dbo.sack).filter(latest=True)]
+                if not pkgnames:
+                    raise dnf.exceptions.PackageNotFoundError("no package matched", p)
+
+                # Apply excludes to the name only
+                for exclude in excludes:
+                    pkgnames = [pkg for pkg in pkgnames if not fnmatch.fnmatch(pkg.name, exclude)]
+
+                # Convert to a sorted NVR list for installation
+                pkgnvrs = sorted(["{}-{}-{}".format(pkg.name, pkg.version, pkg.release) for pkg in pkgnames])
+
+                # If the request is a glob, expand it in the log
+                if any(g for g in ['*','?','.'] if g in p):
+                    logger.info("installpkg: %s expands to %s", p, ",".join(pkgnvrs))
+
+                self.pkgs.extend(pkgnvrs)
+            except Exception as e: # pylint: disable=broad-except
+                logger.error("installpkg %s failed: %s", p, str(e))
+                errors = True
+
+        if errors and required:
+            raise Exception("Required installpkg failed.")

--- a/src/pylorax/ltmpl.py
+++ b/src/pylorax/ltmpl.py
@@ -103,8 +103,83 @@ def rexists(pathname, root=""):
         return True
     return False
 
+class TemplateRunner(object):
+    '''
+    This class parses and executes Lorax templates. Sample usage:
+
+      # install a bunch of packages
+      runner = LoraxTemplateRunner(inroot=rundir, outroot=rundir, dbo=dnf_obj)
+      runner.run("install-packages.ltmpl")
+    NOTES:
+
+    * Parsing procedure is roughly:
+      1. Mako template expansion (on the whole file)
+      2. For each line of the result,
+
+        a. Whitespace splitting (using shlex.split())
+        b. Brace expansion (using brace_expand())
+        c. If the first token is the name of a function, call that function
+           with the rest of the line as arguments
+
+    * Parsing and execution are *separate* passes - so you can't use the result
+      of a command in an %if statement (or any other control statements)!
+    '''
+    def __init__(self, fatalerrors=True, templatedir=None, defaults=None, builtins=None):
+        self.fatalerrors = fatalerrors
+        self.templatedir = templatedir or "/usr/share/lorax"
+        self.templatefile = None
+        self.builtins = builtins or {}
+        self.defaults = defaults or {}
+
+
+    def run(self, templatefile, **variables):
+        for k,v in list(self.defaults.items()) + list(self.builtins.items()):
+            variables.setdefault(k,v)
+        logger.debug("executing %s with variables=%s", templatefile, variables)
+        self.templatefile = templatefile
+        t = LoraxTemplate(directories=[self.templatedir])
+        commands = t.parse(templatefile, variables)
+        self._run(commands)
+
+
+    def _run(self, parsed_template):
+        logger.info("running %s", self.templatefile)
+        for (num, line) in enumerate(parsed_template,1):
+            logger.debug("template line %i: %s", num, " ".join(line))
+            skiperror = False
+            (cmd, args) = (line[0], line[1:])
+            # Following Makefile convention, if the command is prefixed with
+            # a dash ('-'), we'll ignore any errors on that line.
+            if cmd.startswith('-'):
+                cmd = cmd[1:]
+                skiperror = True
+            try:
+                # grab the method named in cmd and pass it the given arguments
+                f = getattr(self, cmd, None)
+                if cmd[0] == '_' or cmd == 'run' or not isinstance(f, collections.Callable):
+                    raise ValueError("unknown command %s" % cmd)
+                f(*args)
+            except Exception: # pylint: disable=broad-except
+                if skiperror:
+                    logger.debug("ignoring error")
+                    continue
+                logger.error("template command error in %s:", self.templatefile)
+                logger.error("  %s", " ".join(line))
+                # format the exception traceback
+                exclines = traceback.format_exception(*sys.exc_info())
+                # skip the bit about "ltmpl.py, in _run()" - we know that
+                exclines.pop(1)
+                # log the "ErrorType: this is what happened" line
+                logger.error("  %s", exclines[-1].strip())
+                # and log the entire traceback to the debug log
+                for _line in ''.join(exclines).splitlines():
+                    logger.debug("  %s", _line)
+                if self.fatalerrors:
+                    raise
+
+
 # TODO: operate inside an actual chroot for safety? Not that RPM bothers..
-class LoraxTemplateRunner(object):
+class LoraxTemplateRunner(TemplateRunner):
     '''
     This class parses and executes Lorax templates. Sample usage:
 
@@ -117,18 +192,6 @@ class LoraxTemplateRunner(object):
       runner.run("runtime-transmogrify.ltmpl")
 
     NOTES:
-
-    * Parsing procedure is roughly:
-      1. Mako template expansion (on the whole file)
-      2. For each line of the result,
-      
-        a. Whitespace splitting (using shlex.split())
-        b. Brace expansion (using brace_expand())
-        c. If the first token is the name of a function, call that function
-           with the rest of the line as arguments
-
-    * Parsing and execution are *separate* passes - so you can't use the result
-      of a command in an %if statement (or any other control statements)!
 
     * Commands that run external programs (e.g. systemctl) currently use
       the *host*'s copy of that program, which may cause problems if there's a
@@ -152,14 +215,11 @@ class LoraxTemplateRunner(object):
         self.inroot = inroot
         self.outroot = outroot
         self.dbo = dbo
-        self.fatalerrors = fatalerrors
-        self.templatedir = templatedir or "/usr/share/lorax"
-        self.templatefile = None
-        # some builtin methods
-        self.builtins = DataHolder(exists=lambda p: rexists(p, root=inroot),
-                                   glob=lambda g: list(rglob(g, root=inroot)))
-        self.defaults = defaults or {}
+        builtins = DataHolder(exists=lambda p: rexists(p, root=inroot),
+                              glob=lambda g: list(rglob(g, root=inroot)))
         self.results = DataHolder(treeinfo=dict()) # just treeinfo for now
+
+        super(LoraxTemplateRunner, self).__init__(fatalerrors, templatedir, defaults, builtins)
         # TODO: set up custom logger with a filter to add line info
 
     def _out(self, path):
@@ -210,51 +270,6 @@ class LoraxTemplateRunner(object):
             for pkg in debug_pkgs:
                 f.write("%s\n" % pkg)
 
-    def run(self, templatefile, **variables):
-        for k,v in list(self.defaults.items()) + list(self.builtins.items()):
-            variables.setdefault(k,v)
-        logger.debug("executing %s with variables=%s", templatefile, variables)
-        self.templatefile = templatefile
-        t = LoraxTemplate(directories=[self.templatedir])
-        commands = t.parse(templatefile, variables)
-        self._run(commands)
-
-
-    def _run(self, parsed_template):
-        logger.info("running %s", self.templatefile)
-        for (num, line) in enumerate(parsed_template,1):
-            logger.debug("template line %i: %s", num, " ".join(line))
-            skiperror = False
-            (cmd, args) = (line[0], line[1:])
-            # Following Makefile convention, if the command is prefixed with
-            # a dash ('-'), we'll ignore any errors on that line.
-            if cmd.startswith('-'):
-                cmd = cmd[1:]
-                skiperror = True
-            try:
-                # grab the method named in cmd and pass it the given arguments
-                f = getattr(self, cmd, None)
-                if cmd[0] == '_' or cmd == 'run' or not isinstance(f, collections.Callable):
-                    raise ValueError("unknown command %s" % cmd)
-                f(*args)
-            except Exception: # pylint: disable=broad-except
-                if skiperror:
-                    logger.debug("ignoring error")
-                    continue
-                logger.error("template command error in %s:", self.templatefile)
-                logger.error("  %s", " ".join(line))
-                # format the exception traceback
-                exclines = traceback.format_exception(*sys.exc_info())
-                # skip the bit about "ltmpl.py, in _run()" - we know that
-                exclines.pop(1)
-                # log the "ErrorType: this is what happened" line
-                logger.error("  %s", exclines[-1].strip())
-                # and log the entire traceback to the debug log
-                for _line in ''.join(exclines).splitlines():
-                    logger.debug("  %s", _line)
-                if self.fatalerrors:
-                    raise
-
     def install(self, srcglob, dest):
         '''
         install SRC DEST
@@ -265,7 +280,7 @@ class LoraxTemplateRunner(object):
           If DEST doesn't exist, SRC will be copied to a file with that name,
           assuming the rest of the path exists.
           This is pretty much like how the 'cp' command works.
-          
+
           Examples:
             install usr/share/myconfig/grub.conf /boot
             install /usr/share/myconfig/grub.conf.in /boot/grub.conf
@@ -321,7 +336,7 @@ class LoraxTemplateRunner(object):
         '''
         mkdir DIR [DIR ...]
           Create the named DIR(s). Will create leading directories as needed.
-          
+
           Example:
             mkdir /images
         '''
@@ -335,7 +350,7 @@ class LoraxTemplateRunner(object):
         replace PATTERN REPLACEMENT FILEGLOB [FILEGLOB ...]
           Find-and-replace the given PATTERN (Python-style regex) with the given
           REPLACEMENT string for each of the files listed.
-          
+
           Example:
             replace @VERSION@ ${product.version} /boot/grub.conf /boot/isolinux.cfg
         '''
@@ -353,9 +368,9 @@ class LoraxTemplateRunner(object):
           Append STRING (followed by a newline character) to FILE.
           Python character escape sequences ('\\n', '\\t', etc.) will be
           converted to the appropriate characters.
-          
+
           Examples:
-          
+
             append /etc/depmod.d/dd.conf "search updates built-in"
             append /etc/resolv.conf ""
         '''
@@ -368,7 +383,7 @@ class LoraxTemplateRunner(object):
           Add an item to the treeinfo data store.
           The given SECTION will have a new item added where
           KEY = ARG ARG ...
-          
+
           Example:
             treeinfo images-${kernel.arch} boot.iso images/boot.iso
         '''
@@ -469,7 +484,7 @@ class LoraxTemplateRunner(object):
         '''
         log MESSAGE
           Emit the given log message. Be sure to put it in quotes!
-          
+
           Example:
             log "Reticulating splines, please wait..."
         '''
@@ -588,7 +603,7 @@ class LoraxTemplateRunner(object):
         '''
         removepkg PKGGLOB [PKGGLOB...]
           Delete the named package(s).
-          
+
           IMPLEMENTATION NOTES:
             RPM scriptlets (%preun/%postun) are *not* run.
             Files are deleted, but directories are left behind.
@@ -653,7 +668,7 @@ class LoraxTemplateRunner(object):
           (or packages) named.
           If '--allbut' is used, all the files from the given package(s) will
           be removed *except* the ones which match the file globs.
-          
+
           Examples:
             removefrom usbutils /usr/bin/*
             removefrom xfsprogs --allbut /sbin/*
@@ -748,7 +763,7 @@ class LoraxTemplateRunner(object):
         '''
         createaddrsize INITRD_ADDRESS INITRD ADDRSIZE
           Create the initrd.addrsize file required in LPAR boot process.
-          
+
           Examples:
             createaddrsize ${INITRD_ADDRESS} ${outroot}/${BOOTDIR}/initrd.img ${outroot}/${BOOTDIR}/initrd.addrsize
         '''
@@ -761,7 +776,7 @@ class LoraxTemplateRunner(object):
         '''
         systemctl [enable|disable|mask] UNIT [UNIT...]
           Enable, disable, or mask the given systemd units.
-          
+
           Examples:
             systemctl disable lvm2-monitor.service
             systemctl mask fedora-storage-init.service fedora-configure.service

--- a/tests/pylorax/test_creator.py
+++ b/tests/pylorax/test_creator.py
@@ -27,6 +27,7 @@ from ..lib import get_file_magic
 from pylorax import find_templates
 from pylorax.base import DataHolder
 from pylorax.creator import FakeDNF, create_pxe_config, make_appliance, make_squashfs, squashfs_args
+from pylorax.creator import calculate_disk_size
 from pylorax.creator import get_arch, find_ostree_root, check_kickstart
 from pylorax.executils import runcmd
 from pylorax.imgutils import mksparse
@@ -242,6 +243,71 @@ class CreatorTest(unittest.TestCase):
                                    "reboot\n")
         errors = check_kickstart(ks, opts)
         self.assertTrue("must include shutdown when using virt" in errors[0])
+
+    def disk_size_simple_test(self):
+        """Test calculating the disk size with a simple / partition"""
+        opts = DataHolder(no_virt=True, make_fsimage=False, make_iso=False, make_pxe_live=False)
+        ks_version = makeVersion()
+        ks = KickstartParser(ks_version, errorsAreFatal=False, missingIncludeIsFatal=False)
+        ks.readKickstartFromString("url --url=http://dl.fedoraproject.com\n"
+                                   "network --bootproto=dhcp --activate\n"
+                                   "repo --name=other --baseurl=http://dl.fedoraproject.com\n"
+                                   "part / --size=4096\n"
+                                   "shutdown\n")
+        self.assertEqual(calculate_disk_size(opts, ks), 4098)
+
+    def disk_size_boot_test(self):
+        """Test calculating the disk size with / and /boot partitions"""
+        opts = DataHolder(no_virt=True, make_fsimage=False, make_iso=False, make_pxe_live=False)
+        ks_version = makeVersion()
+        ks = KickstartParser(ks_version, errorsAreFatal=False, missingIncludeIsFatal=False)
+        ks.readKickstartFromString("url --url=http://dl.fedoraproject.com\n"
+                                   "network --bootproto=dhcp --activate\n"
+                                   "repo --name=other --baseurl=http://dl.fedoraproject.com\n"
+                                   "part / --size=4096\n"
+                                   "part /boot --size=512\n"
+                                   "shutdown\n")
+        self.assertEqual(calculate_disk_size(opts, ks), 4610)
+
+    def disk_size_boot_fsimage_test(self):
+        """Test calculating the disk size with / and /boot partitions on a fsimage"""
+        opts = DataHolder(no_virt=True, make_fsimage=True, make_iso=False, make_pxe_live=False)
+        ks_version = makeVersion()
+        ks = KickstartParser(ks_version, errorsAreFatal=False, missingIncludeIsFatal=False)
+        ks.readKickstartFromString("url --url=http://dl.fedoraproject.com\n"
+                                   "network --bootproto=dhcp --activate\n"
+                                   "repo --name=other --baseurl=http://dl.fedoraproject.com\n"
+                                   "part / --size=4096\n"
+                                   "part /boot --size=512\n"
+                                   "shutdown\n")
+        self.assertEqual(calculate_disk_size(opts, ks), 4098)
+
+    def disk_size_reqpart_test(self):
+        """Test calculating the disk size with reqpart and a / partition"""
+        opts = DataHolder(no_virt=True, make_fsimage=False, make_iso=False, make_pxe_live=False)
+        ks_version = makeVersion()
+        ks = KickstartParser(ks_version, errorsAreFatal=False, missingIncludeIsFatal=False)
+        ks.readKickstartFromString("url --url=http://dl.fedoraproject.com\n"
+                                   "network --bootproto=dhcp --activate\n"
+                                   "repo --name=other --baseurl=http://dl.fedoraproject.com\n"
+                                   "part / --size=4096\n"
+                                   "reqpart\n"
+                                   "shutdown\n")
+        self.assertEqual(calculate_disk_size(opts, ks), 4598)
+
+    def disk_size_reqpart_boot_test(self):
+        """Test calculating the disk size with reqpart --add-boot and a / partition"""
+        opts = DataHolder(no_virt=True, make_fsimage=False, make_iso=False, make_pxe_live=False)
+        ks_version = makeVersion()
+        ks = KickstartParser(ks_version, errorsAreFatal=False, missingIncludeIsFatal=False)
+        ks.readKickstartFromString("url --url=http://dl.fedoraproject.com\n"
+                                   "network --bootproto=dhcp --activate\n"
+                                   "repo --name=other --baseurl=http://dl.fedoraproject.com\n"
+                                   "part / --size=4096\n"
+                                   "reqpart --add-boot\n"
+                                   "shutdown\n")
+        self.assertEqual(calculate_disk_size(opts, ks), 5622)
+
 
     @unittest.skipUnless(os.geteuid() == 0 and not os.path.exists("/.in-container"), "requires root privileges, and no containers")
     def boot_over_root_test(self):


### PR DESCRIPTION
Some platforms do not have grub2, and some require other partitions.

Anaconda will add platform specific partitions if the 'reqpart' command
is included, and it will add bootloader specific packages to the list if
they are needed.

--- Merge policy ---

- [ ] Travis CI PASS
- [x] `*-aws-runtest` PASS
- [x] `*-azure-runtest` PASS
- [x] `*-images-runtest` PASS
- [x] `*-openstack-runtest` PASS
- [x] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
