### PR TITLE
Enable networking in lorax-composer templates

### DIFF
--- a/share/composer/ami.ks
+++ b/share/composer/ami.ks
@@ -44,6 +44,8 @@ sed -i 's/cloud-user/ec2-user/' /etc/cloud/cloud.cfg
 %packages
 kernel
 -dracut-config-rescue
+# Enable networking by removing the config file that disables it
+-NetworkManager-config-server
 
 grub2
 

--- a/share/composer/ext4-filesystem.ks
+++ b/share/composer/ext4-filesystem.ks
@@ -33,5 +33,7 @@ touch /etc/machine-id
 %packages --nobase
 # Packages requires to support this output format go here
 selinux-policy-targeted
+# Enable networking by removing the config file that disables it
+-NetworkManager-config-server
 
 # NOTE lorax-composer will add the blueprint packages below here, including the final %end

--- a/share/composer/live-iso.ks
+++ b/share/composer/live-iso.ks
@@ -348,6 +348,8 @@ memtest86+
 syslinux
 -dracut-config-rescue
 selinux-policy-targeted
+# Enable networking by removing the config file that disables it
+-NetworkManager-config-server
 
 # This package is needed to boot the iso on UEFI
 shim

--- a/share/composer/openstack.ks
+++ b/share/composer/openstack.ks
@@ -37,6 +37,8 @@ touch /etc/machine-id
 kernel
 -dracut-config-rescue
 grub2
+# Enable networking by removing the config file that disables it
+-NetworkManager-config-server
 
 # Make sure virt guest agents are installed
 qemu-guest-agent

--- a/share/composer/partitioned-disk.ks
+++ b/share/composer/partitioned-disk.ks
@@ -37,5 +37,7 @@ kernel
 -dracut-config-rescue
 selinux-policy-targeted
 grub2
+# Enable networking by removing the config file that disables it
+-NetworkManager-config-server
 
 # NOTE lorax-composer will add the blueprint packages below here, including the final %end

--- a/share/composer/qcow2.ks
+++ b/share/composer/qcow2.ks
@@ -37,6 +37,8 @@ kernel
 -dracut-config-rescue
 selinux-policy-targeted
 grub2
+# Enable networking by removing the config file that disables it
+-NetworkManager-config-server
 
 # Make sure virt guest agents are installed
 qemu-guest-agent

--- a/share/composer/tar.ks
+++ b/share/composer/tar.ks
@@ -34,5 +34,7 @@ touch /etc/machine-id
 %packages
 # Packages requires to support this output format go here
 selinux-policy-targeted
+# Enable networking by removing the config file that disables it
+-NetworkManager-config-server
 
 # NOTE lorax-composer will add the blueprint packages below here, including the final %end

--- a/share/composer/vhd.ks
+++ b/share/composer/vhd.ks
@@ -61,6 +61,8 @@ dracut -f -v --persistent-policy by-uuid
 %packages
 kernel
 -dracut-config-rescue
+# Enable networking by removing the config file that disables it
+-NetworkManager-config-server
 
 grub2
 

--- a/share/composer/vmdk.ks
+++ b/share/composer/vmdk.ks
@@ -36,6 +36,8 @@ touch /etc/machine-id
 %packages
 kernel
 -dracut-config-rescue
+# Enable networking by removing the config file that disables it
+-NetworkManager-config-server
 
 grub2
 


### PR DESCRIPTION
Because anaconda --dirinstall is used the kickstart's network like isn't
processed at all. So we need to remove the NetworkManager-server-config
package which disables networking.

Resolves: rhbz#1710877