### PR TITLE
tests: Source lib.sh from the right directory

### DIFF
--- a/test/check-cli
+++ b/test/check-cli
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import composertest
+import unittest
 
 
 class TestSanity(composertest.ComposerTestCase):
@@ -24,6 +25,7 @@ class TestImages(composertest.ComposerTestCase):
     def test_qcow2(self):
         self.runCliTest("/tests/cli/test_compose_qcow2.sh")
 
+    @unittest.skip("https://github.com/weldr/lorax/issues/731")
     def test_live_iso(self):
         self.runCliTest("/tests/cli/test_compose_live-iso.sh")
 

--- a/tests/cli/test_build_and_deploy_aws.sh
+++ b/tests/cli/test_build_and_deploy_aws.sh
@@ -8,7 +8,7 @@
 #####
 
 . /usr/share/beakerlib/beakerlib.sh
-. ./tests/cli/lib/lib.sh
+. $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
 

--- a/tests/cli/test_build_and_deploy_azure.sh
+++ b/tests/cli/test_build_and_deploy_azure.sh
@@ -8,7 +8,7 @@
 #####
 
 . /usr/share/beakerlib/beakerlib.sh
-. ./tests/cli/lib/lib.sh
+. $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
 

--- a/tests/cli/test_build_and_deploy_openstack.sh
+++ b/tests/cli/test_build_and_deploy_openstack.sh
@@ -8,7 +8,7 @@
 #####
 
 . /usr/share/beakerlib/beakerlib.sh
-. ./tests/cli/lib/lib.sh
+. $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
 

--- a/tests/cli/test_build_and_deploy_vmware.sh
+++ b/tests/cli/test_build_and_deploy_vmware.sh
@@ -8,7 +8,7 @@
 #####
 
 . /usr/share/beakerlib/beakerlib.sh
-. ./tests/cli/lib/lib.sh
+. $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
 

--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -8,7 +8,7 @@
 #####
 
 . /usr/share/beakerlib/beakerlib.sh
-. ./tests/cli/lib/lib.sh
+. $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
 QEMU="/usr/bin/qemu-system-$(uname -m)"

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -8,7 +8,7 @@
 #####
 
 . /usr/share/beakerlib/beakerlib.sh
-. ./tests/cli/lib/lib.sh
+. $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
 QEMU="/usr/bin/qemu-system-$(uname -m)"


### PR DESCRIPTION
When testing in one of the VMs, tests are in /tests. Source the lib from
a relative directory instead.