### PR TITLE
Removed remnants of fedora branding.

### DIFF
--- a/docs/rhel-atomic-pxe-live-novirt.ks
+++ b/docs/rhel-atomic-pxe-live-novirt.ks
@@ -1,4 +1,4 @@
-# Fedora Atomic PXE Live creation kickstart
+# RHEL Atomic PXE Live creation kickstart
 # Suitable for use with livemedia-creator --no-virt
 
 # Settings for unattended installation:
@@ -14,7 +14,7 @@ shutdown
 
 # Replace OSTREE-REPO with the url to an ostree repo
 # Replace OSTREE-REFERENCE with an ostree reference to pull
-ostreesetup --nogpg --osname=fedora-atomic --remote=fedora-atomic --url=OSTREE-REPO --ref=OSTREE-REFERENCE
+ostreesetup --nogpg --osname=rhel-atomic-host --remote=rhel-atomic-host --url=OSTREE-REPO --ref=OSTREE-REFERENCE
 
 services --disabled=cloud-init,cloud-init-local,cloud-final,cloud-config,docker-storage-setup
 
@@ -25,8 +25,8 @@ cat /dev/null > /etc/fstab
 %end
 
 %post --erroronfail
-rm -f /etc/ostree/remotes.d/fedora-atomic.conf
+rm -f /etc/ostree/remotes.d/rhel-atomic-host.conf
 
 # Replace OSTREE-REPO with the url to an ostree repo
-ostree remote add --set=gpg-verify=false fedora-atomic 'OSTREE-REPO'
+ostree remote add --set=gpg-verify=false rhel-atomic-host 'OSTREE-REPO'
 %end

--- a/docs/rhel-livemedia.ks
+++ b/docs/rhel-livemedia.ks
@@ -345,10 +345,10 @@ favorite-apps=['firefox.desktop', 'evolution.desktop', 'rhythmbox.desktop', 'sho
 FOE
 
   # Make the welcome screen show up
-  if [ -f /usr/share/anaconda/gnome/fedora-welcome.desktop ]; then
+  if [ -f /usr/share/anaconda/gnome/rhel-welcome.desktop ]; then
     mkdir -p ~liveuser/.config/autostart
-    cp /usr/share/anaconda/gnome/fedora-welcome.desktop /usr/share/applications/
-    cp /usr/share/anaconda/gnome/fedora-welcome.desktop ~liveuser/.config/autostart/
+    cp /usr/share/anaconda/gnome/rhel-welcome.desktop /usr/share/applications/
+    cp /usr/share/anaconda/gnome/rhel-welcome.desktop ~liveuser/.config/autostart/
   fi
 
   # Copy Anaconda branding in place


### PR DESCRIPTION
Removed mentions of fedora in example live and atomic kickstarts.
Resolves: rhbz#1672583

--- Description of proposed changes ---
There were still mentions of fedora in example kickstarts.



--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [x] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
