### PR TITLE
Update VMware info for VMware testing

### DIFF
--- a/tests/cli/test_build_and_deploy_vmware.sh
+++ b/tests/cli/test_build_and_deploy_vmware.sh
@@ -35,10 +35,10 @@ rlJournalStart
         V_DATACENTER="${V_DATACENTER:-RH_Engineering}"
         rlLogInfo "V_DATACENTER=$V_DATACENTER"
 
-        V_CLUSTER="${V_CLUSTER:-SysMgmt_vMotion}"
+        V_CLUSTER="${V_CLUSTER:-vMotion-Cluster}"
         rlLogInfo "V_CLUSTER=$V_CLUSTER"
 
-        V_NETWORK="${V_NETWORK:-CEE_VM_Network}"
+        V_NETWORK="${V_NETWORK:-vMotion-Network}"
         rlLogInfo "V_NETWORK=$V_NETWORK"
 
         V_DATASTORE="${V_DATASTORE:-iSCSI-Node2}"
@@ -102,7 +102,7 @@ __EOF__
         fi
     rlPhaseEnd
 
-    rlPhaseStartTest "Upload vmdk image in vCenter"
+    rlPhaseStartTest "Upload VMDK image in vCenter"
         rlRun -t -c "$CLI compose image $UUID"
         IMAGE="$UUID-disk.vmdk"
 


### PR DESCRIPTION
--- Description of proposed changes ---

Cluster and Network changed due to new hardware in RDU2 DC

Related: rhbz#1678937

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
