### PR TITLE
tests: Add check to make sure the compose actually finished

### DIFF
--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -64,3 +64,12 @@ check_kernel_cmdline() {
     rlRun -t -c "ssh $SSH_OPTS ${SSH_USER}@${SSH_MACHINE} 'grep custom_cmdline_arg /proc/cmdline'" 0 \
         "System booted from the image contains specified parameter on kernel command line"
 }
+
+# Fail if the compose failed, only call after checking for FINISHED|FAILED
+check_compose_status() {
+    UUID="$1"
+    if "$CLI" compose info "$UUID" | grep FAILED; then
+        rlFail "compose $UUID FAILED"
+        return 1
+    fi
+}

--- a/tests/cli/test_compose_ext4-filesystem.sh
+++ b/tests/cli/test_compose_ext4-filesystem.sh
@@ -32,6 +32,7 @@ rlJournalStart
                 sleep 10
                 rlLogInfo "Waiting for compose to finish ..."
             done;
+            check_compose_status "$UUID"
         else
             rlFail "Compose UUID is empty!"
         fi

--- a/tests/cli/test_compose_google.sh
+++ b/tests/cli/test_compose_google.sh
@@ -28,6 +28,7 @@ rlJournalStart
                 sleep 10
                 rlLogInfo "Waiting for compose to finish..."
             done
+            check_compose_status "$UUID"
         else
             flFail "Compose UUID is empty!"
         fi

--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -37,6 +37,7 @@ rlJournalStart
                 sleep 20
                 rlLogInfo "Waiting for compose to finish ..."
             done;
+            check_compose_status "$UUID"
         else
             rlFail "Compose UUID is empty!"
         fi

--- a/tests/cli/test_compose_partitioned-disk.sh
+++ b/tests/cli/test_compose_partitioned-disk.sh
@@ -32,6 +32,7 @@ rlJournalStart
                 sleep 10
                 rlLogInfo "Waiting for compose to finish ..."
             done;
+            check_compose_status "$UUID"
         else
             rlFail "Compose UUID is empty!"
         fi

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -65,6 +65,7 @@ __EOF__
                 sleep 20
                 rlLogInfo "Waiting for compose to finish ..."
             done;
+            check_compose_status "$UUID"
         else
             rlFail "Compose UUID is empty!"
         fi

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -36,6 +36,7 @@ rlJournalStart
                 sleep 5
                 rlLogInfo "Waiting for compose to finish ..."
             done;
+            check_compose_status "$UUID"
 
             rlRun -t -c "$CLI compose image $UUID"
             rlAssertExists "$UUID-root.tar.xz"

--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -34,6 +34,7 @@ rlJournalStart
                 sleep 10
                 rlLogInfo "Waiting for compose to finish ..."
             done;
+            check_compose_status "$UUID"
         else
             rlFail "Compose UUID is empty!"
         fi


### PR DESCRIPTION
Previously it was looping, waiting for FINISHED|FAILED but was not
actually failing the test if the compose failed to build.
This adds a function to check the status of the compose and calls it
after each compose.