### PR TITLE
tests: Use liveuser account for live-iso boot check

### DIFF
--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -55,8 +55,8 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Verify VM instance"
-        # run generic tests to verify the instance
-        ROOT_ACCOUNT_LOCKED=0 verify_image root localhost "-p 2222"
+        # run generic tests to verify the instance, log in a liveuser with no password
+        ROOT_ACCOUNT_LOCKED=0 verify_image liveuser localhost "-p 2222"
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
On rawhide you cannot ssh in as root without changing PermitRootLogin,
and really we should be testing that liveuser can login not root.