### PR TITLE
Switch to new toml library

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -132,14 +132,14 @@ Lorax templates for creating the boot.iso and live isos are placed in
 %package composer
 Summary: Lorax Image Composer API Server
 # For Sphinx documentation build
-BuildRequires: python3-flask python3-gobject libgit2-glib python3-pytoml python3-semantic_version
+BuildRequires: python3-flask python3-gobject libgit2-glib python3-toml python3-semantic_version
 
 Requires: lorax = %{version}-%{release}
 Requires(pre): /usr/bin/getent
 Requires(pre): /usr/sbin/groupadd
 Requires(pre): /usr/sbin/useradd
 
-Requires: python3-pytoml
+Requires: python3-toml
 Requires: python3-semantic_version
 Requires: libgit2
 Requires: libgit2-glib

--- a/src/pylorax/api/compose.py
+++ b/src/pylorax/api/compose.py
@@ -37,7 +37,6 @@ import os
 from glob import glob
 from io import StringIO
 from math import ceil
-import pytoml as toml
 import shutil
 from uuid import uuid4
 
@@ -51,6 +50,7 @@ from pylorax.api.projects import projects_depsolve, projects_depsolve_with_size,
 from pylorax.api.projects import ProjectsError
 from pylorax.api.recipes import read_recipe_and_id
 from pylorax.api.timestamp import TS_CREATED, write_timestamp
+import pylorax.api.toml as toml
 from pylorax.base import DataHolder
 from pylorax.imgutils import default_image_name
 from pylorax.ltmpl import LiveTemplateRunner

--- a/src/pylorax/api/queue.py
+++ b/src/pylorax/api/queue.py
@@ -21,7 +21,6 @@ import os
 import grp
 from glob import glob
 import multiprocessing as mp
-import pytoml as toml
 import pwd
 import shutil
 import subprocess
@@ -32,6 +31,7 @@ from pylorax import find_templates
 from pylorax.api.compose import move_compose_results
 from pylorax.api.recipes import recipe_from_file
 from pylorax.api.timestamp import TS_CREATED, TS_STARTED, TS_FINISHED, write_timestamp, timestamp_dict
+import pylorax.api.toml as toml
 from pylorax.base import DataHolder
 from pylorax.creator import run_creator
 from pylorax.sysutils import joinpaths

--- a/src/pylorax/api/recipes.py
+++ b/src/pylorax/api/recipes.py
@@ -22,12 +22,12 @@ from gi.repository import Gio
 from gi.repository import GLib
 
 import os
-import pytoml as toml
 import semantic_version as semver
 
 from pylorax.api.projects import dep_evra
 from pylorax.base import DataHolder
 from pylorax.sysutils import joinpaths
+import pylorax.api.toml as toml
 
 
 class CommitTimeValError(Exception):

--- a/src/pylorax/api/timestamp.py
+++ b/src/pylorax/api/timestamp.py
@@ -15,10 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import pytoml as toml
 import time
 
 from pylorax.sysutils import joinpaths
+import pylorax.api.toml as toml
 
 TS_CREATED  = "created"
 TS_STARTED  = "started"

--- a/src/pylorax/api/toml.py
+++ b/src/pylorax/api/toml.py
@@ -1,0 +1,32 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import toml
+
+class TomlError(toml.TomlDecodeError):
+    pass
+
+def loads(s):
+    if isinstance(s, bytes):
+        s = s.decode('utf-8')
+    try:
+        return toml.loads(s)
+    except toml.TomlDecodeError as e:
+        raise TomlError(e.msg, e.doc, e.pos)
+
+def dumps(o):
+    return toml.dumps(o, encoder=toml.TomlEncoder(dict))

--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -54,7 +54,6 @@ log = logging.getLogger("lorax-composer")
 import os
 from flask import jsonify, request, Response, send_file
 from flask import current_app as api
-import pytoml as toml
 
 from pylorax.sysutils import joinpaths
 from pylorax.api.checkparams import checkparams
@@ -70,6 +69,7 @@ from pylorax.api.recipes import RecipeError, list_branch_files, read_recipe_comm
 from pylorax.api.recipes import recipe_from_dict, recipe_from_toml, commit_recipe, delete_recipe, revert_recipe
 from pylorax.api.recipes import tag_recipe_commit, recipe_diff, RecipeFileError
 from pylorax.api.regexes import VALID_API_STRING
+import pylorax.api.toml as toml
 from pylorax.api.workspace import workspace_read, workspace_write, workspace_delete
 
 # The API functions don't actually get called by any code here

--- a/tests/pylorax/test_gitrpm.py
+++ b/tests/pylorax/test_gitrpm.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import os
-import pytoml as toml
 import rpm
 import shutil
 import stat
@@ -25,6 +24,7 @@ import unittest
 
 from ..lib import create_git_repo
 from pylorax.api.gitrpm import GitArchiveTarball, GitRpmBuild, make_git_rpm, create_gitrpm_repo
+import pylorax.api.toml as toml
 from pylorax.sysutils import joinpaths
 
 class GitArchiveTest(unittest.TestCase):

--- a/tests/pylorax/test_recipes.py
+++ b/tests/pylorax/test_recipes.py
@@ -16,13 +16,13 @@
 #
 import os
 import mock
-from pytoml import TomlError
 import shutil
 import tempfile
 import unittest
 
 import pylorax.api.recipes as recipes
 from pylorax.api.compose import add_customizations, customize_ks_template
+from pylorax.api.toml import TomlError
 from pylorax.sysutils import joinpaths
 
 from pykickstart.parser import KickstartParser
@@ -721,7 +721,7 @@ version = "2.7.*"
             recipes.commit_recipe_directory(self.repo, "master", self.examples_path)
 
         # try to commit while raising TomlError
-        with mock.patch('pylorax.api.recipes.commit_recipe_file', side_effect=TomlError('TESTING', 0, 0, '__test__')):
+        with mock.patch('pylorax.api.recipes.commit_recipe_file', side_effect=TomlError('TESTING', "", 0)):
             recipes.commit_recipe_directory(self.repo, "master", self.examples_path)
 
         # verify again that the newly created file isn't present b/c we raised an exception

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -27,13 +27,13 @@ from threading import Lock
 import unittest
 
 from flask import json
-import pytoml as toml
 from ..lib import create_git_repo
 from pylorax.api.config import configure, make_dnf_dirs, make_queue_dirs
 from pylorax.api.errors import *                               # pylint: disable=wildcard-import
 from pylorax.api.queue import start_queue_monitor
 from pylorax.api.recipes import open_or_create_repo, commit_recipe_directory
 from pylorax.api.server import server, GitLock
+import pylorax.api.toml as toml
 from pylorax.api.dnfbase import DNFLock
 from pylorax.sysutils import joinpaths
 


### PR DESCRIPTION
The previous library, pytoml from https://github.com/avakar/pytoml is no
longer supported. So this adds a compatibility layer on top of the
suggested replacement, toml from https://github.com/uiri/toml