### PR TITLE
[don't merge] Fix VMware not consistent biosdevname issue

### DIFF
--- a/share/composer/vmdk.ks
+++ b/share/composer/vmdk.ks
@@ -5,7 +5,7 @@ firewall --enabled
 
 # NOTE: The root account is locked by default
 # Network information
-network  --bootproto=dhcp --onboot=on --activate
+network  --bootproto=dhcp --onboot=on --activate --device=eth0
 # NOTE: keyboard and lang can be replaced by blueprint customizations.locale settings
 # System keyboard
 keyboard --xlayouts=us --vckeymap=us
@@ -18,7 +18,7 @@ logging --level=info
 # Shutdown after installation
 shutdown
 # System bootloader configuration
-bootloader --location=mbr
+bootloader --location=mbr --append="net.ifnames=0 biosdevname=0"
 # Add platform specific partitions
 reqpart --add-boot
 


### PR DESCRIPTION
--- Description of proposed changes ---

Cherry-pick #748 onto master b/c in (from #754)
https://209.132.184.41:8493/logs/pull-754-20190611-132929-55616c2c-cockpit-fedora-30-vmware/log

we see vmware VM failing to get an IP address.

Opening this PR so we can see the changes tested in the new CI system.

CC @chris1984 