### PR TITLE
Correct "recipes" use to "blueprints" in the composer-cli description

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -157,7 +157,7 @@ Summary: A command line tool for use with the lorax-composer API server
 Requires: python3-urllib3
 
 %description -n composer-cli
-A command line tool for use with the lorax-composer API server. Examine recipes,
+A command line tool for use with the lorax-composer API server. Examine blueprints,
 build images, etc. from the command line.
 
 %prep


### PR DESCRIPTION
The original "recipes" term is indicated in the composer-cli description,
but the identifier has been changed to "blueprints" with later releases.
This commit changes the string to "blueprints".

--- Description of proposed changes ---




--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
