### PR TITLE
Update qemu arguments to work correctly with nographic

### DIFF
--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -46,7 +46,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Start VM instance"
-        rlRun -t -c "$QEMU -m 2048 -boot c -cdrom $IMAGE -nographic \
+        rlRun -t -c "$QEMU -m 2048 -boot d -cdrom $IMAGE -nographic -monitor none \
                            -net user,id=nic0,hostfwd=tcp::2222-:22 -net nic &"
         # 60 seconds timeout at boot menu screen
         # then media check + boot ~ 30 seconds

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -74,7 +74,7 @@ __EOF__
     rlPhaseEnd
 
     rlPhaseStartTest "Start VM instance"
-        rlRun -t -c "$QEMU -m 2048 -boot c -hda $IMAGE -nographic \
+        rlRun -t -c "$QEMU -m 2048 -boot c -hda $IMAGE -nographic -monitor none \
                            -net user,id=nic0,hostfwd=tcp::2222-:22 -net nic &"
         sleep 60
     rlPhaseEnd

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -32,7 +32,7 @@ function setup_tests {
     cat >> $blueprints_dir/example-http-server.toml << __EOF__
 
 [customizations.kernel]
-append = "custom_cmdline_arg"
+append = "custom_cmdline_arg console=ttyS0,115200n8"
 __EOF__
 }
 


### PR DESCRIPTION
Add -monitor none to turn off the qemu monitor multiplexing.
Pass -boot d for -cdrom booting instead of 'c'.

Add 'console=ttyS0,115200n8' to the boot arguments so that kernel output
will show up on the serial port.

--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
