### PR TITLE
Add checks for disabled root account

### DIFF
--- a/tests/cli/lib/root_account.sh
+++ b/tests/cli/lib/root_account.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+check_root_account() {
+# Try to SSH to a remote machine first using root account using password-based
+# auth (this is expected to fail) and then using key-based auth with the
+# supplied username to check content of /etc/shadow and audit.log.
+#
+# use: check_root_account <user> <machine> [ssh options]
+
+    local ssh_opts="-o StrictHostKeyChecking=no $3"
+    local user="$1"
+    local machine="$2"
+    if [[ "$user" == "" || "$machine" == "" ]]; then
+        rlFail "check_root_account: Missing user or machine parameter."
+        return 1
+    fi
+
+    if [ $ROOT_ACCOUNT_LOCKED == 0 ]; then
+        rlRun -t -c "ssh $ssh_opts ${user}@${machine} \"sudo grep '^root::' /etc/shadow\"" \
+            0 "Password for root account in /etc/shadow is empty"
+    else
+        # ssh returns 255 in case of any ssh error, so it's better to grep the specific error message
+        rlRun -t -c "ssh $ssh_opts -o PubkeyAuthentication=no root@${machine} 2>&1 | grep -i 'permission denied ('" \
+            0 "Can't ssh to '$machine' as root using password-based auth"
+        rlRun -t -c "ssh $ssh_opts ${user}@${machine} \"sudo grep -E '^root:(\*LOCK\*|!):' /etc/shadow\"" \
+            0 "root account is disabled in /etc/shadow"
+        rlRun -t -c "ssh $ssh_opts ${user}@${machine} \"sudo grep 'USER_LOGIN.*acct=\\\"root\\\".*terminal=ssh.*res=failed' /var/log/audit/audit.log\"" \
+            0 "audit.log contains entry about unsuccessful root login"
+        # We modify the default sshd settings on live ISO, so we can only check the default empty password setting
+        # outside of live ISO
+        rlRun -t -c "ssh $ssh_opts ${user}@${machine} 'grep -E \"^[[:blank:]]*PermitEmptyPasswords[[:blank:]]*yes\" /etc/ssh/sshd_config'" 1 \
+            "Login with empty passwords is disabled in sshd config file"
+    fi
+    rlRun -t -c "ssh $ssh_opts ${user}@${machine} 'cat /etc/redhat-release'"
+
+}
+

--- a/tests/cli/test_build_and_deploy_aws.sh
+++ b/tests/cli/test_build_and_deploy_aws.sh
@@ -186,8 +186,9 @@ __EOF__
             CLOUD_USER="fedora"
         fi
 
-        # verify we can login into that instance and maybe some other details
-        rlRun -t -c "ssh -oStrictHostKeyChecking=no -i $SSH_KEY_DIR/id_rsa $CLOUD_USER@$IP_ADDRESS 'cat /etc/redhat-release'"
+        # verify we can login into that instance and root account is disabled
+        . ./tests/cli/lib/root_account.sh
+        check_root_account $CLOUD_USER $IP_ADDRESS "-i $SSH_KEY_DIR/id_rsa"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/cli/test_build_and_deploy_azure.sh
+++ b/tests/cli/test_build_and_deploy_azure.sh
@@ -137,8 +137,9 @@ __EOF__
     rlPhaseEnd
 
     rlPhaseStartTest "Verify VM instance"
-        # verify we can login into that instance
-        rlRun -t -c "ssh -oStrictHostKeyChecking=no -i $SSH_KEY_DIR/id_rsa azure-user@$IP_ADDRESS 'cat /etc/redhat-release'"
+        # verify we can login into that instance and root account is disabled
+        . ./tests/cli/lib/root_account.sh
+        check_root_account azure-user $IP_ADDRESS "-i $SSH_KEY_DIR/id_rsa"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/cli/test_build_and_deploy_openstack.sh
+++ b/tests/cli/test_build_and_deploy_openstack.sh
@@ -123,8 +123,9 @@ __EOF__
             CLOUD_USER="fedora"
         fi
 
-        # verify we can login into that instance
-        rlRun -t -c "ssh -oStrictHostKeyChecking=no -i $SSH_KEY_DIR/id_rsa $CLOUD_USER@$IP_ADDRESS 'cat /etc/redhat-release'"
+        # verify we can login into that instance and root account is disabled
+        . ./tests/cli/lib/root_account.sh
+        check_root_account $CLOUD_USER $IP_ADDRESS "-i $SSH_KEY_DIR/id_rsa"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/cli/test_build_and_deploy_vmware.sh
+++ b/tests/cli/test_build_and_deploy_vmware.sh
@@ -141,8 +141,9 @@ __EOF__
     rlPhaseEnd
 
     rlPhaseStartTest "Verify VM instance"
-        # Verify we can login into that instance
-        rlRun -t -c "ssh -oStrictHostKeyChecking=no -i $SSH_KEY_DIR/id_rsa root@$IP_ADDRESS 'cat /etc/redhat-release'"
+        # verify we can login into that instance and root account is disabled
+        . ./tests/cli/lib/root_account.sh
+        check_root_account root $IP_ADDRESS "-i $SSH_KEY_DIR/id_rsa"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -51,7 +51,8 @@ rlJournalStart
 
     rlPhaseStartTest "Verify VM instance"
         # verify we can login into that instance *WITHOUT* a password
-        rlRun -t -c "ssh -oStrictHostKeyChecking=no -p 2222 root@localhost 'cat /etc/redhat-release'"
+        . ./tests/cli/lib/root_account.sh
+        ROOT_ACCOUNT_LOCKED=0 check_root_account root localhost "-p 2222"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -73,8 +73,9 @@ __EOF__
     rlPhaseEnd
 
     rlPhaseStartTest "Verify VM instance"
-        # verify we can login into that instance
-        rlRun -t -c "ssh -oStrictHostKeyChecking=no -i $SSH_KEY_DIR/id_rsa -p 2222 root@localhost 'cat /etc/redhat-release'"
+        # verify we can login into that instance and root account is disabled
+        . ./tests/cli/lib/root_account.sh
+        check_root_account $CLOUD_USER $IP_ADDRESS "-i $SSH_KEY_DIR/id_rsa -p 2222"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -8,6 +8,13 @@ function setup_tests {
     # explicitly enable sshd for live-iso b/c it is disabled by default
     # due to security concerns (no root password required)
     sed -i.orig 's/^services.*/services --disabled="network" --enabled="NetworkManager,sshd"/' $1/composer/live-iso.ks
+    # explicitly enable logging in with empty passwords via ssh, because
+    # the default sshd setting for PermitEmptyPasswords is 'no'; we need a little hack to do inplace
+    # substitution as awk on RHEL-7 doesn't provide '-i inplace' option
+    echo "$(awk "
+        /%post/ && FLAG != 2 {FLAG=1}
+        /%end/ && FLAG == 1 {print \"sed -i 's/.*PermitEmptyPasswords.*/PermitEmptyPasswords yes/' /etc/ssh/sshd_config\"; FLAG=2}
+        {print}" $1/composer/live-iso.ks)" > $1/composer/live-iso.ks
 }
 
 function teardown_tests {


### PR DESCRIPTION
The root account checks are applied to generated and deployed images
to make sure that root account is locked, except for live ISO.

--- Description of proposed changes ---




--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
