### PR TITLE
Make it easier to generate docs for the next release

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -19,6 +19,7 @@ RUN  dnf -y install \
   python3-pytoml \
   python3-semantic_version \
   python3-sphinx \
+  python3-sphinx-argparse \
   python3-sphinx_rtd_theme \
   python3-rpmfluff \
   python3-librepo \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,19 +56,32 @@ copyright = u'2018, Red Hat, Inc.'      # pylint: disable=redefined-builtin
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
+# Pass in LORAX_VERSION to set a specific version
+# Set LORAX_VERSION=next to bump it to the next release
 def read_version():
-    """Read version from $LORAX_VERSION or ../lorax.spec"""
+    """Read version from $LORAX_VERSION or ../lorax.spec, or bump the version from lorax.spec"""
     # This allows the .spec version to be overridded. eg. when documenting an upcoming release
-    if "LORAX_VERSION" in os.environ:
+    if "LORAX_VERSION" in os.environ and "next" not in os.environ["LORAX_VERSION"]:
         return os.environ["LORAX_VERSION"]
 
+    doc_version = None
     import re
     version_re = re.compile(r"Version:\s+(.*)")
     with open("../lorax.spec", "rt") as f:
         for line in f:
             m = version_re.match(line)
             if m:
-                return m.group(1)
+                doc_version = m.group(1)
+    if not doc_version:
+        raise RuntimeError("Failed to find current version")
+
+    # Make it easier to generate docs for the next release
+    if "next" in os.environ["LORAX_VERSION"]:
+        fields = doc_version.split(".")
+        fields[-1] = str(int(fields[-1]) + 1)
+        doc_version = ".".join(fields)
+
+    return doc_version
 
 #
 # The short X.Y version.


### PR DESCRIPTION
Change the docs-in-docker target to generate the docs for the NEXT
release, not the current one. Also pass in uid/gid so that the new files
can be set to the correct ownership instead of root.

Modify docs/conf.py to bump the version of the docs if
LORAX_VERSION=next is set in the environment.

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
