### PR TITLE
Update datastore for VMware testing

### DIFF
--- a/tests/cli/test_build_and_deploy_vmware.sh
+++ b/tests/cli/test_build_and_deploy_vmware.sh
@@ -41,7 +41,7 @@ rlJournalStart
         V_NETWORK="${V_NETWORK:-CEE_VM_Network}"
         rlLogInfo "V_NETWORK=$V_NETWORK"
 
-        V_DATASTORE="${V_DATASTORE:-NFS-Synology-1}"
+        V_DATASTORE="${V_DATASTORE:-iSCSI-Node2}"
         rlLogInfo "V_DATASTORE=$V_DATASTORE"
 
         V_FOLDER="${V_FOLDER:-Composer}"


### PR DESCRIPTION
--- Description of proposed changes ---
Updating the datastore to unblock VMware testing

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
