### PR TITLE
Leave lscpu in the image for additional debugging

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -315,7 +315,7 @@ removefrom util-linux --allbut \
     /etc/mtab /etc/pam.d/login /etc/pam.d/remote \
     /usr/sbin/{agetty,blkid,blockdev,clock,fdisk,fsck,fstrim,hwclock,losetup} \
     /usr/sbin/{mkswap,swaplabel,nologin,sfdisk,swapoff,swapon,wipefs,partx,fsfreeze} \
-    /usr/bin/{logger,hexdump,flock,chmem,lsmem}
+    /usr/bin/{logger,hexdump,flock,chmem,lsmem,lscpu}
 removefrom volume_key-libs /usr/share/locale/*
 removefrom wget /etc/* /usr/share/locale/*
 removefrom xorg-x11-drv-intel /usr/${libdir}/libI*


### PR DESCRIPTION
The RHEL8 images added lscpu for additional debugging.  This would be handy in a lot of cases beyond RHEL.

This patch leaves `lscpu` in the image for folks that would like to use it.

Once this is merged I'll send a patch to anaconda to add lscpu output to the debug logs.