### PR TITLE
lorax-composer: Reduce computational complexity of _unique_dict

### DIFF
--- a/src/pylorax/api/projects.py
+++ b/src/pylorax/api/projects.py
@@ -370,11 +370,11 @@ def _unique_dicts(lst, key):
     list of unique return values.
     """
     result = []
-    result_keys = []
+    result_keys = set()
     for d in lst:
         if key(d) not in result_keys:
             result.append(d)
-            result_keys.append(key(d))
+            result_keys.add(key(d))
     return result
 
 def modules_info(dbo, module_names):

--- a/tests/pylorax/test_projects.py
+++ b/tests/pylorax/test_projects.py
@@ -28,7 +28,7 @@ from pylorax.api.projects import api_time, api_changelog, pkg_to_project, pkg_to
 from pylorax.api.projects import proj_to_module, projects_list, projects_info, projects_depsolve
 from pylorax.api.projects import modules_list, modules_info, ProjectsError, dep_evra, dep_nevra
 from pylorax.api.projects import repo_to_source, get_repo_sources, delete_repo_source, source_to_repo
-from pylorax.api.projects import dnf_repo_to_file_repo
+from pylorax.api.projects import dnf_repo_to_file_repo, _unique_dicts
 from pylorax.api.dnfbase import get_base_object
 
 class Package(object):
@@ -201,6 +201,21 @@ class ProjectsTest(unittest.TestCase):
         self.assertTrue("autoconf" in names)            # mandatory package
         self.assertTrue("ctags" in names)               # default package
         self.assertFalse("cmake" in names)              # optional package
+
+class MehTest(unittest.TestCase):
+    def test_unique_dicts(self):
+        lst = [
+            { "name": "foo" },
+            { "name": "bar" },
+            { "name": "bar" },
+            { "name": "baz" }
+        ]
+        expected = [
+            { "name": "foo" },
+            { "name": "bar" },
+            { "name": "baz" }
+        ]
+        self.assertEqual(_unique_dicts(lst, key=lambda d: d["name"]), expected)
 
 
 class ConfigureTest(unittest.TestCase):


### PR DESCRIPTION
_unique_dicts uses a list to keep track of already-added items. This
gets slow for large lists. Use a set instead.

This was introduced as part of d1893477.

Fixes #609

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
