### PR TITLE
Fixes for locked root account test

### DIFF
--- a/tests/cli/lib/root_account.sh
+++ b/tests/cli/lib/root_account.sh
@@ -10,6 +10,7 @@ check_root_account() {
     local ssh_opts="-o StrictHostKeyChecking=no $3"
     local user="$1"
     local machine="$2"
+    ROOT_ACCOUNT_LOCKED=${ROOT_ACCOUNT_LOCKED:-1}
     if [[ "$user" == "" || "$machine" == "" ]]; then
         rlFail "check_root_account: Missing user or machine parameter."
         return 1
@@ -28,7 +29,7 @@ check_root_account() {
             0 "audit.log contains entry about unsuccessful root login"
         # We modify the default sshd settings on live ISO, so we can only check the default empty password setting
         # outside of live ISO
-        rlRun -t -c "ssh $ssh_opts ${user}@${machine} 'grep -E \"^[[:blank:]]*PermitEmptyPasswords[[:blank:]]*yes\" /etc/ssh/sshd_config'" 1 \
+        rlRun -t -c "ssh $ssh_opts ${user}@${machine} 'sudo grep -E \"^[[:blank:]]*PermitEmptyPasswords[[:blank:]]*yes\" /etc/ssh/sshd_config'" 1 \
             "Login with empty passwords is disabled in sshd config file"
     fi
     rlRun -t -c "ssh $ssh_opts ${user}@${machine} 'cat /etc/redhat-release'"

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -75,7 +75,7 @@ __EOF__
     rlPhaseStartTest "Verify VM instance"
         # verify we can login into that instance and root account is disabled
         . ./tests/cli/lib/root_account.sh
-        check_root_account $CLOUD_USER $IP_ADDRESS "-i $SSH_KEY_DIR/id_rsa -p 2222"
+        check_root_account root localhost "-i $SSH_KEY_DIR/id_rsa -p 2222"
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
Fixes related to a few issues in the locked root account test I somehow managed to overlook in the initial commit.

Related: rhbz#1626122

--- Description of proposed changes ---




--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
