### PR TITLE
drop _unique dicts and fix tests

### DIFF
--- a/src/pylorax/api/projects.py
+++ b/src/pylorax/api/projects.py
@@ -353,29 +353,7 @@ def modules_list(dbo, module_names):
 
     """
     # TODO - Figure out what to do with this for Fedora 'modules'
-    projs = _unique_dicts(projects_info(dbo, module_names), key=lambda p: p["name"].lower())
-    return list(map(proj_to_module, projs))
-
-def _unique_dicts(lst, key):
-    """Return a new list of dicts, only including one match of key(d)
-
-    :param lst: list of dicts
-    :type lst: list
-    :param key: key function to match lst entries
-    :type key: function
-    :returns: list of the unique lst entries
-    :rtype: list
-
-    Uses key(d) to test for duplicates in the returned list, creating a
-    list of unique return values.
-    """
-    result = []
-    result_keys = []
-    for d in lst:
-        if key(d) not in result_keys:
-            result.append(d)
-            result_keys.append(key(d))
-    return result
+    return list(map(proj_to_module, projects_info(dbo, module_names)))
 
 def modules_info(dbo, module_names):
     """Return details about a module, including dependencies

--- a/tests/pylorax/test_ltmpl.py
+++ b/tests/pylorax/test_ltmpl.py
@@ -111,11 +111,11 @@ class LoraxTemplateRunnerTestCase(unittest.TestCase):
         makeFakeRPM(self.repo1_dir, "fake-milhouse", 0, "1.0.0", "1")
         makeFakeRPM(self.repo1_dir, "fake-bart", 2, "1.13.0", "6")
         makeFakeRPM(self.repo1_dir, "fake-homer", 0, "0.4.0", "2")
-        makeFakeRPM(self.repo1_dir, "lots-of-files", 0, "0.1.1", 1,
+        makeFakeRPM(self.repo1_dir, "lots-of-files", 0, "0.1.1", "1",
                     ["/lorax-files/file-one.txt",
                      "/lorax-files/file-two.txt",
                      "/lorax-files/file-three.txt"])
-        makeFakeRPM(self.repo1_dir, "known-path", 0, "0.1.8", 1, ["/known-path/file-one.txt"])
+        makeFakeRPM(self.repo1_dir, "known-path", 0, "0.1.8", "1", ["/known-path/file-one.txt"])
         os.system("createrepo_c " + self.repo1_dir)
 
         self.repo2_dir = tempfile.mkdtemp(prefix="lorax.test.repo.")


### PR DESCRIPTION

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
