### PR TITLE
test: Add --dry-run option to test/check* scripts

### DIFF
--- a/test/composertest.py
+++ b/test/composertest.py
@@ -81,9 +81,21 @@ class ComposerTestCase(unittest.TestCase):
         self.assertEqual(r.returncode, 0)
 
 
+def print_tests(tests):
+    for test in tests:
+        if isinstance(test, unittest.TestSuite):
+            print_tests(test)
+        elif isinstance(test, unittest.loader._FailedTest):
+            name = test.id().replace("unittest.loader._FailedTest.", "")
+            print(f"Error: '{name}' does not match a test", file=sys.stderr)
+        else:
+            print(test.id().replace("__main__.", ""))
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("tests", nargs="*", help="List of tests modules, classes, and methods")
+    parser.add_argument("-l", "--list", action="store_true", help="Print the list of tests that would be executed")
     parser.add_argument("-s", "--sit", action="store_true", help="Halt test execution (but keep VM running) when a test fails")
     args = parser.parse_args()
 
@@ -94,6 +106,10 @@ def main():
         tests = unittest.defaultTestLoader.loadTestsFromNames(args.tests, module)
     else:
         tests = unittest.defaultTestLoader.loadTestsFromModule(module)
+
+    if args.list:
+        print_tests(tests)
+        return 0
 
     runner = unittest.TextTestRunner(verbosity=2, failfast=args.sit)
     result = runner.run(tests)


### PR DESCRIPTION
Helps in figuring out which tests are in a file without having to open
it. Use like this:

    $ test/check-cli -n
    TestImages.test_live_iso
    TestImages.test_partitioned_disk
    TestImages.test_qcow2
    TestImages.test_tar
    TestSanity.test_blueprint_sanity
    TestSanity.test_compose_sanity

Names of classes containing multiple tests can be given, just like
normal:

    $ test/check-cli -n TestSanity
    TestSanity.test_blueprint_sanity
    TestSanity.test_compose_sanity