### PR TITLE
New test: Verify tar images with Docker and systemd-nspawn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ test:
 # but even so fails in Travis CI
 test_images:
 	sudo -E ./tests/test_cli.sh tests/cli/test_compose_ext4-filesystem.sh \
-				    tests/cli/test_compose_partitioned-disk.sh
+				    tests/cli/test_compose_partitioned-disk.sh \
+				    tests/cli/test_compose_tar.sh
 
 test_aws:
 	sudo -E ./tests/test_cli.sh tests/cli/test_build_and_deploy_aws.sh

--- a/tests/cli/test_compose_ext4-filesystem.sh
+++ b/tests/cli/test_compose_ext4-filesystem.sh
@@ -34,5 +34,9 @@ rlJournalStart
         fi
     rlPhaseEnd
 
+    rlPhaseStartCleanup
+        rlRun -t -c "$CLI compose delete $UUID"
+    rlPhaseEnd
+
 rlJournalEnd
 rlJournalPrintText

--- a/tests/cli/test_compose_partitioned-disk.sh
+++ b/tests/cli/test_compose_partitioned-disk.sh
@@ -34,5 +34,9 @@ rlJournalStart
         fi
     rlPhaseEnd
 
+    rlPhaseStartCleanup
+        rlRun -t -c "$CLI compose delete $UUID"
+    rlPhaseEnd
+
 rlJournalEnd
 rlJournalPrintText

--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Note: execute this file from the project root directory
+
+#####
+#
+# Builds tar images and tests them with Docker and systemd-nspawn
+#
+#####
+
+. /usr/share/beakerlib/beakerlib.sh
+
+CLI="./src/bin/composer-cli"
+
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertExists /usr/bin/docker
+    rlPhaseEnd
+
+    rlPhaseStartTest "compose start"
+        rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
+        UUID=`$CLI compose start example-http-server tar`
+        rlAssertEquals "exit code should be zero" $? 0
+
+        UUID=`echo $UUID | cut -f 2 -d' '`
+    rlPhaseEnd
+
+    rlPhaseStartTest "compose finished"
+        if [ -n "$UUID" ]; then
+            until $CLI compose info $UUID | grep FINISHED; do
+                sleep 10
+                rlLogInfo "Waiting for compose to finish ..."
+            done;
+        else
+            rlFail "Compose UUID is empty!"
+        fi
+
+        rlRun -t -c "$CLI compose image $UUID"
+        IMAGE="$UUID-root.tar.xz"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify tar image with Docker"
+        rlRun -t -c "docker import $IMAGE composer/$UUID:latest"
+
+        # verify we can run a container with this image
+        rlRun -t -c "docker run -it --rm --entrypoint /usr/bin/cat composer/$UUID /etc/redhat-release"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify tar image with systemd-nspawn"
+        if [ -f /usr/bin/systemd-nspawn ]; then
+            NSPAWN_DIR=`mktemp -d /tmp/nspawn.XXXX`
+            rlRun -t -c "tar -xJvf $IMAGE -C $NSPAWN_DIR"
+
+            # verify we can run a container with this image
+            rlRun -t -c "systemd-nspawn -D $NSPAWN_DIR cat /etc/redhat-release"
+        else
+            rlLogInfo "systemd-nspawn not found!"
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun -t -c "rm -rf $IMAGE $NSPAWN_DIR"
+        rlRun -t -c "$CLI compose delete $UUID"
+        rlRun -t -c "docker rmi composer/$UUID"
+    rlPhaseEnd
+
+rlJournalEnd
+rlJournalPrintText


### PR DESCRIPTION
--- Description of proposed changes ---

initial implementation, part of our existing test suite


--- Merge policy ---

- [ ] Travis CI PASS
- [x] `*-aws-runtest` PASS
- [x] `*-azure-runtest` PASS
- [x] `*-images-runtest` PASS
- [x] `*-openstack-runtest` PASS
- [x] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
