### PR TITLE
Add test for starting compose with deleted blueprint

### DIFF
--- a/tests/cli/test_blueprints_sanity.sh
+++ b/tests/cli/test_blueprints_sanity.sh
@@ -41,5 +41,34 @@ __EOF__
         rlAssertEquals "pushed bp is found via list" "`$CLI blueprints list | grep beakerlib`" "beakerlib"
     rlPhaseEnd
 
+    rlPhaseStartTest "start a compose with deleted blueprint"
+        cat > to-be-deleted.toml << __EOF__
+name = "to-be-deleted"
+description = "Dummy blueprint for testing compose start with a deleted blueprint"
+version = "0.0.1"
+__EOF__
+
+        rlRun -t -c "$CLI blueprints push to-be-deleted.toml"
+        rlRun -t -c "$CLI blueprints delete to-be-deleted"
+        rlRun -t -c "$CLI compose list | grep to-be-deleted" 1
+        rlRun -t -c "$CLI blueprints list | grep to-be-deleted" 1
+        compose_id=$($CLI compose start to-be-deleted tar)
+        rlAssertEquals "composer-cli exited with 1 when starting a compose using a deleted blueprint" "$?" "1"
+        compose_id=$(echo $compose_id | cut -f 2 -d' ')
+
+        if [ -z "$compose_id" ]; then
+            rlPass "It wasn't possible to start a compose using a deleted blueprint."
+        else
+            rlFail "It was possible to start a compose using a deleted blueprint!"
+            # don't wait for the compose to finish if it started unexpectedly, and do cleanup
+            rlRun -t -c "$CLI compose cancel $compose_id"
+            rlRun -t -c "$CLI compose delete $compose_id"
+        fi
+
+        rlRun -t -c "rm -f to-be-deleted.toml"
+        unset compose_id
+    rlPhaseEnd
+
+
 rlJournalEnd
 rlJournalPrintText


### PR DESCRIPTION
Related: rhbz#1699303

--- Description of proposed changes ---




--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
