### PR TITLE
Minor changes and rlAssert reverts

### DIFF
--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -11,9 +11,14 @@
 . $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
-QEMU="qemu-system-$(uname -m) -machine accel=kvm:tcg"
+QEMU_BIN="/usr/bin/qemu-system-$(uname -m)"
+QEMU="$QEMU_BIN -machine accel=kvm:tcg"
 
 rlJournalStart
+    rlPhaseStartSetup
+        rlAssertExists $QEMU_BIN
+    rlPhaseEnd
+
     rlPhaseStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
 

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -11,9 +11,14 @@
 . $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
-QEMU="qemu-system-$(uname -m) -machine accel=kvm:tcg"
+QEMU_BIN="/usr/bin/qemu-system-$(uname -m)"
+QEMU="$QEMU_BIN -machine accel=kvm:tcg"
 
 rlJournalStart
+    rlPhaseStartSetup
+        rlAssertExists $QEMU_BIN
+    rlPhaseEnd
+
     rlPhaseStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
 

--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -13,6 +13,10 @@ CLI="${CLI:-./src/bin/composer-cli}"
 
 
 rlJournalStart
+    rlPhaseStartSetup
+        rlAssertExists /usr/bin/docker
+    rlPhaseEnd
+
     rlPhaseStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
         UUID=`$CLI compose start example-http-server tar`

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -64,10 +64,10 @@ fi
 tries=0
 until curl -m 15 --unix-socket /run/weldr/api.socket http://localhost:4000/api/status | grep 'db_supported.*true'; do
     tries=$((tries + 1))
-    if [ $tries -gt 20 ]; then
+    if [ $tries -gt 50 ]; then
         exit 1
     fi
-    sleep 2
+    sleep 5
     echo "DEBUG: Waiting for backend API to become ready before testing ..."
 done;
 


### PR DESCRIPTION
--- Description of proposed changes ---

Pushing these back since they were originally part of #735 but later removed. We (QE) do actually like to have these `rlAssert` statements b/c they more clearly show to us when something is missing. 

FTR on the console you can see that a command you try to execute doesn't exist, this is show in the first part of the output (call it raw test output) and then when done beakerlib shows a more summarized output (which they call the test protocol).

Although ATM beakerlib doesn't fail the test script immediately on `rlAssert` failures I still think these are useful. And they don't hurt definitely.


--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
