### PR TITLE
Use ansible instead of awscli

### DIFF
--- a/tests/cli/playbooks/aws/instance.yml
+++ b/tests/cli/playbooks/aws/instance.yml
@@ -1,0 +1,32 @@
+- hosts: localhost
+  tasks:
+  - name: Import SSH key pair
+    ec2_key:
+      name: "{{ key_name }}"
+      key_material: "{{ lookup('file', ssh_key_dir + '/id_rsa.pub') }}"
+
+  - name: Create instance
+    ec2_instance:
+      name: "{{ ami_id }}"
+      image_id: "{{ ami_id }}"
+      key_name: "{{ key_name }}"
+      instance_type: t2.small
+      security_group: allow-ssh
+      instance_initiated_shutdown_behavior: terminate
+      state: present
+    register: ec2
+
+  - name: Wait for SSH to come up
+    wait_for:
+      host: "{{ item.public_ip_address }}"
+      port: 22
+      state: started
+    with_items: "{{ ec2.instances }}"
+
+  - name: Save instance ID
+    local_action: copy content={{ item.instance_id }} dest={{ tmp_dir }}/instance_id
+    with_items: "{{ ec2.instances }}"
+
+  - name: Save public IP
+    local_action: copy content={{ item.public_ip_address }} dest={{ tmp_dir }}/public_ip
+    with_items: "{{ ec2.instances }}"

--- a/tests/cli/playbooks/aws/setup.yml
+++ b/tests/cli/playbooks/aws/setup.yml
@@ -1,0 +1,14 @@
+- hosts: localhost
+  tasks:
+  - name: Make sure bucket exists
+    aws_s3:
+      bucket: "{{ aws_bucket }}"
+      mode: create
+
+  - name: Make sure vmimport role exists
+    iam_role_facts:
+      name: vmimport
+    register: role_facts
+  - fail:
+      msg: "Role vmimport doesn't exist"
+    when: role_facts.iam_roles | length < 1


### PR DESCRIPTION
--- Description of proposed changes ---

The following parts of the script haven't been rewritten to ansible yet:
* Import of the image from S3 as a snapshot
* Registerring AMI image from the imported snapshot.

Ansible modules do not support importing an s3 object as a snapshot, reported as:
https://github.com/ansible/ansible/issues/53453

A possible workaround using the image_location parameter of the ec2_ami ansible module is being investigated.

--- Merge policy ---

- [ ] Travis CI PASS
- [x] `*-aws-runtest` PASS
- [x] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [x] `*-openstack-runtest` PASS
- [x] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
