### PR TITLE
test: check the number of tests that ran

### DIFF
--- a/test/composertest.py
+++ b/test/composertest.py
@@ -186,4 +186,8 @@ def main():
     runner = ComposerTestRunner(failfast=args.sit)
     result = runner.run(tests)
 
+    if tests.countTestCases() != result.testsRun:
+        print("Error: unexpected number of tests were run", file=sys.stderr)
+        sys.exit(1)
+
     sys.exit(not result.wasSuccessful())


### PR DESCRIPTION
Fail if the number of excuted tests != number of dicovered tests.

This is a patch from @atodorov that I backported from #790. 