### PR TITLE
Don't refresh metadata on startup

### DIFF
--- a/src/pylorax/api/dnfbase.py
+++ b/src/pylorax/api/dnfbase.py
@@ -121,10 +121,6 @@ def get_base_object(conf):
     log.info("Using %s for module_platform_id", platform_id)
     dbc.module_platform_id = platform_id
 
-    # Make sure metadata is always current
-    dbc.metadata_expire = 0
-    dbc.metadata_expire_filter = "never"
-
     # write the dnf configuration file
     with open(dnfconf, "w") as f:
         f.write(dbc.dump())

--- a/test/vm.install
+++ b/test/vm.install
@@ -33,3 +33,10 @@ yum install -y $packages
 
 systemctl enable lorax-composer.socket
 systemctl enable docker.service
+
+# Start lorax-composer to update the cache, so that it doesn't have to do this
+# on every test run. A single request to it is sufficient, because it doesn't
+# answer the first request until it has updated the cache.
+
+systemctl start lorax-composer.socket
+composer-cli status show


### PR DESCRIPTION
dnf repositories are configured with metadata_expire, which is related
to the length of time that old versions of the packages stay in the
repository. Thus, dnf should update the cache when necessary.

Also start lorax-composer once in vm.install to include the cache on the
test image. That should make iterating on tests quicker in the common
case.