### PR TITLE
New test: Build live-iso and boot with KVM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ test_images:
 	sudo -E ./tests/test_cli.sh tests/cli/test_compose_ext4-filesystem.sh  \
 				    tests/cli/test_compose_partitioned-disk.sh \
 				    tests/cli/test_compose_tar.sh              \
-				    tests/cli/test_compose_qcow2.sh
+				    tests/cli/test_compose_qcow2.sh            \
+				    tests/cli/test_compose_live-iso.sh
 
 test_aws:
 	sudo -E ./tests/test_cli.sh tests/cli/test_build_and_deploy_aws.sh

--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Note: execute this file from the project root directory
+
+#####
+#
+# Builds live-iso image and test it with QEMU-KVM
+#
+#####
+
+. /usr/share/beakerlib/beakerlib.sh
+
+CLI="./src/bin/composer-cli"
+QEMU="/usr/bin/qemu-kvm"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertExists $QEMU
+    rlPhaseEnd
+
+    rlPhaseStartTest "compose start"
+        rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
+
+        # NOTE: live-iso.ks explicitly disables sshd but test_cli.sh enables it
+        UUID=`$CLI compose start example-http-server live-iso`
+        rlAssertEquals "exit code should be zero" $? 0
+
+        UUID=`echo $UUID | cut -f 2 -d' '`
+    rlPhaseEnd
+
+    rlPhaseStartTest "compose finished"
+        if [ -n "$UUID" ]; then
+            until $CLI compose info $UUID | grep FINISHED; do
+                sleep 20
+                rlLogInfo "Waiting for compose to finish ..."
+            done;
+        else
+            rlFail "Compose UUID is empty!"
+        fi
+
+        rlRun -t -c "$CLI compose image $UUID"
+        IMAGE="$UUID-live.iso"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Start VM instance"
+        rlRun -t -c "$QEMU -m 2048 -boot c -cdrom $IMAGE -nographic \
+                           -net user,id=nic0,hostfwd=tcp::2222-:22 -net nic &"
+        # 60 seconds timeout at boot menu screen
+        # then media check + boot ~ 30 seconds
+        sleep 120
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify VM instance"
+        # verify we can login into that instance *WITHOUT* a password
+        rlRun -t -c "ssh -oStrictHostKeyChecking=no -p 2222 root@localhost 'cat /etc/redhat-release'"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun -t -c "killall -9 qemu-system-$(uname -m)"
+        rlRun -t -c "$CLI compose delete $UUID"
+        rlRun -t -c "rm -rf $IMAGE"
+    rlPhaseEnd
+
+rlJournalEnd
+rlJournalPrintText

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -13,6 +13,10 @@ SHARE_DIR=`mktemp -d '/tmp/composer-share.XXXXX'`
 cp -R ./share/* $SHARE_DIR
 chmod a+rx -R $SHARE_DIR
 
+# explicitly enable sshd for live-iso b/c it is disabled by default
+# due to security concerns (no root password required)
+sed -i 's/^services.*/services --disabled="network" --enabled="NetworkManager,sshd"/' $SHARE_DIR/composer/live-iso.ks
+
 # start the lorax-composer daemon
 ./src/sbin/lorax-composer --sharedir $SHARE_DIR $BLUEPRINTS_DIR &
 


### PR DESCRIPTION
--- Description of proposed changes ---

explicitly enables sshd for live-iso during testing


--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
