### PR TITLE
Update ppc64le isolabel to match x86_64 logic

### DIFF
--- a/share/templates.d/99-generic/ppc64le.tmpl
+++ b/share/templates.d/99-generic/ppc64le.tmpl
@@ -6,11 +6,11 @@ GRUBDIR="boot/grub"
 STAGE2IMG="images/install.img"
 LORAXDIR="usr/share/lorax/"
 
-## NOTE: yaboot freaks out and stops parsing its config if it sees a '\',
-## so we can't use the udev escape sequences in the root arg.
-## Instead we'll just replace any non-ASCII characters in the isolabel
-## with '_', which means we won't need any udev escapes.
-isolabel = ''.join(ch if ch.isalnum() else '_' for ch in isolabel)
+## Don't allow spaces or escape characters in the iso label
+def valid_label(ch):
+    return ch.isalnum() or ch == '_'
+
+isolabel = ''.join(ch if valid_label(ch) else '-' for ch in isolabel)
 
 from os.path import basename
 %>

--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -107,6 +107,7 @@ append etc/depmod.d/dd.conf "search updates built-in"
 
 ## create multipath.conf so multipath gets auto-started
 append etc/multipath.conf "defaults {\n\tfind_multipaths yes\n\tuser_friendly_names yes\n}\n"
+append etc/multipath.conf "blacklist_exceptions {\n\tproperty \"(SCSI_IDENT_|ID_WWN)\"\n}\n"
 
 ## make lvm auto-activate
 remove etc/lvm/archive/*


### PR DESCRIPTION
It was substituting _ which didn't match what pungi uses for creating
the DVD. Make things consistent and use - as the replacement character.

Resolves: rhbz#1687882

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
