### PR TITLE
[don't merge] Fix VMware not consistent biosdevname issue

### DIFF
--- a/share/composer/vmdk.ks
+++ b/share/composer/vmdk.ks
@@ -5,7 +5,7 @@ firewall --enabled
 
 # NOTE: The root account is locked by default
 # Network information
-network  --bootproto=dhcp --onboot=on --activate
+network  --bootproto=dhcp --onboot=on --activate --device=eth0
 # System keyboard
 keyboard --xlayouts=us --vckeymap=us
 # System language
@@ -19,7 +19,7 @@ shutdown
 # System timezone
 timezone  US/Eastern
 # System bootloader configuration
-bootloader --location=mbr
+bootloader --location=mbr --append="net.ifnames=0 biosdevname=0"
 
 # Basic services
 services --enabled=sshd,chronyd,vmtoolsd


### PR DESCRIPTION
--- Description of proposed changes ---

PR to attempt to fix VMware tests and have the image pick up an IP


--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
