### PR TITLE
More descriptive error for a bad ref in repos.git

### DIFF
--- a/src/pylorax/api/gitrpm.py
+++ b/src/pylorax/api/gitrpm.py
@@ -60,7 +60,7 @@ class GitArchiveTarball:
         cmd = ["git", "clone", self._gitRepo["repo"], joinpaths(sourcesDir, "gitrepo")]
         log.debug(cmd)
         try:
-            subprocess.check_output(cmd)
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             log.error("Failed to clone %s: %s", self._gitRepo["repo"], e.output)
             raise RuntimeError("Failed to clone %s" % self._gitRepo["repo"])
@@ -77,10 +77,11 @@ class GitArchiveTarball:
             cmd = ["git", "archive", "--prefix", self._gitRepo["rpmname"] + "/", "-o", joinpaths(sourcesDir, self.sourceName), self._gitRepo["ref"]]
             log.debug(cmd)
             try:
-                subprocess.check_output(cmd)
+                subprocess.check_output(cmd, stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError as e:
                 log.error("Failed to archive %s: %s", self._gitRepo["repo"], e.output)
-                raise RuntimeError("Failed to clone %s" % self._gitRepo["repo"])
+                raise RuntimeError('Failed to archive %s from ref "%s"' % (self._gitRepo["repo"],
+                                                                           self._gitRepo["ref"]))
         finally:
             # Cleanup even if there was an error
             os.chdir(oldcwd)
@@ -213,7 +214,7 @@ def create_gitrpm_repo(results_dir, recipe):
     cmd = ["createrepo_c", gitrepo]
     log.debug(cmd)
     try:
-        subprocess.check_output(cmd)
+        subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         log.error("Failed to create repo at %s: %s", gitrepo, e.output)
         raise RuntimeError("Failed to create repo at %s" % gitrepo)

--- a/tests/pylorax/test_gitrpm.py
+++ b/tests/pylorax/test_gitrpm.py
@@ -111,9 +111,10 @@ class GitArchiveTest(unittest.TestCase):
             ref="v1.1.0"
             destination="/srv/testing-rpm/"
         """ % ("/tmp/no-repo-here/"))
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(RuntimeError) as e:
             archive = GitArchiveTarball(git_repo["repos"]["git"][0])
             self._check_tar(archive, "git-rpm-test/", None)
+        self.assertIn("Failed to clone", str(e.exception))
 
     def git_fail_ref_test(self):
         """Test creating an archive from a bad ref"""
@@ -127,9 +128,10 @@ class GitArchiveTest(unittest.TestCase):
             ref="0297617d7b8baa263a69ae7dc901bbbcefd0eaa4"
             destination="/srv/testing-rpm/"
         """ % (self.repodir))
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(RuntimeError) as e:
             archive = GitArchiveTarball(git_repo["repos"]["git"][0])
             self._check_tar(archive, "git-rpm-test/", None)
+        self.assertIn("Failed to archive", str(e.exception))
 
 
 class GitRpmTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #771

I also redirected stderr to stdout in a couple subprocess calls so that git's error messages are captured in the log.