### PR TITLE
tests: set skip_if_unavailable in test repos

### DIFF
--- a/src/pylorax/api/projects.py
+++ b/src/pylorax/api/projects.py
@@ -404,6 +404,9 @@ def dnf_repo_to_file_repo(repo):
     if repo.gpgkey:
         repo_str += "gpgkey = %s\n" % ",".join(repo.gpgkey)
 
+    if repo.skip_if_unavailable:
+        repo_str += "skip_if_unavailable=1\n"
+
     return repo_str
 
 def repo_to_source(repo, system_source):

--- a/tests/pylorax/repos/baseurl-test.repo
+++ b/tests/pylorax/repos/baseurl-test.repo
@@ -3,3 +3,4 @@ name = A fake repo with a baseurl
 baseurl = https://fake-repo.base.url
 sslverify = True
 gpgcheck = True
+skip_if_unavailable=1

--- a/tests/pylorax/repos/metalink-test.repo
+++ b/tests/pylorax/repos/metalink-test.repo
@@ -3,3 +3,4 @@ name = A fake repo with a metalink
 metalink = https://fake-repo.metalink
 sslverify = True
 gpgcheck = True
+skip_if_unavailable=1

--- a/tests/pylorax/repos/mirrorlist-test.repo
+++ b/tests/pylorax/repos/mirrorlist-test.repo
@@ -3,3 +3,4 @@ name = A fake repo with a mirrorlist
 mirrorlist = https://fake-repo.mirrorlist
 sslverify = True
 gpgcheck = True
+skip_if_unavailable=1


### PR DESCRIPTION
dnf seems to have changed the default for skip_if_unavailable. Some
mock repositories are still around in later tests, which then fail
because metadata cannot be synced.

Also expose skip_if_unavailable in dnf_repo_to_file_repo(), so that
tests checking for equality of repo files continue to pass.