### PR TITLE
test: Fix test_blueprint_sanity

### DIFF
--- a/src/pylorax/api/toml.py
+++ b/src/pylorax/api/toml.py
@@ -29,4 +29,5 @@ def loads(s):
         raise TomlError(e.msg, e.doc, e.pos)
 
 def dumps(o):
-    return toml.dumps(o, encoder=toml.TomlEncoder(dict))
+    # strip the result, because `toml.dumps` adds a lot of newlines
+    return toml.dumps(o, encoder=toml.TomlEncoder(dict)).strip()

--- a/tests/cli/test_blueprints_sanity.sh
+++ b/tests/cli/test_blueprints_sanity.sh
@@ -36,7 +36,6 @@ description = "Start building tests with beakerlib."
 version = "0.0.1"
 modules = []
 groups = []
-
 [[packages]]
 name = "beakerlib"
 version = "*"


### PR DESCRIPTION
The new toml library, introduced with abe7df34f, outputs different
whitespace from the old one. Fix the test expectation and strip()
results from toml.dumps(), because it contains superfluous newlines at
the end.