### PR TITLE
Mention python3-magic in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -14,7 +14,7 @@ How to build it:
 To run the tests you need the following dependencies installed:
 
     $ yum install python3-nose python3-pytest-mock python3-pocketlint \
-		python3-mock
+		python3-mock python3-magic
 
 Run the basic linting tests like this:
 


### PR DESCRIPTION
Some tests fail for me when python3-magic is not installed. Since python3-magic isn't listed as a dependency of lorax in `lorax.spec`, I think it's worth mentioning here.