### PR TITLE
Remove unsupported anaconda-docker-addon

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -181,8 +181,5 @@ installpkg gdisk hexedit sg3_utils
 ## satisfy libnotify's desktop-notification-daemon with the least crazy option
 installpkg notification-daemon
 
-## Docker enabled boot.iso
-installpkg docker-anaconda-addon
-
 ## actually install all the requested packages
 run_pkg_transaction


### PR DESCRIPTION
It is failing to load on Fedora for quite some time and there no-one
complaining about this so it would be easier to disable it instead of
fixing it.