### PR TITLE
lorax-composer: Add the ability to append to the kernel command-line

### DIFF
--- a/docs/lorax-composer.rst
+++ b/docs/lorax-composer.rst
@@ -181,6 +181,18 @@ The ``[[customizations]]`` section can be used to configure the hostname of the 
     hostname = "baseimage"
 
 
+[customizations.kernel]
+***********************
+
+This allows you to append arguments to the bootloader's kernel commandline. This will not have any
+effect on ``tar`` or ``ext4-filesystem`` images since they do not include a bootloader.
+
+For example::
+
+    [customizations.kernel]
+    append = "nosmt=force"
+
+
 [[customizations.sshkey]]
 *************************
 

--- a/share/templates.d/99-generic/live/aarch64.tmpl
+++ b/share/templates.d/99-generic/live/aarch64.tmpl
@@ -1,4 +1,4 @@
-<%page args="kernels, runtime_img, basearch, inroot, outroot, product, isolabel"/>
+<%page args="kernels, runtime_img, basearch, inroot, outroot, product, isolabel, extra_boot_args"/>
 <%
 configdir="tmp/config_files/aarch64"
 PXEBOOTDIR="images/pxeboot"
@@ -45,7 +45,7 @@ mkdir ${KERNELDIR}
         %>
         treeinfo images-${basearch} ${img|basename} ${img}
     %endfor
-    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch32=efiarch32, efiarch64=efiarch64, isolabel=isolabel"/>
+    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch32=efiarch32, efiarch64=efiarch64, isolabel=isolabel, extra_boot_args=extra_boot_args"/>
 %endif
 
 # Create optional product.img and updates.img

--- a/share/templates.d/99-generic/live/config_files/aarch64/grub2-efi.cfg
+++ b/share/templates.d/99-generic/live/config_files/aarch64/grub2-efi.cfg
@@ -27,16 +27,16 @@ search --no-floppy --set=root -l '@ISOLABEL@'
 
 ### BEGIN /etc/grub.d/10_linux ###
 menuentry 'Start @PRODUCT@ @VERSION@' --class red --class gnu-linux --class gnu --class os {
-	linux @KERNELPATH@ @ROOT@ rd.live.image quiet
+	linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image quiet
 	initrd @INITRDPATH@
 }
 menuentry 'Test this media & start @PRODUCT@ @VERSION@' --class red --class gnu-linux --class gnu --class os {
-	linux @KERNELPATH@ @ROOT@ rd.live.image rd.live.check quiet
+	linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.check quiet
 	initrd @INITRDPATH@
 }
 submenu 'Troubleshooting -->' {
 	menuentry 'Install @PRODUCT@ @VERSION@ in basic graphics mode' --class red --class gnu-linux --class gnu --class os {
-		linux @KERNELPATH@ @ROOT@ rd.live.image nomodeset quiet
+		linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image nomodeset quiet
 		initrd @INITRDPATH@
 	}
 }

--- a/share/templates.d/99-generic/live/config_files/ppc/grub.cfg.in
+++ b/share/templates.d/99-generic/live/config_files/ppc/grub.cfg.in
@@ -6,12 +6,12 @@ echo -e "\nWelcome to the @PRODUCT@ @VERSION@ installer!\n\n"
 for BITS in 32 64; do
   if [ -d "/ppc/ppc${BITS}" ]; then
     menuentry "Start @PRODUCT@ @VERSION@ (${BITS}-bit kernel)"  $BITS --class fedora --class gnu-linux --class gnu --class os {
-      linux /ppc/ppc${2}/vmlinuz @ROOT@ ro rd.live.image quiet
+      linux /ppc/ppc${2}/vmlinuz @ROOT@ @EXTRA@ ro rd.live.image quiet
       initrd /ppc/ppc${2}/initrd.img
     }
 
     menuentry "Test this media & start @PRODUCT@ @VERSION@  (${BITS}-bit kernel)" $BITS --class fedora --class gnu-linux --class  gnu --class os {
-      linux /ppc/ppc${2}/vmlinuz @ROOT@ rd.live.image rd.live.check ro quiet
+      linux /ppc/ppc${2}/vmlinuz @ROOT@ @EXTRA@ rd.live.image rd.live.check ro quiet
       initrd /ppc/ppc${2}/initrd.img
       }
   fi

--- a/share/templates.d/99-generic/live/config_files/s390/generic.prm
+++ b/share/templates.d/99-generic/live/config_files/s390/generic.prm
@@ -1,1 +1,1 @@
-ro ramdisk_size=40000 cio_ignore=all,!condev
+ro ramdisk_size=40000 cio_ignore=all,!condev @EXTRA@

--- a/share/templates.d/99-generic/live/config_files/x86/grub.conf
+++ b/share/templates.d/99-generic/live/config_files/x86/grub.conf
@@ -5,9 +5,9 @@ timeout 60
 hiddenmenu
 title Start @PRODUCT@ @VERSION@
 	findiso
-	kernel @KERNELPATH@ @ROOT@ rd.live.image quiet
+	kernel @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image quiet
 	initrd @INITRDPATH@
 title Test this media & start @PRODUCT@ @VERSION@
 	findiso
-	kernel @KERNELPATH@ @ROOT@ rd.live.image rd.live.check quiet
+	kernel @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.check quiet
 	initrd @INITRDPATH@

--- a/share/templates.d/99-generic/live/config_files/x86/grub2-efi.cfg
+++ b/share/templates.d/99-generic/live/config_files/x86/grub2-efi.cfg
@@ -21,16 +21,16 @@ search --no-floppy --set=root -l '@ISOLABEL@'
 
 ### BEGIN /etc/grub.d/10_linux ###
 menuentry 'Start @PRODUCT@ @VERSION@' --class fedora --class gnu-linux --class gnu --class os {
-	linuxefi @KERNELPATH@ @ROOT@ rd.live.image quiet
+	linuxefi @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image quiet
 	initrdefi @INITRDPATH@
 }
 menuentry 'Test this media & start @PRODUCT@ @VERSION@' --class fedora --class gnu-linux --class gnu --class os {
-	linuxefi @KERNELPATH@ @ROOT@ rd.live.image rd.live.check quiet
+	linuxefi @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.check quiet
 	initrdefi @INITRDPATH@
 }
 submenu 'Troubleshooting -->' {
 	menuentry 'Start @PRODUCT@ @VERSION@ in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
-		linuxefi @KERNELPATH@ @ROOT@ rd.live.image nomodeset quiet
+		linuxefi @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image nomodeset quiet
 		initrdefi @INITRDPATH@
 	}
 }

--- a/share/templates.d/99-generic/live/config_files/x86/isolinux.cfg
+++ b/share/templates.d/99-generic/live/config_files/x86/isolinux.cfg
@@ -61,13 +61,13 @@ menu separator # insert an empty line
 label linux
   menu label ^Start @PRODUCT@ @VERSION@
   kernel vmlinuz
-  append initrd=initrd.img @ROOT@ rd.live.image quiet
+  append initrd=initrd.img @ROOT@ @EXTRA@ rd.live.image quiet
 
 label check
   menu label Test this ^media & start @PRODUCT@ @VERSION@
   menu default
   kernel vmlinuz
-  append initrd=initrd.img @ROOT@ rd.live.image rd.live.check quiet
+  append initrd=initrd.img @ROOT@ @EXTRA@ rd.live.image rd.live.check quiet
 
 menu separator # insert an empty line
 
@@ -83,7 +83,7 @@ label vesa
 	@PRODUCT@ @VERSION@.
   endtext
   kernel vmlinuz
-  append initrd=initrd.img @ROOT@ rd.live.image nomodeset quiet
+  append initrd=initrd.img @ROOT@ @EXTRA@ rd.live.image nomodeset quiet
 
 label memtest
   menu label Run a ^memory test

--- a/share/templates.d/99-generic/live/efi.tmpl
+++ b/share/templates.d/99-generic/live/efi.tmpl
@@ -1,4 +1,4 @@
-<%page args="configdir, KERNELDIR, efiarch32, efiarch64, isolabel"/>
+<%page args="configdir, KERNELDIR, efiarch32, efiarch64, isolabel, extra_boot_args"/>
 <%
 EFIBOOTDIR="EFI/BOOT"
 APPLE_EFI_ICON=inroot+"/usr/share/pixmaps/bootloader/fedora.icns"
@@ -45,6 +45,7 @@ ${make_efiboot("images/efiboot.img")}
     replace @KERNELPATH@ /${kdir}/vmlinuz ${eficonf}
     replace @INITRDPATH@ /${kdir}/initrd.img ${eficonf}
     replace @ISOLABEL@ '${isolabel}' ${eficonf}
+    replace @EXTRA@ '${extra_boot_args}' ${eficonf}
     %if disk:
         replace @ROOT@ root=live:LABEL=ANACONDA ${eficonf}
     %else:

--- a/share/templates.d/99-generic/live/ppc64le.tmpl
+++ b/share/templates.d/99-generic/live/ppc64le.tmpl
@@ -1,4 +1,4 @@
-<%page args="kernels, runtime_img, basearch, libdir, inroot, outroot, product, isolabel"/>
+<%page args="kernels, runtime_img, basearch, libdir, inroot, outroot, product, isolabel, extra_boot_args"/>
 <%
 configdir="tmp/config_files/ppc"
 BOOTDIR="ppc"
@@ -38,6 +38,7 @@ install ${configdir}/grub.cfg.in     ${GRUBDIR}/grub.cfg
 replace @PRODUCT@ '${product.name}'  ${GRUBDIR}/grub.cfg
 replace @VERSION@ ${product.version} ${GRUBDIR}/grub.cfg
 replace @ROOT@ 'root=live:CDLABEL=${isolabel|udev}' ${GRUBDIR}/grub.cfg
+replace @EXTRA@ '${extra_boot_args}' ${GRUBDIR}/grub.cfg
 
 ## Install kernel and bootloader config (in separate places for each arch)
 %for kernel in kernels:

--- a/share/templates.d/99-generic/live/s390.tmpl
+++ b/share/templates.d/99-generic/live/s390.tmpl
@@ -1,4 +1,4 @@
-<%page args="kernels, runtime_img, runtime_base, basearch, outroot"/>
+<%page args="kernels, runtime_img, runtime_base, basearch, outroot, extra_boot_args"/>
 <%
 configdir="tmp/config_files/s390"
 BOOTDIR="images"
@@ -22,6 +22,7 @@ install ${configdir}/generic.ins .
 
 ## configure bootloader
 replace @INITRD_LOAD_ADDRESS@ ${INITRD_ADDRESS} generic.ins
+replace @EXTRA@ ${extra_boot_args} generic.prm
 
 ## install kernel
 installkernel images-${basearch} ${kernel.path} ${KERNELDIR}/kernel.img

--- a/share/templates.d/99-generic/live/x86.tmpl
+++ b/share/templates.d/99-generic/live/x86.tmpl
@@ -1,4 +1,4 @@
-<%page args="kernels, runtime_img, basearch, inroot, outroot, product, isolabel"/>
+<%page args="kernels, runtime_img, basearch, inroot, outroot, product, isolabel, extra_boot_args"/>
 <%
 configdir="tmp/config_files/x86"
 SYSLINUXDIR="usr/share/syslinux"
@@ -38,6 +38,7 @@ install boot/memtest* ${BOOTDIR}/memtest
 replace @VERSION@ ${product.version} ${BOOTDIR}/grub.conf ${BOOTDIR}/isolinux.cfg ${BOOTDIR}/*.msg
 replace @PRODUCT@ '${product.name}'  ${BOOTDIR}/grub.conf ${BOOTDIR}/isolinux.cfg ${BOOTDIR}/*.msg
 replace @ROOT@ 'root=live:CDLABEL=${isolabel|udev}' ${BOOTDIR}/isolinux.cfg
+replace @EXTRA@ '${extra_boot_args}' ${BOOTDIR}/isolinux.cfg
 
 ## install kernels
 mkdir ${KERNELDIR}
@@ -80,7 +81,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
         %>
         treeinfo images-${basearch} ${img|basename} ${img}
     %endfor
-    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch32=efiarch32, efiarch64=efiarch64, isolabel=isolabel"/>
+    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch32=efiarch32, efiarch64=efiarch64, isolabel=isolabel, extra_boot_args=extra_boot_args"/>
 %endif
 
 # Create optional product.img and updates.img

--- a/src/pylorax/api/compose.py
+++ b/src/pylorax/api/compose.py
@@ -149,6 +149,21 @@ def bootloader_append(line, kernel_append):
     return str(ks.handler.bootloader).splitlines()[-1]
 
 
+def get_kernel_append(recipe):
+    """Return the customizations.kernel append value
+
+    :param recipe:
+    :type recipe: Recipe object
+    :returns: append value or empty string
+    :rtype: str
+    """
+    if "customizations" not in recipe or \
+       "kernel" not in recipe["customizations"] or \
+       "append" not in recipe["customizations"]["kernel"]:
+        return ""
+    return recipe["customizations"]["kernel"]["append"]
+
+
 def customize_ks_template(ks_template, recipe):
     """ Customize the kickstart template and return it
 
@@ -160,11 +175,9 @@ def customize_ks_template(ks_template, recipe):
     Apply customizations.kernel.append to the bootloader argument in the template.
     Add bootloader line if it is missing.
     """
-    if "customizations" not in recipe or \
-       "kernel" not in recipe["customizations"] or \
-       "append" not in recipe["customizations"]["kernel"]:
+    kernel_append = get_kernel_append(recipe)
+    if not kernel_append:
         return ks_template
-    kernel_append = recipe["customizations"]["kernel"]["append"]
     found_bootloader = False
     output = StringIO()
     for line in ks_template.splitlines():
@@ -535,6 +548,7 @@ def start_build(cfg, dnflock, gitlock, branch, recipe_name, compose_type, test_m
     cfg_args["project"] = os_release.get("NAME", "")
     cfg_args["releasever"] = os_release.get("VERSION_ID", "")
     cfg_args["volid"] = ""
+    cfg_args["extra_boot_args"] = get_kernel_append(recipe)
 
     cfg_args.update({
         "compression":      "xz",

--- a/src/pylorax/api/compose.py
+++ b/src/pylorax/api/compose.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 Red Hat, Inc.
+# Copyright (C) 2018-2019 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -35,6 +35,7 @@ log = logging.getLogger("lorax-composer")
 
 import os
 from glob import glob
+from io import StringIO
 from math import ceil
 import pytoml as toml
 import shutil
@@ -122,6 +123,62 @@ def repo_to_ks(r, url="url"):
         cmd += ' --sslclientkey="%s"' % r.sslclientkey
 
     return cmd
+
+
+def bootloader_append(line, kernel_append):
+    """ Insert the kernel_append string into the --append argument
+
+    :param line: The bootloader ... line
+    :type line: str
+    :param kernel_append: The arguments to append to the --append section
+    :type kernel_append: str
+
+    Using pykickstart to process the line is the best way to make sure it
+    is parsed correctly, and re-assembled for inclusion into the final kickstart
+    """
+    ks_version = makeVersion()
+    ks = KickstartParser(ks_version, errorsAreFatal=False, missingIncludeIsFatal=False)
+    ks.readKickstartFromString(line)
+
+    if ks.handler.bootloader.appendLine:
+        ks.handler.bootloader.appendLine += " %s" % kernel_append
+    else:
+        ks.handler.bootloader.appendLine = kernel_append
+
+    # Converting back to a string includes a comment, return just the bootloader line
+    return str(ks.handler.bootloader).splitlines()[-1]
+
+
+def customize_ks_template(ks_template, recipe):
+    """ Customize the kickstart template and return it
+
+    :param ks_template: The kickstart template
+    :type ks_template: str
+    :param recipe:
+    :type recipe: Recipe object
+
+    Apply customizations.kernel.append to the bootloader argument in the template.
+    Add bootloader line if it is missing.
+    """
+    if "customizations" not in recipe or \
+       "kernel" not in recipe["customizations"] or \
+       "append" not in recipe["customizations"]["kernel"]:
+        return ks_template
+    kernel_append = recipe["customizations"]["kernel"]["append"]
+    found_bootloader = False
+    output = StringIO()
+    for line in ks_template.splitlines():
+        if not line.startswith("bootloader"):
+            print(line, file=output)
+            continue
+        found_bootloader = True
+        log.debug("Found bootloader line: %s", line)
+        print(bootloader_append(line, kernel_append), file=output)
+
+    if found_bootloader:
+        return output.getvalue()
+    else:
+        return 'bootloader --append="%s" --location=none' % kernel_append + output.getvalue()
 
 
 def write_ks_root(f, user):
@@ -447,7 +504,8 @@ def start_build(cfg, dnflock, gitlock, branch, recipe_name, compose_type, test_m
         # Write the root partition and it's size in MB (rounded up)
         f.write('part / --size=%d\n' % ceil(installed_size / 1024**2))
 
-        f.write(ks_template)
+        # Some customizations modify the template before writing it
+        f.write(customize_ks_template(ks_template, recipe))
 
         for d in deps:
             f.write(dep_nevra(d)+"\n")
@@ -459,6 +517,7 @@ def start_build(cfg, dnflock, gitlock, branch, recipe_name, compose_type, test_m
 
         f.write("%end\n")
 
+        # Other customizations can be appended to the kickstart
         add_customizations(f, recipe)
 
     # Setup the config to pass to novirt_install

--- a/src/pylorax/api/recipes.py
+++ b/src/pylorax/api/recipes.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017  Red Hat, Inc.
+# Copyright (C) 2017-2019  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -203,6 +203,9 @@ def lmc_parser(dracut_default=""):
     parser.add_argument("--nomacboot", action="store_false",
                         dest="domacboot")
 
+    parser.add_argument("--extra-boot-args", default="", dest="extra_boot_args",
+                        help="Extra arguments to add to the bootloader kernel cmdline in the templates")
+
     image_group = parser.add_argument_group("disk/fs image arguments")
     image_group.add_argument("--disk-image", type=os.path.abspath,
                              help="Path to existing disk image to use for creating final image.")

--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -355,7 +355,8 @@ def make_livecd(opts, mount_dir, work_dir):
     tb = TreeBuilder(product=product, arch=arch, domacboot=opts.domacboot,
                      inroot=mount_dir, outroot=work_dir,
                      runtime=RUNTIME, isolabel=isolabel,
-                     templatedir=joinpaths(opts.lorax_templates,"live/"))
+                     templatedir=joinpaths(opts.lorax_templates,"live/"),
+                     extra_boot_args=opts.extra_boot_args)
     log.info("Rebuilding initrds")
     if not opts.dracut_args:
         dracut_args = DRACUT_DEFAULT

--- a/src/pylorax/ltmpl.py
+++ b/src/pylorax/ltmpl.py
@@ -67,10 +67,16 @@ class LoraxTemplate(object):
         # remove comments
         lines = [line for line in lines if not line.startswith("#")]
 
-        # split with shlex and perform brace expansion
-        lines = [split_and_expand(line) for line in lines]
-
-        return lines
+        # split with shlex and perform brace expansion. This can fail, so we unroll the loop
+        # for better error reporting.
+        expanded_lines = []
+        try:
+            for line in lines:
+                expanded_lines.append(split_and_expand(line))
+        except Exception as e:
+            logger.error('shlex error processing "%s": %s', line, str(e))
+            raise
+        return expanded_lines
 
 def split_and_expand(line):
     return [exp for word in shlex.split(line) for exp in brace_expand(word)]

--- a/src/pylorax/treebuilder.py
+++ b/src/pylorax/treebuilder.py
@@ -245,7 +245,8 @@ class RuntimeBuilder(object):
 class TreeBuilder(object):
     '''Builds the arch-specific boot images.
     inroot should be the installtree root (the newly-built runtime dir)'''
-    def __init__(self, product, arch, inroot, outroot, runtime, isolabel, domacboot=True, doupgrade=True, templatedir=None, add_templates=None, add_template_vars=None, workdir=None):
+    def __init__(self, product, arch, inroot, outroot, runtime, isolabel, domacboot=True, doupgrade=True,
+                 templatedir=None, add_templates=None, add_template_vars=None, workdir=None, extra_boot_args=""):
 
         # NOTE: if you pass an arg named "runtime" to a mako template it'll
         # clobber some mako internal variables - hence "runtime_img".
@@ -254,7 +255,8 @@ class TreeBuilder(object):
                                inroot=inroot, outroot=outroot,
                                basearch=arch.basearch, libdir=arch.libdir,
                                isolabel=isolabel, udev=udev_escape, domacboot=domacboot, doupgrade=doupgrade,
-                               workdir=workdir, lower=string_lower)
+                               workdir=workdir, lower=string_lower,
+                               extra_boot_args=extra_boot_args)
         self._runner = LoraxTemplateRunner(inroot, outroot, templatedir=templatedir)
         self._runner.defaults = self.vars
         self.add_templates = add_templates or []

--- a/tests/pylorax/blueprints/example-append.toml
+++ b/tests/pylorax/blueprints/example-append.toml
@@ -1,0 +1,18 @@
+name = "example-append"
+description = "An example using kernel append customization"
+version = "0.0.1"
+
+[[packages]]
+name = "tmux"
+version = "2.8"
+
+[[packages]]
+name = "openssh-server"
+version = "7.*"
+
+[[packages]]
+name = "rsync"
+version = "3.1.*"
+
+[customizations.kernel]
+append = "nosmt=force"

--- a/tests/pylorax/test_compose.py
+++ b/tests/pylorax/test_compose.py
@@ -21,10 +21,12 @@ import tempfile
 import unittest
 
 from pylorax import get_buildarch
-from pylorax.api.compose import add_customizations, get_extra_pkgs
+from pylorax.api.compose import add_customizations, get_extra_pkgs, compose_types
+from pylorax.api.compose import bootloader_append, customize_ks_template
 from pylorax.api.config import configure, make_dnf_dirs
 from pylorax.api.dnfbase import get_base_object
 from pylorax.api.recipes import recipe_from_toml
+from pylorax.sysutils import joinpaths
 
 BASE_RECIPE = """name = "test-cases"
 description = "Used for testing"
@@ -230,6 +232,60 @@ class CustomizationsTestCase(unittest.TestCase):
         self.assertCustomization(ROOT_PLAIN_KEY, 'sshkey --user root "A SSH KEY FOR THE USER"')
         self.assertNotCustomization(ROOT_PLAIN_KEY, "rootpw --lock")
 
+    def test_bootloader_append(self):
+        """Test bootloader_append function"""
+
+        self.assertEqual(bootloader_append("", "nosmt=force"), 'bootloader --append="nosmt=force" --location=none')
+        self.assertEqual(bootloader_append("", "nosmt=force console=ttyS0,115200n8"),
+                         'bootloader --append="nosmt=force console=ttyS0,115200n8" --location=none')
+        self.assertEqual(bootloader_append("bootloader --location=none", "nosmt=force"),
+                         'bootloader --append="nosmt=force" --location=none')
+        self.assertEqual(bootloader_append("bootloader --location=none", "console=ttyS0,115200n8 nosmt=force"),
+                         'bootloader --append="console=ttyS0,115200n8 nosmt=force" --location=none')
+        self.assertEqual(bootloader_append('bootloader --append="no_timer_check console=ttyS0,115200n8" --location=mbr', "nosmt=force"),
+                         'bootloader --append="no_timer_check console=ttyS0,115200n8 nosmt=force" --location=mbr')
+        self.assertEqual(bootloader_append('bootloader --append="console=tty1" --location=mbr --password="BADPASSWORD"', "nosmt=force"),
+                         'bootloader --append="console=tty1 nosmt=force" --location=mbr --password="BADPASSWORD"')
+
+    def _checkBootloader(self, result, append_str):
+        """Find the bootloader line and make sure append_str is in it"""
+
+        for line in result.splitlines():
+            if line.startswith("bootloader") and append_str in line:
+                return True
+        return False
+
+    def test_customize_ks_template(self):
+        """Test that [customizations.kernel] works correctly"""
+        blueprint_data = """name = "test-kernel"
+description = "test recipe"
+version = "0.0.1"
+
+[customizations.kernel]
+append="nosmt=force"
+"""
+        recipe = recipe_from_toml(blueprint_data)
+
+        # Test against a kickstart without bootloader
+        result = customize_ks_template("firewall --enabled\n", recipe)
+        self.assertTrue(self._checkBootloader(result, "nosmt=force"))
+
+        # Test against all of the available templates
+        share_dir = "./share/"
+        errors = []
+        for compose_type in compose_types(share_dir):
+            # Read the kickstart template for this type
+            ks_template_path = joinpaths(share_dir, "composer", compose_type) + ".ks"
+            ks_template = open(ks_template_path, "r").read()
+            result = customize_ks_template(ks_template, recipe)
+            if not self._checkBootloader(result, "nosmt=force"):
+                errors.append(("compose_type %s failed" % compose_type, result))
+
+        # Print the bad results
+        for e, r in errors:
+            print("%s:\n%s\n\n" % (e, r))
+
+        self.assertEqual(errors, [])
 
 class ExtraPkgsTest(unittest.TestCase):
     @classmethod

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -1109,6 +1109,12 @@ class ServerTestCase(unittest.TestCase):
         self.assertTrue("network --hostname=" in final_ks)
         self.assertTrue("sshkey --user root" in final_ks)
 
+        # Examine the config.toml to make sure it has an empty extra_boot_args
+        cfg_path = joinpaths(self.repo_dir, "var/lib/lorax/composer/results/", build_id, "config.toml")
+        cfg_dict = toml.loads(open(cfg_path, "r").read())
+        self.assertTrue("extra_boot_args" in cfg_dict)
+        self.assertEqual(cfg_dict["extra_boot_args"], "")
+
         # Delete the finished build
         # Test the /api/v0/compose/delete/<uuid> route
         resp = self.server.delete("/api/v0/compose/delete/%s" % build_id)
@@ -1261,6 +1267,12 @@ class ServerTestCase(unittest.TestCase):
                 break
         self.assertNotEqual(bootloader_line, "", "No bootloader line found")
         self.assertTrue("nosmt=force" in bootloader_line)
+
+        # Examine the config.toml to make sure it was written there as well
+        cfg_path = joinpaths(self.repo_dir, "var/lib/lorax/composer/results/", build_id, "config.toml")
+        cfg_dict = toml.loads(open(cfg_path, "r").read())
+        self.assertTrue("extra_boot_args" in cfg_dict)
+        self.assertEqual(cfg_dict["extra_boot_args"], "nosmt=force")
 
     def assertInputError(self, resp):
         """Check all the conditions for a successful input check error result"""

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -182,9 +182,9 @@ class ServerTestCase(unittest.TestCase):
 
     def test_02_blueprints_list(self):
         """Test the /api/v0/blueprints/list route"""
-        list_dict = {"blueprints":["example-atlas", "example-custom-base", "example-development",
+        list_dict = {"blueprints":["example-append", "example-atlas", "example-custom-base", "example-development",
                                    "example-glusterfs", "example-http-server", "example-jboss",
-                                   "example-kubernetes"], "limit":20, "offset":0, "total":7}
+                                   "example-kubernetes"], "limit":20, "offset":0, "total":8}
         resp = self.server.get("/api/v0/blueprints/list")
         data = json.loads(resp.data)
         self.assertEqual(data, list_dict)
@@ -1214,6 +1214,53 @@ class ServerTestCase(unittest.TestCase):
         ids = [e["id"] for e in data["uuids"]]
         self.assertIn(build_id_fail, ids, "Failed build not listed by /compose/status status filter")
         self.assertNotIn(build_id_success, "Finished build listed by /compose/status status filter")
+
+    def test_compose_14_kernel_append(self):
+        """Test the /api/v0/compose with kernel append customization"""
+        test_compose = {"blueprint_name": "example-append",
+                        "compose_type": "tar",
+                        "branch": "master"}
+
+        resp = self.server.post("/api/v0/compose?test=2",
+                                data=json.dumps(test_compose),
+                                content_type="application/json")
+        data = json.loads(resp.data)
+        self.assertNotEqual(data, None)
+        self.assertEqual(data["status"], True, "Failed to start test compose: %s" % data)
+
+        build_id = data["build_id"]
+
+        # Is it in the queue list (either new or run is fine, based on timing)
+        resp = self.server.get("/api/v0/compose/queue")
+        data = json.loads(resp.data)
+        self.assertNotEqual(data, None)
+        ids = [e["id"] for e in data["new"] + data["run"]]
+        self.assertEqual(build_id in ids, True, "Failed to add build to the queue")
+
+        # Wait for it to start
+        self.assertEqual(_wait_for_status(self, build_id, ["RUNNING"]), True, "Failed to start test compose")
+
+        # Wait for it to finish
+        self.assertEqual(_wait_for_status(self, build_id, ["FINISHED"]), True, "Failed to finish test compose")
+
+        resp = self.server.get("/api/v0/compose/info/%s" % build_id)
+        data = json.loads(resp.data)
+        self.assertNotEqual(data, None)
+        self.assertEqual(data["queue_status"], "FINISHED", "Build not in FINISHED state")
+
+        # Examine the final-kickstart.ks for the customizations
+        # A bit kludgy since it examines the filesystem directly, but that's better than unpacking the metadata
+        final_ks = open(joinpaths(self.repo_dir, "var/lib/lorax/composer/results/", build_id, "final-kickstart.ks")).read()
+
+        # Check for the expected customizations in the kickstart
+        # nosmt=force should be in the bootloader line, find it and check it
+        bootloader_line = ""
+        for line in final_ks.splitlines():
+            if line.startswith("bootloader"):
+                bootloader_line = line
+                break
+        self.assertNotEqual(bootloader_line, "", "No bootloader line found")
+        self.assertTrue("nosmt=force" in bootloader_line)
 
     def assertInputError(self, resp):
         """Check all the conditions for a successful input check error result"""


### PR DESCRIPTION
Sometimes it is necessary to modify the kernel command-line of the
image, this adds support for a [customizations.kernel] section to the
blueprint:

[customizations.kernel]
append = "nosmt=force"

This will be appended to the kickstart's bootloader --append argument.

Includes tests for modifying the bootloader line, the kickstart
template, and examining the final-kickstart.ks created for a compose.

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
