### PR TITLE
Remove 3G minimum from lorax-composer

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -136,7 +136,7 @@ Requires: libgit2
 Requires: libgit2-glib
 Requires: python3-flask
 Requires: python3-gevent
-Requires: anaconda-tui
+Requires: anaconda-tui >= 29.19-1
 Requires: qemu-img
 Requires: tar
 

--- a/src/pylorax/api/compose.py
+++ b/src/pylorax/api/compose.py
@@ -340,9 +340,7 @@ def start_build(cfg, dnflock, gitlock, branch, recipe_name, compose_type, test_m
     log.debug("installed_size = %d, template_size=%d", installed_size, template_size)
 
     # Minimum LMC disk size is 1GiB, and anaconda bumps the estimated size up by 10% (which doesn't always work).
-    # XXX BUT Anaconda has a bug, it won't execute a kickstart on a disk smaller than 3000 MB
-    # XXX There is an upstream patch pending, but until then, use that as the minimum
-    installed_size = max(3e9, int((installed_size+template_size))) * 1.2
+    installed_size = int((installed_size+template_size)) * 1.2
     log.debug("/ partition size = %d", installed_size)
 
     # Create the results directory


### PR DESCRIPTION
The reason for the 3G minimum was because anaconda had a bug with how it
calculated minimum disk size when using kickstart. The gix for this has
been in Anaconda since 29.19-1, so we can now remove our limit and
create somewhat smaller disk images.

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
