### PR TITLE
pylorax.ltmpl: Add a test for missing quotes

### DIFF
--- a/tests/pylorax/templates/parse-missing-quote.tmpl
+++ b/tests/pylorax/templates/parse-missing-quote.tmpl
@@ -1,0 +1,4 @@
+<%page args="basearch"/>
+
+# missing quote
+replace @ROOT@ 'inst.stage2=hd:LABEL=foo isolinux.cfg

--- a/tests/pylorax/test_ltmpl.py
+++ b/tests/pylorax/test_ltmpl.py
@@ -58,6 +58,11 @@ class LoraxTemplateTestCase(unittest.TestCase):
     def setUpClass(self):
         self.templates = LoraxTemplate(["./tests/pylorax/templates/"])
 
+    def test_parse_missing_quote(self):
+        """Test parsing a template with missing quote"""
+        with self.assertRaises(Exception):
+            self.templates.parse("parse-missing-quote.tmpl", {"basearch": "x86_64"})
+
     def test_parse_template_x86_64(self):
         """Test LoraxTemplate.parse() with basearch set to x86_64"""
         commands = self.templates.parse("parse-test.tmpl", {"basearch": "x86_64"})


### PR DESCRIPTION
It should raise an error if a quote is missing in the template.

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
