### PR TITLE
Revert "test: Disable test_live_iso test"

### DIFF
--- a/test/check-cli
+++ b/test/check-cli
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
 import composertest
-import unittest
 
 
 class TestImages(composertest.ComposerTestCase):
@@ -36,7 +35,6 @@ class TestQcow2(composertest.ComposerTestCase):
 
 
 class TestLiveIso(composertest.ComposerTestCase):
-    @unittest.skip("https://github.com/weldr/lorax/issues/731")
     def test_live_iso(self):
         self.runCliTest("/tests/cli/test_compose_live-iso.sh")
 


### PR DESCRIPTION
Enable the live-iso test again.

This reverts commit 1ac75e98b4910ff67df153c65a4f2e8f21389d02.