### PR TITLE
'compose info' is 'compose details' on RHEL-7

### DIFF
--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -29,7 +29,7 @@ rlJournalStart
 
     rlPhaseStartTest "compose finished"
         if [ -n "$UUID" ]; then
-            until $CLI compose info $UUID | grep FINISHED; do
+            until $CLI compose details $UUID | grep FINISHED; do
                 sleep 20
                 rlLogInfo "Waiting for compose to finish ..."
             done;

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -54,7 +54,7 @@ __EOF__
 
     rlPhaseStartTest "compose finished"
         if [ -n "$UUID" ]; then
-            until $CLI compose info $UUID | grep FINISHED; do
+            until $CLI compose details $UUID | grep FINISHED; do
                 sleep 20
                 rlLogInfo "Waiting for compose to finish ..."
             done;

--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -27,7 +27,7 @@ rlJournalStart
 
     rlPhaseStartTest "compose finished"
         if [ -n "$UUID" ]; then
-            until $CLI compose info $UUID | grep FINISHED; do
+            until $CLI compose details $UUID | grep FINISHED; do
                 sleep 10
                 rlLogInfo "Waiting for compose to finish ..."
             done;


### PR DESCRIPTION
Add the correct composer-cli command 'compose details' in places
where 'compose info' was still used on RHEL-7
(see commit 808454b5615940d88e4c9124578f1b67a7140d4d)

--- Description of proposed changes ---




--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
