### PR TITLE
lorax: provide runtime lorax config in debug log

### DIFF
--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -187,6 +187,9 @@ def main():
     if opts.sharedir:
         lorax.conf.set("lorax", "sharedir", opts.sharedir)
 
+    with open(lorax.conf.get("lorax", "logdir") + '/lorax.conf', 'w') as f:
+        lorax.conf.write(f)
+
     lorax.run(dnfbase, opts.product, opts.version, opts.release,
               opts.variant, opts.bugurl, opts.isfinal,
               workdir=tempdir, outputdir=opts.outputdir, buildarch=opts.buildarch,


### PR DESCRIPTION
While debugging a remote lorax session I thought it would be helpful to have the runtime lorax config within the logs.