### PR TITLE
Switch the --virt-uefi method to use SecureBoot

### DIFF
--- a/docs/livemedia-creator.rst
+++ b/docs/livemedia-creator.rst
@@ -579,18 +579,10 @@ Creating UEFI disk images with virt
 
 Partitioned disk images can only be created for the same platform as the host system (BIOS or
 UEFI). You can use virt to create BIOS images on UEFI systems, and it is also possible
-to create UEFI images on BIOS systems using OVMF. You first need to setup your system with
-the OVMF firmware. The details can be `found here linux-kvm OVMF page <http://www.linux-kvm.org/page/OVMF>`_
-but it amounts to:
+to create UEFI images on BIOS systems using OVMF firmware and qemu.
 
-1. Download the firmware.repo from `Gerd Hoffmann <https://www.kraxel.org/repos/>`_ and install it
-   in /etc/yum.repos.d/
-
-2. Install the edk2.git-ovmf-x64 package
-
-3. Copy /usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd to /usr/share/OVMF/OVMF_CODE.fd
-
-4. Copy /usr/share/edk2.git/ovmf-x64/OVMF_VARS-pure-efi.fd to /usr/share/OVMF/OVMF_VARS.fd
+Install the lorax-lmc-virt package, this will install qemu and the OVMF
+firmware files.
 
 Now you can run livemedia-creator with ``--virt-uefi`` to boot and install using UEFI::
 
@@ -601,11 +593,10 @@ Make sure that the kickstart you are using creates a /boot/efi partition by incl
 
     part /boot/efi --fstype="efi" --size=500
 
+Or use ``reqpart`` in the kickstart and Anaconda will create the required partitions.
+
 .. note::
-    When using the resulting image with the current version of OVMF (edk2.git-ovmf-x64-0-20151103.b1295.ge5cffca)
-    it will not boot automatically because there is a problem with the fallback path.
-    You can boot it by entering the UEFI shell and running EFI/fedora/shim.efi and
-    then using efibootmgr to setup the correct boot entry.
+    The --virt-uefi method is currently only supported on the x86_64 architecture.
 
 
 Debugging problems

--- a/src/pylorax/installer.py
+++ b/src/pylorax/installer.py
@@ -140,7 +140,7 @@ class QEMUInstall(object):
                  "i386":    "qemu-system-i386",
                  "arm":     "qemu-system-arm",
                  "aarch64": "qemu-system-aarch64",
-                 "ppc64le":   "qemu-system-ppc64"
+                 "ppc64le": "qemu-system-ppc64"
                 }
 
     def __init__(self, opts, iso, ks_paths, disk_img, img_size=2048,
@@ -180,7 +180,11 @@ class QEMUInstall(object):
             qemu_cmd += ["-smp", str(vcpus)]
 
         if not opts.no_kvm and os.path.exists("/dev/kvm"):
-            qemu_cmd += ["--machine", "accel=kvm"]
+            qemu_cmd += ["-machine", "accel=kvm"]
+
+        if boot_uefi:
+            qemu_cmd += ["-machine", "q35,smm=on"]
+            qemu_cmd += ["-global", "driver=cfi.pflash01,property=secure,value=on"]
 
         # Copy the initrd from the iso, create a cpio archive of the kickstart files
         # and append it to the temporary initrd.
@@ -230,17 +234,20 @@ class QEMUInstall(object):
                                 ",id=channel0,name=org.fedoraproject.anaconda.log.0"]
         qemu_cmd += ["-chardev", "socket,id=charchannel0,host=%s,port=%s" % (virtio_host, virtio_port)]
 
-        # PAss through rng from host
+        # Pass through rng from host
         if opts.with_rng != "none":
             qemu_cmd += ["-object", "rng-random,id=virtio-rng0,filename=%s" % opts.with_rng]
-            qemu_cmd += ["-device", "virtio-rng-pci,rng=virtio-rng0,id=rng0,bus=pci.0,addr=0x9"]
+            if boot_uefi:
+                qemu_cmd += ["-device", "virtio-rng-pci,rng=virtio-rng0,id=rng0,bus=pcie.0,addr=0x9"]
+            else:
+                qemu_cmd += ["-device", "virtio-rng-pci,rng=virtio-rng0,id=rng0,bus=pci.0,addr=0x9"]
 
         if boot_uefi and ovmf_path:
-            qemu_cmd += ["-drive", "file=%s/OVMF_CODE.fd,if=pflash,format=raw,unit=0,readonly=on" % ovmf_path]
+            qemu_cmd += ["-drive", "file=%s/OVMF_CODE.secboot.fd,if=pflash,format=raw,unit=0,readonly=on" % ovmf_path]
 
-            # Make a copy of the OVMF_VARS.fd for this run
+            # Make a copy of the OVMF_VARS.secboot.fd for this run
             ovmf_vars = tempfile.mktemp(prefix="lmc-OVMF_VARS-", suffix=".fd")
-            shutil.copy2(joinpaths(ovmf_path, "/OVMF_VARS.fd"), ovmf_vars)
+            shutil.copy2(joinpaths(ovmf_path, "/OVMF_VARS.secboot.fd"), ovmf_vars)
 
             qemu_cmd += ["-drive", "file=%s,if=pflash,format=raw,unit=1" % ovmf_vars]
 

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -137,9 +137,9 @@ def main():
     if opts.virt_uefi and not os.path.isdir(opts.ovmf_path):
         errors.append("The OVMF firmware is missing from %s" % opts.ovmf_path)
     elif opts.virt_uefi and os.path.isdir(opts.ovmf_path):
-        for f in ["OVMF_CODE.fd", "OVMF_VARS.fd"]:
+        for f in ["OVMF_CODE.secboot.fd", "OVMF_VARS.secboot.fd"]:
             if not os.path.exists(joinpaths(opts.ovmf_path, f)):
-                errors.append("OVMF firmware file %s is missing from %s" % (f, opts.ovmf_path))
+                errors.append("OVMF secure boot firmware file %s is missing from %s" % (f, opts.ovmf_path))
 
     if os.getuid() != 0:
         errors.append("You need to run this as root")


### PR DESCRIPTION
This updates the qemu arguments so that it will actually work, and
switches to using SecureBoot OVMF firmware.

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
