### PR TITLE
Also search for pxeboot kernel and initrd pairs

### DIFF
--- a/src/pylorax/mount.py
+++ b/src/pylorax/mount.py
@@ -59,7 +59,8 @@ class IsoMountpoint(object):
             self.mount_dir = self.initrd_path
 
         kernel_list = [("/isolinux/vmlinuz", "/isolinux/initrd.img"),
-                       ("/ppc/ppc64/vmlinuz", "/ppc/ppc64/initrd.img")]
+                       ("/ppc/ppc64/vmlinuz", "/ppc/ppc64/initrd.img"),
+                       ("/images/pxeboot/vmlinuz", "/images/pxeboot/initrd.img")]
 
         if os.path.isdir(self.mount_dir+"/repodata"):
             self.repo = self.mount_dir


### PR DESCRIPTION
As used in the Fedora 30 aarch64 Server DVDs.

Closes: #786