### PR TITLE
Replace isoinfo with pycdlib

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -14,6 +14,7 @@ RUN  dnf -y install \
   python3-mock \
   python3-nose \
   python3-pocketlint \
+  python3-pycdlib \
   python3-pylint \
   python3-pyparted \
   python3-pytoml \

--- a/lorax.spec
+++ b/lorax.spec
@@ -49,6 +49,7 @@ Requires:       python3-mako
 Requires:       python3-kickstart >= 3.19
 Requires:       python3-dnf >= 3.2.0
 Requires:       python3-librepo
+Requires:       python3-pycdlib
 
 %if 0%{?fedora}
 # Fedora specific deps


### PR DESCRIPTION
isoinfo is part of genisoimage, which we no longer use, switch to using
a python library to read the label from the iso.