### PR TITLE
Allow failing tests on first assert 

### DIFF
--- a/test/composertest.py
+++ b/test/composertest.py
@@ -76,9 +76,14 @@ class ComposerTestCase(unittest.TestCase):
         return subprocess.run(self.ssh_command + command, **args)
 
     def runCliTest(self, script):
+        extra_env = []
+        if self.sit:
+            extra_env.append("COMPOSER_TEST_FAIL_FAST=1")
+
         r = self.execute(["CLI=/usr/bin/composer-cli",
                           "TEST=" + self.id(),
                           "PACKAGE=composer-cli",
+                          *extra_env,
                           "/tests/test_cli.sh", script])
         self.assertEqual(r.returncode, 0)
 

--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+# Monkey-patch beakerlib to exit on first failure if COMPOSER_TEST_FAIL_FAST is
+# set. https://github.com/beakerlib/beakerlib/issues/42
+if [ "$COMPOSER_TEST_FAIL_FAST" == "1" ]; then
+  eval "original$(declare -f __INTERNAL_LogAndJournalFail)"
+
+  __INTERNAL_LogAndJournalFail () {
+    original__INTERNAL_LogAndJournalFail
+
+    # end test somewhat cleanly so that beakerlib logs the FAIL correctly
+    rlPhaseEnd
+    rlJournalEnd
+
+    exit 1
+  }
+fi
+
 # a generic helper function unifying the specific checks executed on a running
 # image instance
 verify_image() {

--- a/tests/cli/test_blueprints_sanity.sh
+++ b/tests/cli/test_blueprints_sanity.sh
@@ -4,6 +4,7 @@
 set -e
 
 . /usr/share/beakerlib/beakerlib.sh
+. $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
 

--- a/tests/cli/test_compose_ext4-filesystem.sh
+++ b/tests/cli/test_compose_ext4-filesystem.sh
@@ -12,6 +12,7 @@
 set -e
 
 . /usr/share/beakerlib/beakerlib.sh
+. $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
 

--- a/tests/cli/test_compose_google.sh
+++ b/tests/cli/test_compose_google.sh
@@ -9,6 +9,7 @@
 set -e
 
 . /usr/share/beakerlib/beakerlib.sh
+. $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
 

--- a/tests/cli/test_compose_partitioned-disk.sh
+++ b/tests/cli/test_compose_partitioned-disk.sh
@@ -12,6 +12,7 @@
 set -e
 
 . /usr/share/beakerlib/beakerlib.sh
+. $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
 

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -4,6 +4,7 @@
 set -e
 
 . /usr/share/beakerlib/beakerlib.sh
+. $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
 

--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -10,6 +10,7 @@
 set -e
 
 . /usr/share/beakerlib/beakerlib.sh
+. $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
 

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -3,8 +3,7 @@
 
 set -eu
 
-# setup
-rm -rf /var/tmp/beakerlib-*/
+export BEAKERLIB_DIR=$(mktemp -d /tmp/composer-test.XXXXXX)
 
 function setup_tests {
     local share_dir=$1
@@ -103,8 +102,11 @@ else
     systemctl start lorax-composer
 fi
 
-# look for failures
-grep RESULT_STRING /var/tmp/beakerlib-*/TestResults | grep -v PASS && exit 1
+. $BEAKERLIB_DIR/TestResults
 
-# explicit return code for Makefile
-exit 0
+if [ $TESTRESULT_RESULT_ECODE != 0 ]; then
+  echo "Test failed. Leaving log in $BEAKERLIB_DIR"
+  exit $TESTRESULT_RESULT_ECODE
+fi
+
+rm -rf $BEAKERLIB_DIR


### PR DESCRIPTION
Beakerlib upstream can't do this yet, but might at some point:

    https://github.com/beakerlib/beakerlib/issues/42

This is only enabled in combination with the `--sit` option of the
`test/check-*` scripts. It leaves the system in exacly the state it was
in when an assertion failed. Finishing the test run would run cleanup as
well (such as deleting created images). It also takes longer.