### PR TITLE
Backport some more tests from master

### DIFF
--- a/tests/cli/test_blueprints_sanity.sh
+++ b/tests/cli/test_blueprints_sanity.sh
@@ -34,7 +34,7 @@ version = "0.0.1"
 modules = []
 groups = []
 
-[[modules]]
+[[packages]]
 name = "beakerlib"
 version = "*"
 __EOF__

--- a/tests/cli/test_blueprints_sanity.sh
+++ b/tests/cli/test_blueprints_sanity.sh
@@ -31,6 +31,8 @@ rlJournalStart
 name = "beakerlib"
 description = "Start building tests with beakerlib."
 version = "0.0.1"
+modules = []
+groups = []
 
 [[modules]]
 name = "beakerlib"
@@ -39,6 +41,34 @@ __EOF__
 
         rlRun -t -c "$CLI blueprints push beakerlib.toml"
         rlAssertEquals "pushed bp is found via list" "`$CLI blueprints list | grep beakerlib`" "beakerlib"
+    rlPhaseEnd
+
+    rlPhaseStartTest "blueprints show"
+        rlAssertEquals "show displays blueprint in TOML" "`$CLI blueprints show beakerlib`" "`cat beakerlib.toml`"
+    rlPhaseEnd
+
+    rlPhaseStartTest "SemVer .patch version is incremented automatically"
+        # version is still 0.0.1
+        rlAssertEquals "version is 0.0.1" "`$CLI blueprints show beakerlib | grep 0.0.1`" 'version = "0.0.1"'
+        # add a new package to the existing blueprint
+        cat >> beakerlib.toml << __EOF__
+
+[[packages]]
+name = "php"
+version = "*"
+__EOF__
+        # push again
+        rlRun -t -c "$CLI blueprints push beakerlib.toml"
+        # official documentation says:
+        # If a new blueprint is uploaded with the same version the server will
+        # automatically bump the PATCH level of the version. If the version
+        # doesn't match it will be used as is.
+        rlAssertEquals "version is 0.0.2" "`$CLI blueprints show beakerlib | grep 0.0.2`" 'version = "0.0.2"'
+    rlPhaseEnd
+
+    rlPhaseStartTest "blueprints delete"
+        rlRun -t -c "$CLI blueprints delete beakerlib"
+        rlAssertEquals "bp not found after delete" "`$CLI blueprints list | grep beakerlib`" ""
     rlPhaseEnd
 
     rlPhaseStartTest "start a compose with deleted blueprint"

--- a/tests/cli/test_build_and_deploy_openstack.sh
+++ b/tests/cli/test_build_and_deploy_openstack.sh
@@ -52,11 +52,11 @@ name = "http-with-rng"
 description = "HTTP image for OpenStack with rng-tools"
 version = "0.0.1"
 
-[[modules]]
+[[packages]]
 name = "httpd"
 version = "*"
 
-[[modules]]
+[[packages]]
 name = "rng-tools"
 version = "*"
 __EOF__

--- a/tests/cli/test_build_and_deploy_vmware.sh
+++ b/tests/cli/test_build_and_deploy_vmware.sh
@@ -74,7 +74,7 @@ name = "vmware"
 description = "HTTP image for vmware"
 version = "0.0.1"
 
-[[modules]]
+[[packages]]
 name = "httpd"
 version = "*"
 

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -31,7 +31,7 @@ name = "with-ssh"
 description = "HTTP image with SSH"
 version = "0.0.1"
 
-[[modules]]
+[[packages]]
 name = "httpd"
 version = "*"
 

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -36,6 +36,11 @@ rlJournalStart
 
             rlRun -t -c "$CLI compose image $UUID"
             rlAssertExists "$UUID-root.tar.xz"
+
+            # because this path is listed in the documentation
+            rlAssertExists    "/var/lib/lorax/composer/results/$UUID/"
+            rlAssertExists    "/var/lib/lorax/composer/results/$UUID/root.tar.xz"
+            rlAssertNotDiffer "/var/lib/lorax/composer/results/$UUID/root.tar.xz" "$UUID-root.tar.xz"
         else
             rlFail "Compose UUID is empty!"
         fi


### PR DESCRIPTION
--- Description of proposed changes ---

Backports a few more sanity tests for blueprints and composes.

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
