### PR TITLE
Allow testing installed RPMs instead of source

### DIFF
--- a/tests/cli/test_blueprints_sanity.sh
+++ b/tests/cli/test_blueprints_sanity.sh
@@ -3,7 +3,7 @@
 
 . /usr/share/beakerlib/beakerlib.sh
 
-CLI="./src/bin/composer-cli"
+CLI="${CLI:-./src/bin/composer-cli}"
 
 
 rlJournalStart

--- a/tests/cli/test_build_and_deploy_aws.sh
+++ b/tests/cli/test_build_and_deploy_aws.sh
@@ -9,7 +9,7 @@
 
 . /usr/share/beakerlib/beakerlib.sh
 
-CLI="./src/bin/composer-cli"
+CLI="${CLI:-./src/bin/composer-cli}"
 
 
 rlJournalStart

--- a/tests/cli/test_build_and_deploy_azure.sh
+++ b/tests/cli/test_build_and_deploy_azure.sh
@@ -9,7 +9,7 @@
 
 . /usr/share/beakerlib/beakerlib.sh
 
-CLI="./src/bin/composer-cli"
+CLI="${CLI:-./src/bin/composer-cli}"
 
 
 rlJournalStart

--- a/tests/cli/test_build_and_deploy_openstack.sh
+++ b/tests/cli/test_build_and_deploy_openstack.sh
@@ -9,7 +9,7 @@
 
 . /usr/share/beakerlib/beakerlib.sh
 
-CLI="./src/bin/composer-cli"
+CLI="${CLI:-./src/bin/composer-cli}"
 
 
 rlJournalStart

--- a/tests/cli/test_build_and_deploy_vmware.sh
+++ b/tests/cli/test_build_and_deploy_vmware.sh
@@ -9,7 +9,7 @@
 
 . /usr/share/beakerlib/beakerlib.sh
 
-CLI="./src/bin/composer-cli"
+CLI="${CLI:-./src/bin/composer-cli}"
 
 
 rlJournalStart

--- a/tests/cli/test_compose_ext4-filesystem.sh
+++ b/tests/cli/test_compose_ext4-filesystem.sh
@@ -11,7 +11,7 @@
 
 . /usr/share/beakerlib/beakerlib.sh
 
-CLI="./src/bin/composer-cli"
+CLI="${CLI:-./src/bin/composer-cli}"
 
 
 rlJournalStart

--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -9,7 +9,7 @@
 
 . /usr/share/beakerlib/beakerlib.sh
 
-CLI="./src/bin/composer-cli"
+CLI="${CLI:-./src/bin/composer-cli}"
 QEMU="/usr/bin/qemu-kvm"
 
 rlJournalStart

--- a/tests/cli/test_compose_partitioned-disk.sh
+++ b/tests/cli/test_compose_partitioned-disk.sh
@@ -11,7 +11,7 @@
 
 . /usr/share/beakerlib/beakerlib.sh
 
-CLI="./src/bin/composer-cli"
+CLI="${CLI:-./src/bin/composer-cli}"
 
 
 rlJournalStart

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -9,7 +9,7 @@
 
 . /usr/share/beakerlib/beakerlib.sh
 
-CLI="./src/bin/composer-cli"
+CLI="${CLI:-./src/bin/composer-cli}"
 QEMU="/usr/bin/qemu-kvm"
 
 rlJournalStart

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -3,7 +3,7 @@
 
 . /usr/share/beakerlib/beakerlib.sh
 
-CLI="./src/bin/composer-cli"
+CLI="${CLI:-./src/bin/composer-cli}"
 
 
 rlJournalStart

--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -9,7 +9,7 @@
 
 . /usr/share/beakerlib/beakerlib.sh
 
-CLI="./src/bin/composer-cli"
+CLI="${CLI:-./src/bin/composer-cli}"
 
 
 rlJournalStart


### PR DESCRIPTION
--- Description of proposed changes ---

A few modifications to the existing test suite which will make it easier to test against the installed RPMs lorax-composer/composer-cli instead of the sources.


--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
