### PR TITLE
test: Fix vm.install to be idempotent

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -8,10 +8,11 @@ partprobe
 pvresize /dev/vda2
 lvresize fedora/root -l+100%FREE -r
 
+rm -rf build-results
 su builder -c "/usr/bin/mock --no-clean --resultdir build-results --rebuild $SRPM"
 
 packages=$(find build-results -name '*.rpm' -not -name '*.src.rpm')
-rpm -e $(basename -a ${packages[@]} | sed 's/-[0-9].*.rpm$//') || true
+rpm -e --verbose $(basename -a ${packages[@]} | sed 's/-[0-9].*.rpm$//') || true
 yum install -y beakerlib $packages
 
 systemctl enable lorax-composer.socket


### PR DESCRIPTION
Clean build-results from the VM so that `make vm` can be run without
resetting.

Also be more verbose to catch rpm errors.