### PR TITLE
Backport cancel_func fixes

### DIFF
--- a/src/pylorax/installer.py
+++ b/src/pylorax/installer.py
@@ -566,7 +566,7 @@ def virt_install(opts, install_log, disk_img, disk_size, cancel_func=None):
         else:
             msg = "virt_install failed on line: %s" % log_monitor.server.error_line
         raise InstallError(msg)
-    elif cancel_func():
+    elif cancel_func and cancel_func():
         raise InstallError("virt_install canceled by cancel_func")
 
     if opts.make_fsimage:

--- a/src/pylorax/installer.py
+++ b/src/pylorax/installer.py
@@ -243,7 +243,7 @@ class QEMUInstall(object):
         log.debug(qemu_cmd)
         try:
             execWithRedirect(qemu_cmd[0], qemu_cmd[1:], reset_lang=False, raise_err=True,
-                             callback=lambda p: not cancel_func())
+                             callback=lambda p: not (cancel_func and cancel_func()))
         except subprocess.CalledProcessError as e:
             log.error("Running qemu failed:")
             log.error("cmd: %s", " ".join(e.cmd))
@@ -257,7 +257,7 @@ class QEMUInstall(object):
             if boot_uefi and ovmf_path:
                 os.unlink(ovmf_vars)
 
-        if cancel_func():
+        if cancel_func and cancel_func():
             log.error("Installation error detected. See logfile for details.")
             raise InstallError("QEMUInstall failed")
         else:


### PR DESCRIPTION

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
