### PR TITLE
Fix path to generic.prm

### DIFF
--- a/share/templates.d/99-generic/live/s390.tmpl
+++ b/share/templates.d/99-generic/live/s390.tmpl
@@ -22,7 +22,7 @@ install ${configdir}/generic.ins .
 
 ## configure bootloader
 replace @INITRD_LOAD_ADDRESS@ ${INITRD_ADDRESS} generic.ins
-replace @EXTRA@ ${extra_boot_args} generic.prm
+replace @EXTRA@ '${extra_boot_args}' ${BOOTDIR}/generic.prm
 
 ## install kernel
 installkernel images-${basearch} ${kernel.path} ${KERNELDIR}/kernel.img


### PR DESCRIPTION
Also quote ${extra_boot_args} as in the other templates

Related: rhbz#1712822

--- Description of proposed changes ---




--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
