### PR TITLE
Strip newlines from SSH keys before passing to ks

### DIFF
--- a/src/pylorax/api/compose.py
+++ b/src/pylorax/api/compose.py
@@ -494,7 +494,7 @@ def write_ks_root(f, user):
 
     # ssh key uses the sshkey kickstart command
     if "key" in user:
-        f.write('sshkey --user %s "%s"\n' % (user["name"], user["key"]))
+        f.write('sshkey --user %s "%s"\n' % (user["name"], user["key"].strip()))
 
     if "password" in user:
         if any(user["password"].startswith(prefix) for prefix in ["$2b$", "$6$", "$5$"]):
@@ -522,7 +522,7 @@ def write_ks_user(f, user):
     """
     # ssh key uses the sshkey kickstart command
     if "key" in user:
-        f.write('sshkey --user %s "%s"\n' % (user["name"], user["key"]))
+        f.write('sshkey --user %s "%s"\n' % (user["name"], user["key"].strip()))
 
     # Write out the user kickstart command, much of it is optional
     f.write("user --name %s" % user["name"])
@@ -606,7 +606,7 @@ def add_customizations(f, recipe):
             if "user" not in sshkey or "key" not in sshkey:
                 log.error("%s is incorrect, skipping", sshkey)
                 continue
-            f.write('sshkey --user %s "%s"\n' % (sshkey["user"], sshkey["key"]))
+            f.write('sshkey --user %s "%s"\n' % (sshkey["user"], sshkey["key"].strip()))
 
     # Creating a user also creates a group. Make a list of the names for later
     user_groups = []


### PR DESCRIPTION
OpenSSH puts a newline at the end of public key files, so currently, copying and pasting the entire file into the SSH key field via `xsel -ib < ~/.ssh/id_rsa.pub` screws up the kickstart parse and throws a strange error.

--- Description of proposed changes ---




--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
