### PR TITLE
Do not include /usr/bin/delv

### DIFF
--- a/share/runtime-cleanup.tmpl
+++ b/share/runtime-cleanup.tmpl
@@ -142,7 +142,7 @@ removefrom authconfig /usr/sbin/* /usr/share/*
 removefrom bash /etc/* /usr/bin/bashbug* /usr/share/*
 removefrom bind-libs-lite /usr/${libdir}/libirs*
 removefrom bind-libs-lite /usr/${libdir}/libisccfg-export*
-removefrom bind-utils /usr/bin/dig /usr/bin/host /usr/bin/nsupdate
+removefrom bind-utils /usr/bin/dig /usr/bin/host /usr/bin/nsupdate /usr/bin/delv
 removefrom bitmap-fangsongti-fonts /usr/share/fonts/*
 removefrom ca-certificates /etc/pki/java/*
 removefrom ca-certificates /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/*


### PR DESCRIPTION
It changed packages, and was never included before so add it to the
binaries removed from bind-utils.

Resolves: rhbz#1688767

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
