### PR TITLE
Do not generate journal.xml from beakerlib

### DIFF
--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -88,6 +88,7 @@ until curl -m 15 --unix-socket /run/weldr/api.socket http://localhost:4000/api/s
 done;
 
 
+export BEAKERLIB_JOURNAL=0
 if [ -z "$*" ]; then
     # invoke cli/ tests which can be executed without special preparation
     ./tests/cli/test_blueprints_sanity.sh


### PR DESCRIPTION
bacause this requires additional Python modules and we don't
really use it! Fixes
[ WARNING  ] :: cannot create journal.xml due to missing python interpreter