### PR TITLE
[don't merge] test_compose_tar: Fix docker test

### DIFF
--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -15,6 +15,7 @@ CLI="${CLI:-./src/bin/composer-cli}"
 rlJournalStart
     rlPhaseStartSetup
         rlAssertExists /usr/bin/docker
+        rlRun -t -c "systemctl restart docker"
     rlPhaseEnd
 
     rlPhaseStartTest "compose start"
@@ -43,7 +44,7 @@ rlJournalStart
         rlRun -t -c "docker import $IMAGE composer/$UUID:latest"
 
         # verify we can run a container with this image
-        rlRun -t -c "docker run -it --rm --entrypoint /usr/bin/cat composer/$UUID /etc/redhat-release"
+        rlRun -t -c "docker run --rm --entrypoint /usr/bin/cat composer/$UUID /etc/redhat-release"
     rlPhaseEnd
 
     rlPhaseStartTest "Verify tar image with systemd-nspawn"


### PR DESCRIPTION
The docker phase always failed because `-ti` was passed even though the
the output was not a terminal. Moreover docker service isn't running by
default on RHEL-7, so it's necessary to start it first explicitly.

Also remove the check for /usr/bin/docker in the setup phase. It didn't
test that the daemon was running. More importantly, it didn't abort the
test anwyay (and there doesn't seem to be a good way to do this in
beakerlib).

Related: rhbz#1720224