### PR TITLE
Enable cloud tests for Cockpit CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,10 @@ $(VM_IMAGE): srpm bots
 		--run-command "chmod +x /var/tmp/vm.install" \
 		--run-command "cd /var/tmp; /var/tmp/vm.install $$srpm" \
 		$(TEST_OS)
+	[ -f "~/.config/lorax-test-env" ] && bots/image-customize \
+		--upload ~/.config/lorax-test-env:/var/tmp/lorax-test-env \
+		$(TEST_OS) || echo
+
 
 # convenience target for the above
 vm: $(VM_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,6 @@ test:
 
 	coverage3 report -m
 	[ -f "/usr/bin/coveralls" ] && [ -n "$(COVERALLS_REPO_TOKEN)" ] && coveralls || echo
-	
-	./tests/test_cli.sh
 
 # need `losetup`, which needs Docker to be in privileged mode (--privileged)
 # but even so fails in Travis CI

--- a/test/README.md
+++ b/test/README.md
@@ -4,7 +4,9 @@ lorax uses Cockpit's integration test framework and infrastructure. To do this,
 we're checking out Cockpit's `bots/` subdirectory. It contains links to test
 images and tools to manipulate and start virtual machines from them.
 
-Each test is run on a new instance of a virtual machine. 
+Each test is run on a new instance of a virtual machine.
+Branch/test matrix is configured in `bots/tests-scan` inside the
+[cockpit repository](https://github.com/cockpit-project/cockpit).
 
 ## Dependencies
 

--- a/test/check-cli
+++ b/test/check-cli
@@ -4,15 +4,22 @@ import composertest
 import unittest
 
 
-class TestSanity(composertest.ComposerTestCase):
+class TestImages(composertest.ComposerTestCase):
+    """
+        This is the "entry-point" to the test suite when
+        executed in Cockpit CI. If $TEST_SCENARIO=="" or
+        $TEST_SCENARIO="images" we end up here.
+
+        New test methods should be added here first!
+        When this target becomes too slow we split out into
+        separate scenarios!
+    """
     def test_blueprint_sanity(self):
         self.runCliTest("/tests/cli/test_blueprints_sanity.sh")
 
     def test_compose_sanity(self):
         self.runCliTest("/tests/cli/test_compose_sanity.sh")
 
-
-class TestImages(composertest.ComposerTestCase):
     def test_ext4_filesystem(self):
         self.runCliTest("/tests/cli/test_compose_ext4-filesystem.sh")
 
@@ -22,9 +29,13 @@ class TestImages(composertest.ComposerTestCase):
     def test_tar(self):
         self.runCliTest("/tests/cli/test_compose_tar.sh")
 
+
+class TestQcow2(composertest.ComposerTestCase):
     def test_qcow2(self):
         self.runCliTest("/tests/cli/test_compose_qcow2.sh")
 
+
+class TestLiveIso(composertest.ComposerTestCase):
     @unittest.skip("https://github.com/weldr/lorax/issues/731")
     def test_live_iso(self):
         self.runCliTest("/tests/cli/test_compose_live-iso.sh")

--- a/test/composertest.py
+++ b/test/composertest.py
@@ -77,7 +77,10 @@ class ComposerTestCase(unittest.TestCase):
         return subprocess.run(self.ssh_command + command, **args)
 
     def runCliTest(self, script):
-        r = self.execute(["CLI=/usr/bin/composer-cli", "TEST=" + self.id(), "/tests/test_cli.sh", script])
+        r = self.execute(["CLI=/usr/bin/composer-cli",
+                          "TEST=" + self.id(),
+                          "PACKAGE=composer-cli",
+                          "/tests/test_cli.sh", script])
         self.assertEqual(r.returncode, 0)
 
 

--- a/test/run
+++ b/test/run
@@ -5,7 +5,13 @@
 make vm
 
 if [ -n "$TEST_SCENARIO" ]; then
-  test/check-cloud TestCloud.test_$TEST_SCENARIO
+  if [ "$TEST_SCENARIO" == "live-iso" ]; then
+    test/check-cli TestLiveIso
+  elif [ "$TEST_SCENARIO" == "qcow2" ]; then
+    test/check-cli TestQcow2
+  else
+    test/check-cloud TestCloud.test_$TEST_SCENARIO
+  fi
 else
-  test/check-cli
+  test/check-cli TestImages
 fi

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -53,6 +53,7 @@ if [ -z "$CLI" ]; then
     # start the lorax-composer daemon
     ./src/sbin/lorax-composer --sharedir $SHARE_DIR $BLUEPRINTS_DIR &
 else
+    export PACKAGE="composer-cli"
     SHARE_DIR="/usr/share/lorax"
     setup_tests $SHARE_DIR
     systemctl restart lorax-composer

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -29,6 +29,15 @@ function teardown_tests {
     mv $1/composer/live-iso.ks.orig $1/composer/live-iso.ks
 }
 
+# cloud credentials
+if [ -f "~/.config/lorax-test-env" ]; then
+    . ~/.config/lorax-test-env
+fi
+
+if [ -f "/var/tmp/lorax-test-env" ]; then
+    . /var/tmp/lorax-test-env
+fi
+
 if [ -z "$CLI" ]; then
     export top_srcdir=`pwd`
     . ./tests/testenv.sh


### PR DESCRIPTION
--- Description of proposed changes ---

As a started revert a few `rlAssert` statements which got deleted during the migration.

I will kick-off the cloud tests manually at first and add more commits here if necessary.


--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
