### PR TITLE
Add -iso-level 3 when the install.img is > 4GiB

### DIFF
--- a/share/templates.d/99-generic/aarch64.tmpl
+++ b/share/templates.d/99-generic/aarch64.tmpl
@@ -6,7 +6,15 @@ KERNELDIR=PXEBOOTDIR
 STAGE2IMG="images/install.img"
 LORAXDIR="usr/share/lorax/"
 
+import os
 from os.path import basename
+from pylorax.sysutils import joinpaths
+
+# Test the runtime_img, if it is > 4GiB we need to set -iso-level to 3
+if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
+    isoargs = "-iso-level 3"
+else:
+    isoargs = ""
 %>
 
 mkdir images
@@ -67,7 +75,7 @@ mkdir ${KERNELDIR}
 
 %if exists("boot/efi/EFI/*/gcdaa64.efi"):
 ## make boot.iso
-runcmd xorrisofs -o ${outroot}/images/boot.iso \
+runcmd xorrisofs ${isoargs} -o ${outroot}/images/boot.iso \
        ${efiargs} -R -J -V '${isolabel}' \
        -graft-points \
        .discinfo=${outroot}/.discinfo \

--- a/share/templates.d/99-generic/arm.tmpl
+++ b/share/templates.d/99-generic/arm.tmpl
@@ -1,4 +1,4 @@
-<%page args="kernels, runtime_img, runtime_base, basearch, outroot, arch"/>
+<%page args="kernels, runtime_img, runtime_base, basearch, inroot, outroot, arch"/>
 <%
 configdir="tmp/config_files/uboot"
 PXEBOOTDIR="images/pxeboot"
@@ -12,7 +12,15 @@ LORAXDIR="usr/share/lorax/"
 platforms = ""
 delimiter = ''
 
+import os
 from os.path import basename
+from pylorax.sysutils import joinpaths
+
+# Test the runtime_img, if it is > 4GiB we need to set -iso-level to 3
+if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
+    isoargs = "-iso-level 3"
+else:
+    isoargs = ""
 %>
 
 mkdir images
@@ -84,7 +92,7 @@ treeinfo ${basearch} platforms ${platforms}
 
 %if exists("boot/efi/EFI/*/gcdarm.efi"):
 ## make boot.iso
-runcmd xorrisofs -o ${outroot}/images/boot.iso \
+runcmd xorrisofs ${isoargs} -o ${outroot}/images/boot.iso \
        ${efiargs} -R -J -V '${isolabel}' \
        -graft-points \
        .discinfo=${outroot}/.discinfo \

--- a/share/templates.d/99-generic/live/aarch64.tmpl
+++ b/share/templates.d/99-generic/live/aarch64.tmpl
@@ -12,7 +12,15 @@ def valid_label(ch):
 
 isolabel = ''.join(ch if valid_label(ch) else '-' for ch in isolabel)
 
+import os
 from os.path import basename
+from pylorax.sysutils import joinpaths
+
+# Test the runtime_img, if it is > 4GiB we need to set -iso-level to 3
+if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
+    isoargs = "-iso-level 3"
+else:
+    isoargs = ""
 %>
 
 mkdir ${LIVEDIR}
@@ -73,7 +81,7 @@ mkdir ${KERNELDIR}
 
 %if exists("boot/efi/EFI/*/gcdaa64.efi"):
 ## make boot.iso
-runcmd xorrisofs -o ${outroot}/images/boot.iso \
+runcmd xorrisofs ${isoargs} -o ${outroot}/images/boot.iso \
        ${efiargs} -R -J -V '${isolabel}' \
        -graft-points \
        ${KERNELDIR}=${outroot}/${KERNELDIR} \

--- a/share/templates.d/99-generic/live/ppc64le.tmpl
+++ b/share/templates.d/99-generic/live/ppc64le.tmpl
@@ -12,7 +12,15 @@ LORAXDIR="usr/share/lorax/"
 ## with '_', which means we won't need any udev escapes.
 isolabel = ''.join(ch if ch.isalnum() else '_' for ch in isolabel)
 
+import os
 from os.path import basename
+from pylorax.sysutils import joinpaths
+
+# Test the runtime_img, if it is > 4GiB we need to set -iso-level to 3
+if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
+    isoargs = "-iso-level 3"
+else:
+    isoargs = ""
 %>
 
 mkdir ${LIVEDIR}
@@ -72,7 +80,7 @@ replace @EXTRA@ '${extra_boot_args}' ${GRUBDIR}/grub.cfg
 %endfor
 
 ## make boot.iso
-runcmd xorrisofs -v -U -J -R \
+runcmd xorrisofs -v -U -J -R ${isoargs} \
         -o ${outroot}/images/boot.iso \
         -r -l -sysid PPC \
         -A "${product.name} ${product.version}" -V '${isolabel}' \

--- a/share/templates.d/99-generic/live/x86.tmpl
+++ b/share/templates.d/99-generic/live/x86.tmpl
@@ -14,7 +14,15 @@ def valid_label(ch):
 
 isolabel = ''.join(ch if valid_label(ch) else '-' for ch in isolabel)
 
+import os
 from os.path import basename
+from pylorax.sysutils import joinpaths
+
+# Test the runtime_img, if it is > 4GiB we need to set -iso-level to 3
+if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
+    isoargs = "-iso-level 3"
+else:
+    isoargs = ""
 %>
 
 mkdir ${LIVEDIR}
@@ -105,7 +113,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %endfor
 
 ## make boot.iso
-runcmd xorrisofs -o ${outroot}/images/boot.iso \
+runcmd xorrisofs ${isoargs} -o ${outroot}/images/boot.iso \
        -isohybrid-mbr /usr/share/syslinux/isohdpfx.bin \
        -b ${BOOTDIR}/isolinux.bin -c ${BOOTDIR}/boot.cat \
        -boot-load-size 4 -boot-info-table -no-emul-boot \

--- a/share/templates.d/99-generic/ppc64le.tmpl
+++ b/share/templates.d/99-generic/ppc64le.tmpl
@@ -12,7 +12,15 @@ def valid_label(ch):
 
 isolabel = ''.join(ch if valid_label(ch) else '-' for ch in isolabel)
 
+import os
 from os.path import basename
+from pylorax.sysutils import joinpaths
+
+# Test the runtime_img, if it is > 4GiB we need to set -iso-level to 3
+if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
+    isoargs = "-iso-level 3"
+else:
+    isoargs = ""
 %>
 
 mkdir images
@@ -78,7 +86,7 @@ replace @ROOT@ 'inst.stage2=hd:LABEL=${isolabel|udev}' ${GRUBDIR}/grub.cfg
 %endfor
 
 ## make boot.iso
-runcmd xorrisofs -v -U -J -R \
+runcmd xorrisofs -v -U -J -R ${isoargs} \
         -o ${outroot}/images/boot.iso \
         -r -l -sysid PPC \
         -A "${product.name} ${product.version}" -V '${isolabel}' \

--- a/share/templates.d/99-generic/s390.tmpl
+++ b/share/templates.d/99-generic/s390.tmpl
@@ -1,4 +1,4 @@
-<%page args="kernels, runtime_img, runtime_base, basearch, outroot"/>
+<%page args="kernels, runtime_img, runtime_base, basearch, inroot, outroot"/>
 <%
 configdir="tmp/config_files/s390"
 BOOTDIR="images"
@@ -8,7 +8,15 @@ LORAXDIR="usr/share/lorax/"
 # The assumption seems to be that there is only one s390 kernel, ever
 kernel = kernels[0]
 
+import os
 from os.path import basename
+from pylorax.sysutils import joinpaths
+
+# Test the runtime_img, if it is > 4GiB we need to set -iso-level to 3
+if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
+    isoargs = "-iso-level 3"
+else:
+    isoargs = ""
 %>
 
 mkdir images
@@ -68,7 +76,7 @@ runcmd mk-s390-cdboot -i ${outroot}/${KERNELDIR}/kernel.img \
                       -o ${outroot}/${BOOTDIR}/cdboot.img
 
 ## make boot.iso
-runcmd xorrisofs -o ${outroot}/images/boot.iso \
+runcmd xorrisofs ${isoargs} -o ${outroot}/images/boot.iso \
        -b ${BOOTDIR}/cdboot.img -c ${BOOTDIR}/boot.cat \
        -boot-load-size 4 -no-emul-boot \
        -R -J -V '${isolabel}' -graft-points \

--- a/share/templates.d/99-generic/x86.tmpl
+++ b/share/templates.d/99-generic/x86.tmpl
@@ -14,7 +14,15 @@ def valid_label(ch):
 
 isolabel = ''.join(ch if valid_label(ch) else '-' for ch in isolabel)
 
+import os
 from os.path import basename
+from pylorax.sysutils import joinpaths
+
+# Test the runtime_img, if it is > 4GiB we need to set -iso-level to 3
+if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
+    isoargs = "-iso-level 3"
+else:
+    isoargs = ""
 %>
 
 mkdir images
@@ -113,7 +121,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %endfor
 
 ## make boot.iso
-runcmd xorrisofs -o ${outroot}/images/boot.iso \
+runcmd xorrisofs ${isoargs} -o ${outroot}/images/boot.iso \
        -isohybrid-mbr /usr/share/syslinux/isohdpfx.bin \
        -b ${BOOTDIR}/isolinux.bin -c ${BOOTDIR}/boot.cat \
        -boot-load-size 4 -boot-info-table -no-emul-boot \


### PR DESCRIPTION
xorrisofs needs to use iso-level 3 when creating images with large
files. This adds tests to all the relevant templates, just like we used
to do for udf and mkisofs.

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
