### PR TITLE
tests: Cleanup on failure of in_tempdir

### DIFF
--- a/tests/pylorax/test_ltmpl.py
+++ b/tests/pylorax/test_ltmpl.py
@@ -84,9 +84,11 @@ def in_tempdir(prefix='tmp'):
     oldcwd = os.getcwd()
     tmpdir = tempfile.mkdtemp(prefix=prefix)
     os.chdir(tmpdir)
-    yield
-    os.chdir(oldcwd)
-    shutil.rmtree(tmpdir)
+    try:
+        yield
+    finally:
+        os.chdir(oldcwd)
+        shutil.rmtree(tmpdir)
 
 def makeFakeRPM(repo_dir, name, epoch, version, release, files=None):
     """Make a fake rpm file in repo_dir"""

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -1559,9 +1559,11 @@ def in_tempdir(prefix='tmp'):
     oldcwd = os.getcwd()
     tmpdir = tempfile.mkdtemp(prefix=prefix)
     os.chdir(tmpdir)
-    yield
-    os.chdir(oldcwd)
-    shutil.rmtree(tmpdir)
+    try:
+        yield
+    finally:
+        os.chdir(oldcwd)
+        shutil.rmtree(tmpdir)
 
 def makeFakeRPM(repo_dir, name, epoch, version, release):
     """Make a fake rpm file in repo_dir"""


### PR DESCRIPTION
Otherwise other tests will also fail when they try to run from the wrong
directory.

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
