### PR TITLE
Use Cockpit's test images and infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.rpm
 src/pylorax/version.py*
 _build/
 tests/pylint/.pylint.d/
@@ -7,3 +8,7 @@ __pycache__/
 pylint-log
 .pytest_cache/
 .test-results/
+/lorax-*.tar.gz
+/bots
+/test/images
+/tmp

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,57 @@
+# Integration Tests
+
+lorax uses Cockpit's integration test framework and infrastructure. To do this,
+we're checking out Cockpit's `bots/` subdirectory. It contains links to test
+images and tools to manipulate and start virtual machines from them.
+
+Each test is run on a new instance of a virtual machine. 
+
+## Dependencies
+
+These dependencies are needed on Fedora to run tests locally:
+
+    $ sudo dnf install curl expect \
+        libvirt libvirt-client libvirt-daemon libvirt-python \
+        python python-libguestfs python-lxml libguestfs-xfs \
+        python3 libvirt-python3 \
+        libguestfs-tools qemu qemu-kvm rpm-build rsync xz
+
+## Building a test VM
+
+To build a test VM, run
+
+    $ make vm
+
+This downloads a base image from Cockpit's infrastructure. You can control
+which image is downloaded with the `TEST_OS` environment variable. Cockpit's
+[documentation](https://github.com/cockpit-project/cockpit/blob/master/test/README.md#test-configuration)
+lists accepted values. It then creates a new image based on that (a qemu
+snapshot) in `tests/images`, which contain the current `tests/` directory and
+have newly built rpms from the current checkout installed.
+
+To delete the generated image, run
+
+    $ make vm-reset
+
+Base images are stored in `bots/images`. Set `TEST_DATA` to override this
+directory.
+
+## Running tests
+
+After building a test image, run
+
+    $ ./test/check-cli [TESTNAME]
+
+or any of the other `check-*` scripts. Right after the VM is started, these
+scripts print an `ssh` line to connect to it.
+
+Run `make vm` after changing tests or lorax source to recreate the test
+machine. It is usually not necessary to reset the VM.
+
+## Updating images
+
+The `bots/` directory is checked out from Cockpit when `make vm` is first run.
+To get the latest images you need to update it manually (in order not to poll
+GitHub every time):
+
+    $ make -B bots

--- a/test/check-cli
+++ b/test/check-cli
@@ -1,0 +1,32 @@
+#!/usr/bin/python3
+
+import composertest
+
+
+class TestSanity(composertest.ComposerTestCase):
+    def test_blueprint_sanity(self):
+        self.runCliTest("/tests/cli/test_blueprints_sanity.sh")
+
+    def test_compose_sanity(self):
+        self.runCliTest("/tests/cli/test_compose_sanity.sh")
+
+
+class TestImages(composertest.ComposerTestCase):
+    def test_ext4_filesystem(self):
+        self.runCliTest("/tests/cli/test_compose_ext4-filesystem.sh")
+
+    def test_partitioned_disk(self):
+        self.runCliTest("/tests/cli/test_compose_partitioned-disk.sh")
+
+    def test_tar(self):
+        self.runCliTest("/tests/cli/test_compose_tar.sh")
+
+    def test_qcow2(self):
+        self.runCliTest("/tests/cli/test_compose_qcow2.sh")
+
+    def test_live_iso(self):
+        self.runCliTest("/tests/cli/test_compose_live-iso.sh")
+
+
+if __name__ == '__main__':
+    composertest.main()

--- a/test/check-cloud
+++ b/test/check-cloud
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+
+import composertest
+
+
+class TestCloud(composertest.ComposerTestCase):
+    def test_aws(self):
+        self.runCliTest("/tests/cli/test_build_and_deploy_aws.sh")
+
+    def test_azure(self):
+        self.runCliTest("/tests/cli/test_build_and_deploy_azure.sh")
+
+    def test_openstack(self):
+        self.runCliTest("/tests/cli/test_build_and_deploy_openstack.sh")
+
+    def test_vmware(self):
+        self.runCliTest("/tests/cli/test_build_and_deploy_vmware.sh")
+
+
+if __name__ == '__main__':
+    composertest.main()

--- a/test/composertest.py
+++ b/test/composertest.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+
+import os
+import subprocess
+import sys
+import unittest
+
+# import Cockpit's machinery for test VMs and its browser test API
+sys.path.append(os.path.join(os.path.dirname(__file__), "../bots/machine"))
+import testvm # pylint: disable=import-error
+
+
+class ComposerTestCase(unittest.TestCase):
+    image = testvm.DEFAULT_IMAGE
+
+    def setUp(self):
+        network = testvm.VirtNetwork(0)
+        self.machine = testvm.VirtMachine(self.image, networking=network.host(), memory_mb=2048)
+
+        print(f"Starting virtual machine '{self.image}'")
+        self.machine.start()
+        self.machine.wait_boot()
+
+        # run a command to force starting the SSH master
+        self.machine.execute("uptime")
+
+        self.ssh_command = ["ssh", "-o", "ControlPath=" + self.machine.ssh_master,
+                                   "-p", self.machine.ssh_port,
+                                   self.machine.ssh_user + "@" + self.machine.ssh_address]
+
+        print("Machine is up. Connect to it via:")
+        print(" ".join(self.ssh_command))
+        print()
+
+        print("Waiting for lorax-composer to become ready...")
+        curl_command = ["curl", "--max-time", "360",
+                                "--silent",
+                                "--unix-socket", "/run/weldr/api.socket",
+                                "http://localhost/api/status"]
+        r = subprocess.run(self.ssh_command + curl_command, stdout=subprocess.DEVNULL)
+        self.assertEqual(r.returncode, 0)
+
+    def tearDown(self):
+        self.machine.stop()
+
+    def execute(self, command, **args):
+        """Execute a command on the test machine.
+
+        **args and return value are the same as those for subprocess.run().
+        """
+        return subprocess.run(self.ssh_command + command, **args)
+
+    def runCliTest(self, script):
+        r = self.execute(["CLI=/usr/bin/composer-cli", "TEST=" + self.id(), "/tests/test_cli.sh", script])
+        self.assertEqual(r.returncode, 0)
+
+
+def main():
+    unittest.main(verbosity=2)

--- a/test/run
+++ b/test/run
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+# This is the expected entry point for Cockpit CI; will be called without
+# arguments but with an appropriate $TEST_OS, and optionally $TEST_SCENARIO
+
+make vm
+
+if [ -n "$TEST_SCENARIO" ]; then
+  test/check-cloud TestCloud.test_$TEST_SCENARIO
+else
+  test/check-cli
+fi

--- a/test/vm.install
+++ b/test/vm.install
@@ -1,0 +1,18 @@
+#!/bin/sh -eux
+
+SRPM="$1"
+
+# Grow root partition to make room for images. This only works on Fedora right now.
+echo ", +" | sfdisk -N 2 -f /dev/vda
+partprobe
+pvresize /dev/vda2
+lvresize fedora/root -l+100%FREE -r
+
+su builder -c "/usr/bin/mock --no-clean --resultdir build-results --rebuild $SRPM"
+
+packages=$(find build-results -name '*.rpm' -not -name '*.src.rpm')
+rpm -e $(basename -a ${packages[@]} | sed 's/-[0-9].*.rpm$//') || true
+yum install -y beakerlib $packages
+
+systemctl enable lorax-composer.socket
+systemctl enable docker.service

--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -11,13 +11,9 @@
 . ./tests/cli/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
-QEMU="/usr/bin/qemu-kvm"
+QEMU="/usr/bin/qemu-system-$(uname -m)"
 
 rlJournalStart
-    rlPhaseStartSetup
-        rlAssertExists $QEMU
-    rlPhaseEnd
-
     rlPhaseStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
 

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -11,13 +11,9 @@
 . ./tests/cli/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
-QEMU="/usr/bin/qemu-kvm"
+QEMU="/usr/bin/qemu-system-$(uname -m)"
 
 rlJournalStart
-    rlPhaseStartSetup
-        rlAssertExists $QEMU
-    rlPhaseEnd
-
     rlPhaseStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
 

--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -13,10 +13,6 @@ CLI="${CLI:-./src/bin/composer-cli}"
 
 
 rlJournalStart
-    rlPhaseStartSetup
-        rlAssertExists /usr/bin/docker
-    rlPhaseEnd
-
     rlPhaseStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
         UUID=`$CLI compose start example-http-server tar`
@@ -43,7 +39,7 @@ rlJournalStart
         rlRun -t -c "docker import $IMAGE composer/$UUID:latest"
 
         # verify we can run a container with this image
-        rlRun -t -c "docker run -it --rm --entrypoint /usr/bin/cat composer/$UUID /etc/redhat-release"
+        rlRun -t -c "docker run --rm --entrypoint /usr/bin/cat composer/$UUID /etc/redhat-release"
     rlPhaseEnd
 
     rlPhaseStartTest "Verify tar image with systemd-nspawn"

--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -48,7 +48,7 @@ rlJournalStart
 
     rlPhaseStartTest "Verify tar image with systemd-nspawn"
         if [ -f /usr/bin/systemd-nspawn ]; then
-            NSPAWN_DIR=`mktemp -d /tmp/nspawn.XXXX`
+            NSPAWN_DIR=`mktemp -d /var/tmp/nspawn.XXXX`
             rlRun -t -c "tar -xJvf $IMAGE -C $NSPAWN_DIR"
 
             # verify we can run a container with this image

--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -31,6 +31,13 @@ rlJournalStart
             rlFail "Compose UUID is empty!"
         fi
 
+        # Running a compose can lead to a different selinux policy in the
+        # kernel, which may break docker. Reload the policy from the host and
+        # restart docker as a workaround.
+        # See https://bugzilla.redhat.com/show_bug.cgi?id=1711813
+        semodule -R
+        systemctl restart docker
+
         rlRun -t -c "$CLI compose image $UUID"
         IMAGE="$UUID-root.tar.xz"
     rlPhaseEnd

--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -45,7 +45,7 @@ rlJournalStart
     rlPhaseStartTest "Verify tar image with systemd-nspawn"
         if [ -f /usr/bin/systemd-nspawn ]; then
             NSPAWN_DIR=`mktemp -d /var/tmp/nspawn.XXXX`
-            rlRun -t -c "tar -xJvf $IMAGE -C $NSPAWN_DIR"
+            rlRun -t -c "tar -xJf $IMAGE -C $NSPAWN_DIR"
 
             # verify we can run a container with this image
             rlRun -t -c "systemd-nspawn -D $NSPAWN_DIR cat /etc/redhat-release"

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -22,6 +22,10 @@ class LoraxLintConfig(PocketLintConfig):
         retval.remove("pocketlint.checkers.markup")
         return retval
 
+    @property
+    def ignoreNames(self):
+        return { "bots", "rpmbuild" }
+
 if __name__ == "__main__":
     conf = LoraxLintConfig()
     linter = PocketLinter(conf)

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -10,7 +10,6 @@ class LoraxLintConfig(PocketLintConfig):
 
         self.falsePositives = [ FalsePositive(r"Module 'pylorax' has no 'version' member"),
                                 FalsePositive(r"Catching too general exception Exception"),
-                                FalsePositive(r"^E0712.*: Catching an exception which doesn't inherit from (Base|)Exception: GError$"),
                                 FalsePositive(r"Module 'composer' has no 'version' member"),
                               ]
 

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -70,7 +70,7 @@ else
     # execute other cli tests which need more adjustments in the calling environment
     # or can't be executed inside Travis CI
     for TEST in "$@"; do
-        ./$TEST
+        $TEST
     done
 fi
 


### PR DESCRIPTION
Allows to run the tests on multiple operating systems and on the
infrastructure that the Cockpit team maintains.

`make vm` downloads one of Cockpit's test images (override which one
with TEST_OS) and installs a local build of lorax rpms. The resulting
image is placed in `test/images/$TEST_OS`.

TEST_OS can be set to any of Cockpit's supported images (default:
fedora-30).

Run `make check-vm` to run the CLI checks in the VM. The bulk of the
work is done in `test/check-cli`, which uses Cockpit's `bots` library to
start the VM and run the script in it.

Also included is a `test/run` script, which is the entrypoint for
Cockpit's test infrastructure.


--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!