### PR TITLE
Initialize BLUEPRINTS_DIR when testing RPMs

### DIFF
--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -45,6 +45,7 @@ if [ -z "$CLI" ]; then
     ./src/sbin/lorax-composer --sharedir $SHARE_DIR $BLUEPRINTS_DIR &
 else
     SHARE_DIR="/usr/share/lorax"
+    BLUEPRINTS_DIR="/var/lib/lorax/composer/blueprints"
     setup_tests $SHARE_DIR
     systemctl restart lorax-composer
 fi


### PR DESCRIPTION
--- Description of proposed changes ---

works around a problem where setup_tests() tries to modify existing
blueprints and can't find them.

Related: rhbz#1698368


--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
