### PR TITLE
Update OpenStack flavor in tests b/c we've migrated to Upshift

### DIFF
--- a/tests/cli/test_build_and_deploy_openstack.sh
+++ b/tests/cli/test_build_and_deploy_openstack.sh
@@ -100,11 +100,11 @@ __EOF__
         rlRun -t -c "ssh-keygen -t rsa -N '' -f $SSH_KEY_DIR/id_rsa"
         rlRun -t -c "ansible localhost -m os_keypair -a 'name=$VM_NAME-key public_key_file=$SSH_KEY_DIR/id_rsa.pub'"
 
-        response=`ansible localhost -m os_server -a "name=$VM_NAME image=$OS_IMAGE_UUID flavor=t2.medium key_name=$VM_NAME-key auto_ip=yes"`
+        response=`ansible localhost -m os_server -a "name=$VM_NAME image=$OS_IMAGE_UUID network=provider_net_cci_2 flavor=ci.m1.medium.ephemeral key_name=$VM_NAME-key auto_ip=yes"`
         rlAssert0 "VM started successfully" $?
         rlLogInfo "$response"
 
-        IP_ADDRESS=`echo "$response" | grep '"OS-EXT-IPS:type": "floating"' -A1| grep '"addr":' | cut -f4 -d'"' | head -n 1`
+        IP_ADDRESS=`echo "$response" | grep '"OS-EXT-IPS:type": "fixed"' -A1| grep '"addr":' | cut -f4 -d'"' | head -n 1`
         rlLogInfo "Running instance IP_ADDRESS=$IP_ADDRESS"
 
         rlLogInfo "Waiting 60sec for instance to initialize ..."


### PR DESCRIPTION
--- Description of proposed changes ---

Upshift is a different OpenStack instance to which our Jenkins
slaves have been migrated.

--- Merge policy ---

- [ ] Travis CI PASS
- [x] `*-aws-runtest` PASS
- [x] `*-azure-runtest` PASS
- [x] `*-images-runtest` PASS
- [x] `*-openstack-runtest` PASS
- [x] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
