### PR TITLE
Fix [[repos.git]] installing to /

### DIFF
--- a/src/pylorax/api/gitrpm.py
+++ b/src/pylorax/api/gitrpm.py
@@ -134,10 +134,17 @@ class GitRpmBuild(SimpleRpmBuild):
         sourceIndex = self.add_source(GitArchiveTarball(gitRepo))
         self.section_build += "tar -xvf %s\n" % self.sources[sourceIndex].sourceName
         dest = os.path.normpath(gitRepo["destination"])
+        # Prevent double slash root
+        if dest == "/":
+            dest = ""
         self.create_parent_dirs(dest)
-        self.section_install += "cp -r %s $RPM_BUILD_ROOT/%s\n" % (gitRepo["rpmname"], dest)
+        self.section_install += "cp -r %s/. $RPM_BUILD_ROOT/%s\n" % (gitRepo["rpmname"], dest)
         sub = self.get_subpackage(None)
-        sub.section_files += "%s/" % dest
+        if not dest:
+            # / is special, we don't want to include / itself, just what's under it
+            sub.section_files += "/*\n"
+        else:
+            sub.section_files += "%s/\n" % dest
 
 def make_git_rpm(gitRepo, dest):
     """ Create an rpm from the specified git repo

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -94,9 +94,13 @@ def create_git_repo():
     for f in ["packages-only.toml", "groups-only.toml"]:
         shutil.copy2(os.path.join(oldcwd, results_path, f), os.path.join(repodir, "only-bps/"))
         test_results["second"].append(os.path.join("only-bps/", f))
+
+    # Add a dotfile as well
+    open(os.path.join(repodir, "only-bps/.bpsrc"), "w").write("dotfile test\n")
+    test_results["second"].append("only-bps/.bpsrc")
     test_results["second"] = sorted(test_results["second"])
 
-    cmd = ["git", "add", "*.toml"]
+    cmd = ["git", "add", "*.toml", "only-bps/.bpsrc"]
     subprocess.check_call(cmd)
     cmd = ["git", "commit", "-m", "second files"]
     subprocess.check_call(cmd)


### PR DESCRIPTION

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
