### PR TITLE
Add --forcearch=ARCH option to allow installing packages from different arch than the host one.

### DIFF
--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -111,6 +111,8 @@ def lorax_parser(dracut_default=""):
                           help="Enable a DNF plugin by name/glob, or * to enable all of them.")
     optional.add_argument("--squashfs-only", action="store_true", default=False,
                           help="Use a plain squashfs filesystem for the runtime.")
+    optional.add_argument("--forcearch", default=None,
+                        help="force install architecture", metavar="ARCH")
 
     # dracut arguments
     dracut_group = parser.add_argument_group("dracut arguments")

--- a/src/pylorax/dnfbase.py
+++ b/src/pylorax/dnfbase.py
@@ -26,7 +26,8 @@ from pylorax.sysutils import flatconfig
 def get_dnf_base_object(installroot, sources, mirrorlists=None, repos=None,
                         enablerepos=None, disablerepos=None,
                         tempdir="/var/tmp", proxy=None, releasever="29",
-                        cachedir=None, logdir=None, sslverify=True, dnfplugins=None):
+                        cachedir=None, logdir=None, sslverify=True, dnfplugins=None,
+                        forcearch=None):
     """ Create a dnf Base object and setup the repositories and installroot
 
         :param string installroot: Full path to the installroot
@@ -39,6 +40,7 @@ def get_dnf_base_object(installroot, sources, mirrorlists=None, repos=None,
         :param string releasever: Release version to pass to dnf
         :param string cachedir: Directory to use for caching packages
         :param bool noverifyssl: Set to True to ignore the CA of ssl certs. eg. use self-signed ssl for https repos.
+        :param string forcearch: Force particular architecture.
 
         If tempdir is not set /var/tmp is used.
         If cachedir is None a dnf.cache directory is created inside tmpdir
@@ -100,6 +102,10 @@ def get_dnf_base_object(installroot, sources, mirrorlists=None, repos=None,
 
     if sslverify == False:
         conf.sslverify = False
+
+    if forcearch:
+        conf.ignorearch = True
+        conf.arch = forcearch
 
     # DNF 3.2 needs to have module_platform_id set, otherwise depsolve won't work correctly
     if not os.path.exists("/etc/os-release"):

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -154,7 +154,7 @@ def main():
                                   opts.enablerepos, opts.disablerepos,
                                   dnftempdir, opts.proxy, opts.version, opts.cachedir,
                                   os.path.dirname(opts.logfile), not opts.noverifyssl,
-                                  opts.dnfplugins)
+                                  opts.dnfplugins, opts.forcearch)
 
     if dnfbase is None:
         os.close(dir_fd)


### PR DESCRIPTION
This commit makes it possible to for example generate aarch64 image on x86_64 host:

It is based on the following `dnf` change:

https://github.com/rpm-software-management/dnf/pull/866

The example command:

```
$ lorax -p Fedora-Generic -v 28 -r 28 --forcearch=aarch64 -s http://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/aarch64/os/ ./results/
```




--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
