### PR TITLE
composer: Don't reply with HTML on HTTP errors

### DIFF
--- a/src/pylorax/api/errors.py
+++ b/src/pylorax/api/errors.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# HTTP errors
+HTTP_ERROR = "HTTPError"
+
 # Returned from the API when either an invalid compose type is given, or not
 # compose type is given.
 BAD_COMPOSE_TYPE = "BadComposeType"

--- a/src/pylorax/api/server.py
+++ b/src/pylorax/api/server.py
@@ -21,9 +21,11 @@ from collections import namedtuple
 from flask import Flask, jsonify, redirect, send_from_directory
 from glob import glob
 import os
+import werkzeug
 
 from pylorax import vernum
 from pylorax.api.crossdomain import crossdomain
+from pylorax.api.errors import HTTP_ERROR
 from pylorax.api.v0 import v0_api
 from pylorax.sysutils import joinpaths
 
@@ -78,5 +80,9 @@ def v0_status():
                    schema_version="0",
                    db_supported=True,
                    msgs=server.config["TEMPLATE_ERRORS"])
+
+@server.errorhandler(werkzeug.exceptions.HTTPException)
+def bad_request(error):
+    return jsonify(status=False, errors=[{ "id": HTTP_ERROR, "code": error.code, "msg": error.name }]), error.code
 
 v0_api(server)

--- a/test/check-api
+++ b/test/check-api
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+
+import composertest
+import requests
+import subprocess
+
+
+class TestApi(composertest.ComposerTestCase):
+    """Test Composer HTTP API"""
+
+    def setUp(self):
+        super().setUp()
+
+        # Forward /run/weldr/api.socket to a port on the host
+        # Set ExitOnForwardFailure so that ssh blocks until the forward is set
+        # up before going to the background (-f), which it closes stdout. We
+        # wait for that by calling read() on it.
+        self.composer_port = self.network._lock(8080)
+        forwarder_command = [*self.ssh_command, "-fNT",
+                                                "-o", "ExitOnForwardFailure=yes",
+                                                "-L", f"localhost:{self.composer_port}:/run/weldr/api.socket"]
+        self.forwarder_proc = subprocess.Popen(forwarder_command, stdout=subprocess.PIPE)
+        self.forwarder_proc.stdout.read()
+
+    def tearDown(self):
+        self.forwarder_proc.terminate()
+        try:
+            self.forwarder_proc.wait(timeout=1)
+        except TimeoutError:
+            self.forwarder_proc.kill()
+        super().tearDown()
+
+    def request(self, method, path, check=True):
+        self.assertEqual(path[0], "/")
+        r = requests.request(method, f"http://localhost:{self.composer_port}{path}", timeout=30)
+        if check:
+            r.raise_for_status()
+        return r
+
+    def test_basic(self):
+        """Basic checks for the API"""
+
+        #
+        # API status without depsolve errors
+        #
+        status = self.request("GET", "/api/status").json()
+        self.assertEqual(status.keys(), { "build", "api", "db_version", "schema_version", "db_supported", "backend", "msgs" })
+        self.assertEqual(status["msgs"], [])
+
+        #
+        # HTTP errors should return json responses
+        #
+        r = self.request("GET", "/marmalade", check=False)
+        self.assertEqual(r.status_code, 404)
+        self.assertEqual(r.json(), {
+            "status": False,
+            "errors": [{ "id": "HTTPError", "code": 404, "msg": "Not Found" }]
+        })
+
+        r = self.request("POST", "/api/status", check=False)
+        self.assertEqual(r.status_code, 405)
+        self.assertEqual(r.json(), {
+            "status": False,
+            "errors": [{ "id": "HTTPError", "code": 405, "msg": "Method Not Allowed" }]
+        })
+
+
+if __name__ == '__main__':
+    composertest.main()

--- a/test/composertest.py
+++ b/test/composertest.py
@@ -28,8 +28,8 @@ class ComposerTestCase(unittest.TestCase):
     sit = False
 
     def setUp(self):
-        network = testvm.VirtNetwork(0)
-        self.machine = testvm.VirtMachine(self.image, networking=network.host(), memory_mb=2048)
+        self.network = testvm.VirtNetwork(0)
+        self.machine = testvm.VirtMachine(self.image, networking=self.network.host(), memory_mb=2048)
 
         print(f"Starting virtual machine '{self.image}'")
         self.machine.start()
@@ -58,7 +58,6 @@ class ComposerTestCase(unittest.TestCase):
         # Peek into internal data structure, because there's no way to get the
         # TestResult at this point. `errors` is a list of tuples (method, error)
         errors = filter(None, [ e[1] for e in self._outcome.errors ])
-
         if errors and self.sit:
             for e in errors:
                 print_exception(*e)

--- a/test/run
+++ b/test/run
@@ -14,4 +14,5 @@ if [ -n "$TEST_SCENARIO" ]; then
   fi
 else
   test/check-cli TestImages
+  test/check-api
 fi

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -1553,6 +1553,26 @@ class ServerTestCase(unittest.TestCase):
         self.assertTrue(len(data["errors"]) > 0)
         self.assertEqual(data["errors"][0]["id"], "UnknownBlueprint")
 
+    def test_404(self):
+        """Test that a 404 returns JSON"""
+        resp = self.server.get("/marmalade")
+        print(resp)
+        print(resp.data)
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(json.loads(resp.data), {
+            "status": False,
+            "errors": [{ "id": "HTTPError", "code": 404, "msg": "Not Found" }]
+        })
+
+    def test_405(self):
+        """Test that a 405 returns JSON"""
+        resp = self.server.post("/api/status")
+        self.assertEqual(resp.status_code, 405)
+        self.assertEqual(json.loads(resp.data), {
+            "status": False,
+            "errors": [{ "id": "HTTPError", "code": 405, "msg": "Method Not Allowed" }]
+        })
+
 @contextmanager
 def in_tempdir(prefix='tmp'):
     """Execute a block of code with chdir in a temporary location"""


### PR DESCRIPTION
Override flask's default error handler, because that returns html. Return JSON instead with the usual `{ "status": false, "errors": [ ... ] }` pattern.

Also add a new integration test `check-api` which tests this change. 