### PR TITLE
lorax: Add debug log of command line options

### DIFF
--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -113,6 +113,7 @@ def main():
         parser.error("config file %s doesn't exist." % opts.config)
 
     setup_logging(opts)
+    log.debug(opts)
 
     log_selinux_state()
 

--- a/src/sbin/mkefiboot
+++ b/src/sbin/mkefiboot
@@ -152,6 +152,7 @@ def main():
         print("Warning: --icon is only useful for Apple EFI images")
     if opt.diskname and not opt.imgtype == "apple":
         print("Warning: --diskname is only useful for Apple EFI images")
+    log.debug(opt)
     # do the thing!
     if opt.imgtype == "apple":
         mkmacboot(opt.bootdir, opt.outfile, opt.label, opt.icon, opt.product,


### PR DESCRIPTION
I noticed livemedia-creator had debug output for `opts` and thought it would be useful for lorax.

I know I'd get some use out of this.