### PR TITLE
tests: Re-enable kvm

### DIFF
--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -11,7 +11,7 @@
 . ./tests/cli/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
-QEMU="/usr/bin/qemu-system-$(uname -m)"
+QEMU="qemu-system-$(uname -m) -machine accel=kvm:tcg"
 
 rlJournalStart
     rlPhaseStartTest "compose start"

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -11,7 +11,7 @@
 . ./tests/cli/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
-QEMU="/usr/bin/qemu-system-$(uname -m)"
+QEMU="qemu-system-$(uname -m) -machine accel=kvm:tcg"
 
 rlJournalStart
     rlPhaseStartTest "compose start"


### PR DESCRIPTION
In 303a69bc, we stopped using kvm, because it doesn't exist on all test
builders. Enable it again on those that have it.