### PR TITLE
installer: make sure cancel_func has a value

### DIFF
--- a/src/pylorax/installer.py
+++ b/src/pylorax/installer.py
@@ -572,7 +572,7 @@ def virt_install(opts, install_log, disk_img, disk_size, cancel_func=None):
         else:
             msg = "virt_install failed on line: %s" % log_monitor.server.error_line
         raise InstallError(msg)
-    elif cancel_func():
+    elif cancel_func and cancel_func():
         raise InstallError("virt_install canceled by cancel_func")
 
     if opts.make_fsimage:


### PR DESCRIPTION
When using LMC to virt-install a system to an image, cancel_func is not
provided in run_creator, causing a TypeError (NoneType object is not
callable).

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

--- Description of proposed changes ---




--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
