### PR TITLE
Fix handling of deleted blueprints

### DIFF
--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -201,7 +201,8 @@ DELETE `/api/v0/blueprints/delete/<blueprint_name>`
 
   Delete a blueprint. The blueprint is deleted from the branch, and will no longer
   be listed by the `list` route. A blueprint can be undeleted using the `undo` route
-  to revert to a previous commit.
+  to revert to a previous commit. This will also delete the workspace copy of the
+  blueprint.
 
   The response will be a status response with `status` set to true, or an
   error response with it set to false and an error message included.
@@ -1212,6 +1213,7 @@ def v0_api(api):
 
         try:
             with api.config["GITLOCK"].lock:
+                workspace_delete(api.config["GITLOCK"].repo, branch, blueprint_name)
                 delete_recipe(api.config["GITLOCK"].repo, branch, blueprint_name)
         except Exception as e:
             log.error("(v0_blueprints_delete) %s", str(e))


### PR DESCRIPTION

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
