### PR TITLE
Backport additional tests for blueprints/compose

### DIFF
--- a/tests/cli/lib/toml-compare
+++ b/tests/cli/lib/toml-compare
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+"""
+    Will compare 2 blueprints for equality!
+    On RHEL7/Python 2 toml uses dictionaries and
+    blueprint show doesn't keep the order of the elements.
+
+    For master/Python3 this is not the case.
+"""
+
+import sys
+import pytoml
+
+if len(sys.argv) != 3:
+    print("USAGE: ", __file__, "<blueprint-one.toml> <blueprint-two.toml>")
+    sys.exit(1)
+
+blueprint_one = pytoml.loads(open(sys.argv[1]).read())
+blueprint_two = pytoml.loads(open(sys.argv[2]).read())
+
+assert blueprint_one == blueprint_two

--- a/tests/cli/test_blueprints_sanity.sh
+++ b/tests/cli/test_blueprints_sanity.sh
@@ -34,7 +34,7 @@ version = "0.0.1"
 groups = []
 modules = []
 
-[[modules]]
+[[packages]]
 name = "beakerlib"
 version = "*"
 __EOF__

--- a/tests/cli/test_build_and_deploy_openstack.sh
+++ b/tests/cli/test_build_and_deploy_openstack.sh
@@ -57,11 +57,11 @@ name = "http-with-rng"
 description = "HTTP image for OpenStack with rng-tools"
 version = "0.0.1"
 
-[[modules]]
+[[packages]]
 name = "httpd"
 version = "*"
 
-[[modules]]
+[[packages]]
 name = "rng-tools"
 version = "*"
 __EOF__

--- a/tests/cli/test_build_and_deploy_vmware.sh
+++ b/tests/cli/test_build_and_deploy_vmware.sh
@@ -75,7 +75,7 @@ name = "vmware"
 description = "HTTP image for vmware"
 version = "0.0.1"
 
-[[modules]]
+[[packages]]
 name = "httpd"
 version = "*"
 

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -31,7 +31,7 @@ name = "with-ssh"
 description = "HTTP image with SSH"
 version = "0.0.1"
 
-[[modules]]
+[[packages]]
 name = "httpd"
 version = "*"
 

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -36,6 +36,11 @@ rlJournalStart
 
             rlRun -t -c "$CLI compose image $UUID"
             rlAssertExists "$UUID-root.tar.xz"
+
+            # because this path is listed in the documentation
+            rlAssertExists    "/var/lib/lorax/composer/results/$UUID/"
+            rlAssertExists    "/var/lib/lorax/composer/results/$UUID/root.tar.xz"
+            rlAssertNotDiffer "/var/lib/lorax/composer/results/$UUID/root.tar.xz" "$UUID-root.tar.xz"
         else
             rlFail "Compose UUID is empty!"
         fi


### PR DESCRIPTION
--- Description of proposed changes ---

Referenced bug still not approved.


--- Merge policy ---

- [x] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
