### PR TITLE
 [tests] Handle blueprints in setup_tests/teardown_tests correctly - fix for rhbz#1714298

### DIFF
--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -19,6 +19,12 @@ function setup_tests {
         {print}" \
         $share_dir/composer/live-iso.ks
 
+    # do a backup of the original blueprints directory and get rid of the git
+    # directory (otherwise all of the initial changes in blueprints would have
+    # to be done using blueprints push)
+    cp -r $blueprints_dir ${blueprints_dir}.orig
+    rm -rf $blueprints_dir/git
+
     # append a section with additional option on kernel command line to example-http-server blueprint
     # which is used for building of most of the images
     cat >> $blueprints_dir/example-http-server.toml << __EOF__
@@ -29,7 +35,12 @@ __EOF__
 }
 
 function teardown_tests {
-    mv $1/composer/live-iso.ks.orig $1/composer/live-iso.ks
+    local share_dir=$1
+    local blueprints_dir=$2
+
+    mv $share_dir/composer/live-iso.ks.orig $share_dir/composer/live-iso.ks
+    rm -rf $blueprints_dir
+    mv ${blueprints_dir}.orig $blueprints_dir
 }
 
 if [ -z "$CLI" ]; then
@@ -48,8 +59,9 @@ if [ -z "$CLI" ]; then
     ./src/sbin/lorax-composer --sharedir $SHARE_DIR $BLUEPRINTS_DIR &
 else
     export PACKAGE="composer-cli"
+    systemctl stop lorax-composer
     setup_tests /usr/share/lorax /var/lib/lorax/composer/blueprints
-    systemctl restart lorax-composer
+    systemctl start lorax-composer
 fi
 
 
@@ -85,10 +97,10 @@ if [ -z "$CLI" ]; then
     # only if running against source
     pkill -9 lorax-composer
     rm -f /run/weldr/api.socket
-    teardown_tests $SHARE_DIR
+    teardown_tests $SHARE_DIR $BLUEPRINTS_DIR
 else
     systemctl stop lorax-composer
-    teardown_tests /usr/share/lorax
+    teardown_tests /usr/share/lorax /var/lib/lorax/composer/blueprints
     # start lorax-composer again so we can continue with manual or other kinds
     # of testing on the same system
     systemctl start lorax-composer

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -5,20 +5,23 @@
 rm -rf /var/tmp/beakerlib-*/
 
 function setup_tests {
+    local share_dir=$1
+    local blueprints_dir=$2
+
     # explicitly enable sshd for live-iso b/c it is disabled by default
     # due to security concerns (no root password required)
-    sed -i.orig 's/^services.*/services --disabled="network" --enabled="NetworkManager,sshd"/' $1/composer/live-iso.ks
+    sed -i.orig 's/^services.*/services --disabled="network" --enabled="NetworkManager,sshd"/' $share_dir/composer/live-iso.ks
     # explicitly enable logging in with empty passwords via ssh, because
     # the default sshd setting for PermitEmptyPasswords is 'no'
     awk -i inplace "
         /%post/ && FLAG != 2 {FLAG=1}
         /%end/ && FLAG == 1 {print \"sed -i 's/.*PermitEmptyPasswords.*/PermitEmptyPasswords yes/' /etc/ssh/sshd_config\"; FLAG=2}
         {print}" \
-        $1/composer/live-iso.ks
+        $share_dir/composer/live-iso.ks
 
     # append a section with additional option on kernel command line to example-http-server blueprint
     # which is used for building of most of the images
-    cat >> $BLUEPRINTS_DIR/example-http-server.toml << __EOF__
+    cat >> $blueprints_dir/example-http-server.toml << __EOF__
 
 [customizations.kernel]
 append = "custom_cmdline_arg"
@@ -40,12 +43,12 @@ if [ -z "$CLI" ]; then
     cp -R ./share/* $SHARE_DIR
     chmod a+rx -R $SHARE_DIR
 
-    setup_tests $SHARE_DIR
+    setup_tests $SHARE_DIR $BLUEPRINTS_DIR
     # start the lorax-composer daemon
     ./src/sbin/lorax-composer --sharedir $SHARE_DIR $BLUEPRINTS_DIR &
 else
-    SHARE_DIR="/usr/share/lorax"
-    setup_tests $SHARE_DIR
+    export PACKAGE="composer-cli"
+    setup_tests /usr/share/lorax /var/lib/lorax/composer/blueprints
     systemctl restart lorax-composer
 fi
 
@@ -85,7 +88,7 @@ if [ -z "$CLI" ]; then
     teardown_tests $SHARE_DIR
 else
     systemctl stop lorax-composer
-    teardown_tests $SHARE_DIR
+    teardown_tests /usr/share/lorax
     # start lorax-composer again so we can continue with manual or other kinds
     # of testing on the same system
     systemctl start lorax-composer


### PR DESCRIPTION
--- Description of proposed changes ---


--- Merge policy ---

- [ ] Travis CI PASS
- [ ] `*-aws-runtest` PASS
- [ ] `*-azure-runtest` PASS
- [ ] `*-images-runtest` PASS
- [ ] `*-openstack-runtest` PASS
- [ ] `*-vmware-runtest` PASS
- [ ] For `rhel8-*` and `rhel7-*` branches commit log references an approved
  bug in Bugzilla. Do not merge if the bug doesn't have the 3 ACKs set to `+`!

--- Jenkins commands ---

- `ok to test` to accept this pull request for testing
- `test this please` for a one time test run
- `retest this please` to start a new build
