### PR TITLE
Fix a couple test related things on master

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,4 @@
 FROM registry.fedoraproject.org/fedora:rawhide
-RUN dnf -y install https://kojipkgs.fedoraproject.org//packages/libgit2/0.28.2/1.fc31/x86_64/libgit2-0.28.2-1.fc31.x86_64.rpm
 RUN  dnf -y install \
   anaconda-tui \
   libgit2-glib \

--- a/tests/pylorax/test_gitrpm.py
+++ b/tests/pylorax/test_gitrpm.py
@@ -149,10 +149,10 @@ class GitRpmTest(unittest.TestCase):
         hdr = ts.hdrFromFdno(fd)
         os.close(fd)
 
-        self.assertEqual(hdr[rpm.RPMTAG_NAME].decode("UTF-8"), repo["rpmname"])
-        self.assertEqual(hdr[rpm.RPMTAG_VERSION].decode("UTF-8"), repo["rpmversion"])
-        self.assertEqual(hdr[rpm.RPMTAG_RELEASE].decode("UTF-8"), repo["rpmrelease"])
-        self.assertEqual(hdr[rpm.RPMTAG_URL].decode("UTF-8"), repo["repo"])
+        self.assertEqual(hdr[rpm.RPMTAG_NAME], repo["rpmname"])
+        self.assertEqual(hdr[rpm.RPMTAG_VERSION], repo["rpmversion"])
+        self.assertEqual(hdr[rpm.RPMTAG_RELEASE], repo["rpmrelease"])
+        self.assertEqual(hdr[rpm.RPMTAG_URL], repo["repo"])
 
         files = sorted(f.name for f in rpm.files(hdr) if stat.S_ISREG(f.mode))
         self.assertEqual(files, [os.path.join(repo["destination"], f) for f in self.test_results[test_name]])


### PR DESCRIPTION
Looks like rawhide has sorted out libgit2 issues, so drop installing the rpm from koji.
rpm now returns str() so drop decoding the header when using it in tests.
