### PR TITLE
Use make ci inside test-in-copy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ local:
 
 test-in-copy:
 	rsync -aP --exclude=.git /lorax-ro/ /lorax/
-	make -C /lorax/ check test
+	make -C /lorax/ ci
 	cp /lorax/.coverage /test-results/
 
 test-in-docker:


### PR DESCRIPTION
--- Description of proposed changes ---

this minimizes the possibility of these two to diverge over time.
make ci is the default for Jenkins and will also be used for
internal gating tests.

@bcl - this is only cosmetic ATM so let me know if you want it backported for rhel7 and rhel8 branches.

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
