### PR TITLE
Fix for Azure test

### DIFF
--- a/tests/cli/test_build_and_deploy_azure.sh
+++ b/tests/cli/test_build_and_deploy_azure.sh
@@ -53,7 +53,8 @@ rlJournalStart
             rlAssertRpm python2-pip
         fi
 
-        rlRun -t -c "yum -y remove python*-requests python*-dateutil pyOpenSSL"
+        rlRun -t -c "rpm -e --nodeps pyOpenSSL"
+        rlRun -t -c "yum -y remove python*-requests python*-dateutil"
 
         rlRun -t -c "pip install --upgrade pip setuptools"
         rlRun -t -c "pip install ansible[azure] futures"


### PR DESCRIPTION
--- Description of proposed changes ---

the version coming from RPM is older and prevents installing
ansible[azure] via pip. OTOH removing with yum also removes
lorax-composer and breaks tests when running against the RPM
instead of git checkout (which will be the default with Cockpit CI).

Related: rhbz#1715003



--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
