### PR TITLE
qemu wasn't restoring the terminal if it was terminated early

### DIFF
--- a/src/pylorax/installer.py
+++ b/src/pylorax/installer.py
@@ -226,7 +226,7 @@ class QEMUInstall(object):
         else:
             display_args = opts.vnc
         log.info("qemu %s", display_args)
-        qemu_cmd += ["-nographic", "-display", display_args ]
+        qemu_cmd += ["-nographic", "-monitor", "none", "-serial", "null", "-display", display_args ]
 
         # Setup the virtio log port
         qemu_cmd += ["-device", "virtio-serial-pci,id=virtio-serial0"]


### PR DESCRIPTION
You would need to run reset to regain control of your terminal after
this happened, so this turns off the monitor and serial port mux to
stdout.

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
