### PR TITLE
tests: Add UserKnownHostsFile to ssh options for tests

### DIFF
--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -5,7 +5,7 @@
 verify_image() {
     SSH_USER="$1"
     SSH_MACHINE="$2"
-    SSH_OPTS="-o StrictHostKeyChecking=no $3"
+    SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $3"
     rlLogInfo "verify_image: SSH_OPTS:'$SSH_OPTS' SSH_USER:'$SSH_USER' SSH_MACHINE: '$SSH_MACHINE'"
     check_root_account "$@"
     check_kernel_cmdline "$@"


### PR DESCRIPTION
When running multiple builds, boots, and ssh attempts in one session it
looks like it is having problems with the known_hosts entry even though
strict checking is turned off. This will not update known_hosts so it
should be in a consistent state for each run.

Related: rhbz#1728571