### PR TITLE
Switch the --virt-uefi method to use SecureBoot

### DIFF
--- a/docs/livemedia-creator.rst
+++ b/docs/livemedia-creator.rst
@@ -563,18 +563,10 @@ Creating UEFI disk images with virt
 
 Partitioned disk images can only be created for the same platform as the host system (BIOS or
 UEFI). You can use virt to create BIOS images on UEFI systems, and it is also possible
-to create UEFI images on BIOS systems using OVMF. You first need to setup your system with
-the OVMF firmware. The details can be `found here linux-kvm OVMF page <http://www.linux-kvm.org/page/OVMF>`_
-but it amounts to:
+to create UEFI images on BIOS systems using OVMF firmware and qemu.
 
-1. Download the firmware.repo from `Gerd Hoffmann <https://www.kraxel.org/repos/>`_ and install it
-   in /etc/yum.repos.d/
-
-2. Install the edk2.git-ovmf-x64 package
-
-3. Copy /usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd to /usr/share/OVMF/OVMF_CODE.fd
-
-4. Copy /usr/share/edk2.git/ovmf-x64/OVMF_VARS-pure-efi.fd to /usr/share/OVMF/OVMF_VARS.fd
+Install the lorax-lmc-virt package, this will install qemu and the OVMF
+firmware files.
 
 Now you can run livemedia-creator with ``--virt-uefi`` to boot and install using UEFI::
 
@@ -585,11 +577,10 @@ Make sure that the kickstart you are using creates a /boot/efi partition by incl
 
     part /boot/efi --fstype="efi" --size=500
 
+Or use ``reqpart`` in the kickstart and Anaconda will create the required partitions.
+
 .. note::
-    When using the resulting image with the current version of OVMF (edk2.git-ovmf-x64-0-20151103.b1295.ge5cffca)
-    it will not boot automatically because there is a problem with the fallback path.
-    You can boot it by entering the UEFI shell and running EFI/redhat/shim.efi and
-    then using efibootmgr to setup the correct boot entry.
+    The --virt-uefi method is currently only supported on the x86_64 architecture.
 
 
 Debugging problems

--- a/src/pylorax/installer.py
+++ b/src/pylorax/installer.py
@@ -214,7 +214,7 @@ class QEMUInstall(object):
         else:
             display_args = opts.vnc
         log.info("qemu %s", display_args)
-        qemu_cmd += ["-nographic", "-display", display_args ]
+        qemu_cmd += ["-nographic", "-monitor", "none", "-serial", "null", "-display", display_args ]
 
         # Setup virtio networking
         qemu_cmd += ["-netdev", "user,id=n1", "-device", "virtio-net-pci,netdev=n1"]

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -141,9 +141,9 @@ def main():
     if opts.virt_uefi and not os.path.isdir(opts.ovmf_path):
         errors.append("The OVMF firmware is missing from %s" % opts.ovmf_path)
     elif opts.virt_uefi and os.path.isdir(opts.ovmf_path):
-        for f in ["OVMF_CODE.fd", "OVMF_VARS.fd"]:
+        for f in ["OVMF_CODE.secboot.fd", "OVMF_VARS.secboot.fd"]:
             if not os.path.exists(joinpaths(opts.ovmf_path, f)):
-                errors.append("OVMF firmware file %s is missing from %s" % (f, opts.ovmf_path))
+                errors.append("OVMF secure boot firmware file %s is missing from %s" % (f, opts.ovmf_path))
 
     if os.getuid() != 0:
         errors.append("You need to run this as root")


### PR DESCRIPTION
This updates the qemu arguments so that it will actually work, and
switches to using SecureBoot OVMF firmware.

Resolves: rhbz#1691661

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
