### PR TITLE
WIP: Cloud upload

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(name="lorax",
       url="http://www.github.com/weldr/lorax/",
       download_url="http://www.github.com/weldr/lorax/releases/",
       license="GPLv2+",
-      packages=["pylorax", "pylorax.api", "composer", "composer.cli"],
+      packages=["pylorax", "pylorax.api", "composer", "composer.cli", "lifted"],
       package_dir={"" : "src"},
       data_files=data_files
       )

--- a/share/lifted/providers/azure/playbook.yaml
+++ b/share/lifted/providers/azure/playbook.yaml
@@ -1,0 +1,47 @@
+- hosts: localhost
+  connection: local
+  tasks:
+    - name: Make sure provided credentials work and the storage account exists
+      azure_rm_storageaccount_facts:
+        subscription_id: "{{ subscription_id }}"
+        client_id: "{{ client_id }}"
+        secret: "{{ secret }}"
+        tenant: "{{ tenant }}"
+        resource_group: "{{ resource_group }}"
+        name: "{{ storage_account_name }}"
+      register: storageaccount_facts
+    - name: Fail if we couldn't log in or the storage account was not found
+      fail:
+        msg: "Invalid credentials or storage account not found!"
+      when: storageaccount_facts.ansible_facts.azure_storageaccounts | length < 1
+    - stat:
+        path: "{{ image_path }}"
+      register: image_stat
+    - set_fact:
+        image_id: "{{ image_name }}-{{ image_stat['stat']['checksum'] }}.vhd"
+    - name: Upload image to Azure
+      azure_rm_storageblob:
+        subscription_id: "{{ subscription_id }}"
+        client_id: "{{ client_id }}"
+        secret: "{{ secret }}"
+        tenant: "{{ tenant }}"
+        resource_group: "{{ resource_group }}"
+        storage_account_name: "{{ storage_account_name }}"
+        container: "{{ storage_container }}"
+        src: "{{ image_path }}"
+        blob: "{{ image_id }}"
+        blob_type: page
+        force: no
+    - set_fact:
+        host: "{{ storage_account_name }}.blob.core.windows.net"
+    - name: Import image
+      azure_rm_image:
+        subscription_id: "{{ subscription_id }}"
+        client_id: "{{ client_id }}"
+        secret: "{{ secret }}"
+        tenant: "{{ tenant }}"
+        resource_group: "{{ resource_group }}"
+        name: "{{ image_name }}"
+        os_type: Linux
+        location: "{{ location }}"
+        source: "https://{{ host }}/{{ storage_container }}/{{ image_id }}"

--- a/share/lifted/providers/azure/provider.toml
+++ b/share/lifted/providers/azure/provider.toml
@@ -1,50 +1,53 @@
 display = "Azure"
 
-[settings-info]
-	[settings-info.resource_group]
-	display = "Resource group"
-	type = "string"
-	placeholder = ""
-	regex = ''
+supported_types = [
+	"vhd",
+]
 
-	[settings-info.storage_account_name]
-	display = "Storage account name"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.resource_group]
+display = "Resource group"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.storage_container]
-	display = "Storage container"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.storage_account_name]
+display = "Storage account name"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.subscription_id]
-	display = "Subscription ID"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.storage_container]
+display = "Storage container"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.client_id]
-	display = "Client ID"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.subscription_id]
+display = "Subscription ID"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.secret]
-	display = "Secret"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.client_id]
+display = "Client ID"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.tenant]
-	display = "Tenant"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.secret]
+display = "Secret"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.location]
-	display = "Location"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.tenant]
+display = "Tenant"
+type = "string"
+placeholder = ""
+regex = ''
+
+[settings-info.location]
+display = "Location"
+type = "string"
+placeholder = ""
+regex = ''

--- a/share/lifted/providers/azure/provider.toml
+++ b/share/lifted/providers/azure/provider.toml
@@ -1,0 +1,50 @@
+display = "Azure"
+
+[settings-info]
+	[settings-info.resource_group]
+	display = "Resource group"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.storage_account_name]
+	display = "Storage account name"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.storage_container]
+	display = "Storage container"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.subscription_id]
+	display = "Subscription ID"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.client_id]
+	display = "Client ID"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.secret]
+	display = "Secret"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.tenant]
+	display = "Tenant"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.location]
+	display = "Location"
+	type = "string"
+	placeholder = ""
+	regex = ''

--- a/share/lifted/providers/dummy/playbook.yaml
+++ b/share/lifted/providers/dummy/playbook.yaml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  connection: local
+  tasks:
+  - pause: seconds=30

--- a/share/lifted/providers/dummy/provider.toml
+++ b/share/lifted/providers/dummy/provider.toml
@@ -1,0 +1,4 @@
+display = "Dummy"
+
+[settings-info]
+# This provider has no settings.

--- a/share/lifted/providers/openstack/playbook.yaml
+++ b/share/lifted/providers/openstack/playbook.yaml
@@ -1,0 +1,20 @@
+- hosts: localhost
+  connection: local
+  tasks:
+  - stat:
+      path: "{{ image_path }}"
+    register: image_stat
+  - set_fact:
+      image_id: "{{ image_name }}-{{ image_stat['stat']['checksum'] }}.qcow2"
+  - name: Upload image to OpenStack
+    os_image:
+      auth:
+        auth_url: "{{ auth_url }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        project_name: "{{ project_name }}"
+        os_user_domain_name: "{{ user_domain_name }}"
+        os_project_domain_name: "{{ project_domain_name }}"
+      name: "{{ image_id }}"
+      filename: "{{ image_path }}"
+      is_public: "{{ is_public }}"

--- a/share/lifted/providers/openstack/provider.toml
+++ b/share/lifted/providers/openstack/provider.toml
@@ -1,42 +1,45 @@
-name = "OpenStack"
+display = "OpenStack"
 
-[settings-info]
-	[settings-info.auth_url]
-	display = "Authentication URL"
-	type = "string"
-	placeholder = ""
-	regex = ''
+supported_types = [
+	"qcow2",
+]
 
-	[settings-info.username]
-	display = "Username"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.auth_url]
+display = "Authentication URL"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.password]
-	display = "Password"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.username]
+display = "Username"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.project_name]
-	display = "Project name"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.password]
+display = "Password"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.user_domain_name]
-	display = "User domain name"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.project_name]
+display = "Project name"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.project_domain_name]
-	display = "Project domain name"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.user_domain_name]
+display = "User domain name"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.is_public]
-	display = "Allow public access"
-	type = "boolean"
+[settings-info.project_domain_name]
+display = "Project domain name"
+type = "string"
+placeholder = ""
+regex = ''
+
+[settings-info.is_public]
+display = "Allow public access"
+type = "boolean"

--- a/share/lifted/providers/openstack/provider.toml
+++ b/share/lifted/providers/openstack/provider.toml
@@ -1,0 +1,42 @@
+name = "OpenStack"
+
+[settings-info]
+	[settings-info.auth_url]
+	display = "Authentication URL"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.username]
+	display = "Username"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.password]
+	display = "Password"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.project_name]
+	display = "Project name"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.user_domain_name]
+	display = "User domain name"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.project_domain_name]
+	display = "Project domain name"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.is_public]
+	display = "Allow public access"
+	type = "boolean"

--- a/share/lifted/providers/vsphere/playbook.yaml
+++ b/share/lifted/providers/vsphere/playbook.yaml
@@ -1,0 +1,17 @@
+- hosts: localhost
+  connection: local
+  tasks:
+  - stat:
+      path: "{{ image_path }}"
+    register: image_stat
+  - set_fact:
+      image_id: "{{ image_name }}-{{ image_stat['stat']['checksum'] }}.vmdk"
+  - name: Upload image to vSphere
+    vsphere_copy:
+      login: "{{ username }}"
+      password: "{{ password }}"
+      host: "{{ host }}"
+      datacenter: "{{ datacenter }}"
+      datastore: "{{ datastore }}"
+      src: "{{ image_path }}"
+      path: "{{ folder }}/{{ image_id }}"

--- a/share/lifted/providers/vsphere/provider.toml
+++ b/share/lifted/providers/vsphere/provider.toml
@@ -1,39 +1,42 @@
-name = "vSphere"
+display = "vSphere"
 
-[settings]
-	[settings-info.datacenter]
-	display = "Datacenter"
-	type = "string"
-	placeholder = ""
-	regex = ''
+supported_types = [
+	"vmdk",
+]
 
-	[settings-info.datastore]
-	display = "Datastore"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.datacenter]
+display = "Datacenter"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.host]
-	display = "Host"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.datastore]
+display = "Datastore"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.folder]
-	display = "Folder"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.host]
+display = "Host"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.username]
-	display = "Username"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.folder]
+display = "Folder"
+type = "string"
+placeholder = ""
+regex = ''
 
-	[settings-info.password]
-	display = "Password"
-	type = "string"
-	placeholder = ""
-	regex = ''
+[settings-info.username]
+display = "Username"
+type = "string"
+placeholder = ""
+regex = ''
+
+[settings-info.password]
+display = "Password"
+type = "string"
+placeholder = ""
+regex = ''
 

--- a/share/lifted/providers/vsphere/provider.toml
+++ b/share/lifted/providers/vsphere/provider.toml
@@ -1,0 +1,39 @@
+name = "vSphere"
+
+[settings]
+	[settings-info.datacenter]
+	display = "Datacenter"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.datastore]
+	display = "Datastore"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.host]
+	display = "Host"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.folder]
+	display = "Folder"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.username]
+	display = "Username"
+	type = "string"
+	placeholder = ""
+	regex = ''
+
+	[settings-info.password]
+	display = "Password"
+	type = "string"
+	placeholder = ""
+	regex = ''
+

--- a/src/lifted/__init__.py
+++ b/src/lifted/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#

--- a/src/lifted/providers.py
+++ b/src/lifted/providers.py
@@ -1,0 +1,168 @@
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from glob import glob
+import os
+import re
+import stat
+
+import toml
+
+
+def resolve_provider(ucfg, provider_name):
+    """Get information about the specified provider as defined in that
+    provider's `provider.toml`, including the provider's display name and
+    settings.
+
+    At a minimum, each setting has a display name (that likely
+    differs from its snake_case name), a type, and a saved value. Currently,
+    there are two types of settings: string and boolean. String settings can
+    optionally have a "placeholder" value for use on the front end and a
+    "regex" for making sure that a value follows an expected pattern.
+
+    :param ucfg: upload config
+    :type ucfg: object
+    :param provider_name: the name of the provider to look for
+    :type provider_name: str
+    :raises: RuntimeError when the provider couldn't be found
+    :returns: the provider
+    :rtype: dict
+    """
+    path = os.path.join(ucfg["providers_dir"], provider_name, "provider.toml")
+    try:
+        with open(path) as provider_file:
+            provider = toml.load(provider_file)
+    except OSError as error:
+        raise RuntimeError(f'Couldn\'t find provider "{provider_name}"!') from error
+    saved_settings = load_settings(ucfg, provider_name)
+    for setting, info in provider["settings-info"].items():
+        info["saved"] = saved_settings[setting] if setting in saved_settings else ""
+    return provider
+
+
+def resolve_playbook_path(ucfg, provider_name):
+    """Given a provider's name, return the path to its playbook
+
+    :param ucfg: upload config
+    :type ucfg: object
+    :param provider_name: the name of the provider to find the playbook for
+    :type provider_name: str
+    :raises: RuntimeError when the provider couldn't be found
+    :returns: the path to the playbook
+    :rtype: str
+    """
+    path = os.path.join(ucfg["providers_dir"], provider_name, "playbook.yaml")
+    if not os.path.isfile(path):
+        raise RuntimeError(f'Couldn\'t find playbook for "{provider_name}"!')
+    return path
+
+
+def list_providers(ucfg):
+    """List the names of the available upload providers
+
+    :param ucfg: upload config
+    :type ucfg: object
+    :returns: a list of all available provider_names
+    :rtype: list of str
+    """
+    paths = glob(os.path.join(ucfg["providers_dir"], "*"))
+    return [os.path.basename(path) for path in paths]
+
+
+def _get_settings_path(ucfg, provider_name, write=False):
+    directory = ucfg["settings_dir"]
+
+    # create the upload_queue directory if it doesn't exist
+    os.makedirs(directory, exist_ok=True)
+
+    path = os.path.join(directory, f"{provider_name}.toml")
+    if write and not os.path.isfile(path):
+        open(path, "a").close()
+    if os.path.exists(path):
+        # make sure settings files aren't readable by others, as they will contain
+        # sensitive credentials
+        current = stat.S_IMODE(os.lstat(path).st_mode)
+        os.chmod(path, current & ~stat.S_IROTH)
+    return path
+
+
+def validate_settings(ucfg, provider_name, settings, image_name=None):
+    """Raise a ValueError if any settings are invalid
+
+    :param ucfg: upload config
+    :type ucfg: object
+    :param provider_name: the name of the provider to validate the settings
+    against
+    :type provider_name: str
+    :param settings: the settings to validate
+    :type settings: dict
+    :param image_name: optionally check whether an image_name is valid
+    :type image_name: str
+    :raises: ValueError when the passed settings are invalid
+    :raises: RuntimeError when provider_name can't be found
+    """
+    if image_name == "":
+        raise ValueError("Image name cannot be empty!")
+    type_map = {"string": str, "boolean": bool}
+    settings_info = resolve_provider(ucfg, provider_name)["settings-info"]
+    for key, value in settings.items():
+        if key not in settings_info:
+            raise ValueError(f'Received unexpected setting: "{key}"!')
+        setting_type = settings_info[key]["type"]
+        correct_type = type_map[setting_type]
+        if not isinstance(value, correct_type):
+            raise ValueError(
+                f'Expected a {correct_type} for "{key}", received a {type(value)}!'
+            )
+        if setting_type == "string" and "regex" in settings_info[key]:
+            if not re.match(settings_info[key]["regex"], value):
+                raise ValueError(f'Value "{value}" is invalid for setting "{key}"!')
+
+
+def load_settings(ucfg, provider_name):
+    """Load saved settings for a provider
+
+    :param ucfg: upload config
+    :type ucfg: object
+    :param provider_name: the name of the cloud provider, e.g. "azure"
+    :type provider_name: str
+    :returns: the saved settings for that provider, or {} if no settings are
+    saved
+    :rtype: dict
+    """
+    path = _get_settings_path(ucfg, provider_name, write=False)
+    if os.path.isfile(path):
+        with open(path) as settings_file:
+            return toml.load(settings_file)
+    return {}
+
+
+def save_settings(ucfg, provider_name, settings):
+    """Save (and overwrite) settings for a given provider
+
+    :param ucfg: upload config
+    :type ucfg: object
+    :param provider_name: the name of the cloud provider, e.g. "azure"
+    :type provider_name: str
+    :param settings: settings to save for that provider
+    :type settings: dict
+    :raises: ValueError when passed invalid settings
+    """
+    validate_settings(ucfg, provider_name, settings, image_name=None)
+    settings_path = _get_settings_path(ucfg, provider_name, write=True)
+    with open(settings_path, "w") as settings_file:
+        toml.dump(settings, settings_file)

--- a/src/lifted/queue.py
+++ b/src/lifted/queue.py
@@ -1,0 +1,270 @@
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from functools import partial
+from glob import glob
+import logging
+import multiprocessing
+
+# We use a multiprocessing Pool for uploads so that we can cancel them with a
+# simple SIGINT, which should bubble down to subprocesses.
+from multiprocessing import Pool
+
+# multiprocessing.dummy is to threads as multiprocessing is to processes.
+# Since daemonic processes can't have children, we use a thread to monitor the
+# upload pool.
+from multiprocessing.dummy import Process
+
+from operator import attrgetter
+import os
+import pickle
+import stat
+import time
+
+from lifted.upload import Upload, UploadStatus
+from lifted.providers import resolve_playbook_path, validate_settings
+
+# the maximum number of simultaneous uploads
+SIMULTANEOUS_UPLOADS = 1
+
+LOG = logging.getLogger("lifted")
+multiprocessing.log_to_stderr().setLevel(logging.INFO)
+
+
+def _get_queue_path(ucfg):
+    path = ucfg["queue_dir"]
+
+    # create the upload_queue directory if it doesn't exist
+    os.makedirs(path, exist_ok=True)
+
+    return path
+
+
+def _get_upload_path(ucfg, uuid, write=False):
+    path = os.path.join(_get_queue_path(ucfg), uuid)
+    if write and not os.path.exists(path):
+        open(path, "a").close()
+    if os.path.exists(path):
+        # make sure uploads aren't readable by others, as they will contain
+        # sensitive credentials
+        current = stat.S_IMODE(os.lstat(path).st_mode)
+        os.chmod(path, current & ~stat.S_IROTH)
+    return path
+
+
+def _list_upload_uuids(ucfg):
+    paths = glob(os.path.join(_get_queue_path(ucfg), "*"))
+    return [os.path.basename(path) for path in paths]
+
+
+def _write_upload(ucfg, upload):
+    with open(_get_upload_path(ucfg, upload.uuid, write=True), "wb") as upload_file:
+        pickle.dump(upload, upload_file, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+def _write_callback(ucfg):
+    return partial(_write_upload, ucfg)
+
+
+def get_upload(ucfg, uuid, ignore_missing=False, ignore_corrupt=False):
+    """Get an Upload object by UUID
+
+    :param ucfg: upload config
+    :type ucfg: object
+    :param uuid: UUID of the upload to get
+    :type uuid: str
+    :param ignore_missing: if True, don't raise a RuntimeError when the
+    specified upload is missing, instead just return None
+    :type ignore_missing: bool
+    :param ignore_corrupt: if True, don't raise a RuntimeError when the
+    :type ignore_corrupt: bool
+    specified upload could not be unpickled, instead just return None
+    :returns: the upload object or None
+    :rtype: Upload or None
+    :raises: RuntimeError
+    """
+    try:
+        with open(os.path.join(_get_queue_path(ucfg), uuid), "rb") as pickle_file:
+            return pickle.load(pickle_file)
+    except FileNotFoundError as error:
+        if not ignore_missing:
+            raise RuntimeError(f"Could not find upload {uuid}!") from error
+    except pickle.UnpicklingError as error:
+        if not ignore_corrupt:
+            raise RuntimeError(f"Could not parse upload {uuid}!") from error
+    return None
+
+
+def get_uploads(ucfg, uuids):
+    """Gets a list of Upload objects from a list of upload UUIDs, ignoring
+    missing or corrupt uploads
+
+    :param ucfg: upload config
+    :type ucfg: object
+    :param uuids: list of upload UUIDs to get
+    :type uuids: list of str
+    :returns: a list of the uploads that were successfully unpickled
+    :rtype: list of Upload
+    """
+    uploads = (
+        get_upload(ucfg, uuid, ignore_missing=True, ignore_corrupt=True)
+        for uuid in uuids
+    )
+    return list(filter(None, uploads))
+
+
+def get_all_uploads(ucfg):
+    """Get a list of all stored Upload objects
+
+    :param ucfg: upload config
+    :type ucfg: object
+    :returns: a list of all stored upload objects
+    :rtype: list of Upload
+    """
+    return get_uploads(ucfg, _list_upload_uuids(ucfg))
+
+
+def create_upload(ucfg, provider_name, image_name, settings):
+    """Creates a new upload
+
+    :param ucfg: upload config
+    :type ucfg: object
+    :param provider_name: the name of the cloud provider to upload to, e.g.
+    "azure"
+    :type provider_name: str
+    :param image_name: what to name the image in the cloud
+    :type image_name: str
+    :param settings: settings to pass to the upload, specific to the cloud
+    provider
+    :type settings: dict
+    :returns: the created upload object
+    :rtype: Upload
+    """
+    validate_settings(ucfg, provider_name, settings, image_name)
+    return Upload(
+        image_name,
+        provider_name,
+        resolve_playbook_path(ucfg, provider_name),
+        settings,
+        _write_callback(ucfg),
+    )
+
+
+def ready_upload(ucfg, uuid, image_path):
+    """Pass an image_path to an upload and mark it ready to execute
+
+    :param ucfg: upload config
+    :type ucfg: object
+    :param uuid: the UUID of the upload to mark ready
+    :type uuid: str
+    :param image_path: the path of the image to pass to the upload
+    :type image_path: str
+    """
+    get_upload(ucfg, uuid).ready(image_path, _write_callback(ucfg))
+
+
+def reset_upload(ucfg, uuid, new_image_name=None, new_settings=None):
+    """Reset an upload so it can be attempted again
+
+    :param ucfg: upload config
+    :type ucfg: object
+    :param uuid: the UUID of the upload to reset
+    :type uuid: str
+    :param new_image_name: optionally update the upload's image_name
+    :type new_image_name: str
+    :param new_settings: optionally update the upload's settings
+    :type new_settings: dict
+    """
+    upload = get_upload(ucfg, uuid)
+    validate_settings(
+        ucfg,
+        upload.provider_name,
+        new_settings or upload.settings,
+        new_image_name or upload.image_name,
+    )
+    if new_image_name:
+        upload.image_name = new_image_name
+    if new_settings:
+        upload.settings = new_settings
+    upload.reset(_write_callback(ucfg))
+
+
+def cancel_upload(ucfg, uuid):
+    """Cancel an upload
+
+    :param ucfg: the compose config
+    :type ucfg: ComposerConfig
+    :param uuid: the UUID of the upload to cancel
+    :type uuid: str
+    """
+    get_upload(ucfg, uuid).cancel(_write_callback(ucfg))
+
+
+def delete_upload(ucfg, uuid):
+    """Delete an upload
+
+    :param ucfg: the compose config
+    :type ucfg: ComposerConfig
+    :param uuid: the UUID of the upload to delete
+    :type uuid: str
+    """
+    upload = get_upload(ucfg, uuid)
+    if upload and upload.is_cancellable():
+        upload.cancel()
+    os.remove(_get_upload_path(ucfg, uuid))
+
+
+def start_upload_monitor(ucfg):
+    """Start a thread that manages the upload queue
+
+    :param ucfg: the compose config
+    :type ucfg: ComposerConfig
+    """
+    process = Process(target=_monitor, args=(ucfg,))
+    process.daemon = True
+    process.start()
+
+
+def _monitor(ucfg):
+    LOG.info("Started upload monitor.")
+    for upload in get_all_uploads(ucfg):
+        # Set abandoned uploads to FAILED
+        if upload.status is UploadStatus.RUNNING:
+            upload.set_status(UploadStatus.FAILED, _write_callback(ucfg))
+    pool = Pool(processes=SIMULTANEOUS_UPLOADS)
+    pool_uuids = set()
+
+    def remover(uuid):
+        return lambda _: pool_uuids.remove(uuid)
+
+    while True:
+        # Every second, scoop up READY uploads from the filesystem and throw
+        # them in the pool
+        all_uploads = get_all_uploads(ucfg)
+        for upload in sorted(all_uploads, key=attrgetter("creation_time")):
+            ready = upload.status is UploadStatus.READY
+            if ready and upload.uuid not in pool_uuids:
+                LOG.info("Starting upload %s...", upload.uuid)
+                pool_uuids.add(upload.uuid)
+                callback = remover(upload.uuid)
+                pool.apply_async(
+                    upload.execute,
+                    (_write_callback(ucfg),),
+                    callback=callback,
+                    error_callback=callback,
+                )
+        time.sleep(1)

--- a/src/lifted/queue.py
+++ b/src/lifted/queue.py
@@ -34,7 +34,7 @@ import os
 import stat
 import time
 
-import toml
+import pylorax.api.toml as toml
 
 from lifted.upload import Upload
 from lifted.providers import resolve_playbook_path, validate_settings
@@ -74,7 +74,7 @@ def _list_upload_uuids(ucfg):
 
 def _write_upload(ucfg, upload):
     with open(_get_upload_path(ucfg, upload.uuid, write=True), "w") as upload_file:
-        toml.dump(upload.serialize(), upload_file)
+        toml.dump(upload.serializable(), upload_file)
 
 
 def _write_callback(ucfg):
@@ -104,7 +104,7 @@ def get_upload(ucfg, uuid, ignore_missing=False, ignore_corrupt=False):
     except FileNotFoundError as error:
         if not ignore_missing:
             raise RuntimeError(f"Could not find upload {uuid}!") from error
-    except toml.TomlDecodeError as error:
+    except toml.TomlError as error:
         if not ignore_corrupt:
             raise RuntimeError(f"Could not parse upload {uuid}!") from error
 
@@ -156,11 +156,11 @@ def create_upload(ucfg, provider_name, image_name, settings):
     """
     validate_settings(ucfg, provider_name, settings, image_name)
     return Upload(
-        image_name,
-        provider_name,
-        resolve_playbook_path(ucfg, provider_name),
-        settings,
-        _write_callback(ucfg),
+        provider_name=provider_name,
+        playbook_path=resolve_playbook_path(ucfg, provider_name),
+        image_name=image_name,
+        settings=settings,
+        status_callback=_write_callback(ucfg),
     )
 
 

--- a/src/lifted/upload.py
+++ b/src/lifted/upload.py
@@ -31,8 +31,8 @@ log = logging.getLogger("lifted")
 
 class Upload:
     """Represents an upload of an image to a cloud provider. Instances of this
-    class are serialized and stored upload queue directory, which is
-    /var/lib/lorax/upload/queue/ by default"""
+    class are serialized as TOML and stored in the upload queue directory,
+    which is /var/lib/lorax/upload/queue/ by default"""
 
     def __init__(
         self,
@@ -156,9 +156,6 @@ class Upload:
             os.kill(self.upload_pid, signal.SIGINT)
         self.set_status("CANCELLED", status_callback)
 
-    def verify_settings(self, status_callback=None):
-        """"""
-
     def execute(self, status_callback=None):
         """Execute the upload. Meant to be called from a dedicated process so
         that the upload can be cancelled by sending a SIGINT to
@@ -172,7 +169,7 @@ class Upload:
         self.upload_pid = current_process().pid
         self.set_status("RUNNING", status_callback)
 
-        logger = partial(self._log, callback=status_callback)
+        logger = lambda e: self._log(e["stdout"], status_callback)
 
         runner = ansible_run(
             playbook=self.playbook_path,

--- a/src/lifted/upload.py
+++ b/src/lifted/upload.py
@@ -36,27 +36,27 @@ class Upload:
 
     def __init__(
         self,
-        image_name=None,
+        uuid=None,
         provider_name=None,
         playbook_path=None,
+        image_name=None,
         settings=None,
-        status_callback=None,
-        uuid=None,
         creation_time=None,
         upload_log=None,
-        image_path=None,
         upload_pid=None,
+        image_path=None,
+        status_callback=None,
         status=None,
     ):
-        self.settings = settings
-        self.image_name = image_name
+        self.uuid = uuid or str(uuid4())
         self.provider_name = provider_name
         self.playbook_path = playbook_path
-        self.uuid = uuid or str(uuid4())
+        self.image_name = image_name
+        self.settings = settings
         self.creation_time = creation_time or datetime.now().timestamp()
         self.upload_log = upload_log or ""
-        self.image_path = image_path
         self.upload_pid = upload_pid
+        self.image_path = image_path
         if status:
             self.status = status
         else:
@@ -73,7 +73,12 @@ class Upload:
         if callback:
             callback(self)
 
-    def serialize(self):
+    def serializable(self):
+        """Returns a representation of the object as a dict for serialization
+
+        :returns: the object's __dict__
+        :rtype: dict
+        """
         return self.__dict__
 
     def summary(self):
@@ -176,7 +181,8 @@ class Upload:
                 "image_name": self.image_name,
                 "image_path": self.image_path,
             },
-            event_handler=logger,)
+            event_handler=logger,
+        )
         if runner.status == "successful":
             self.set_status("FINISHED", status_callback)
         else:

--- a/src/lifted/upload.py
+++ b/src/lifted/upload.py
@@ -1,0 +1,180 @@
+#
+# Copyright (C) 2018-2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from datetime import datetime
+from enum import Enum
+from functools import partial
+import logging
+from multiprocessing import current_process
+import os
+import signal
+from uuid import uuid4
+
+from ansible_runner.interface import run as ansible_run
+
+LOG = logging.getLogger("lifted")
+
+
+class UploadStatus(Enum):
+    """Uploads start as WAITING, become READY when they get an image_path,
+    then RUNNING, then FINISHED, FAILED, or CANCELLED."""
+
+    WAITING = "WAITING"
+    READY = "READY"
+    RUNNING = "RUNNING"
+    FINISHED = "FINISHED"
+    FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
+
+
+class Upload:
+    """Represents an upload of an image to a cloud provider. Instances of this
+    class are pickled and stored upload queue directory, which is
+    /var/lib/lorax/upload/queue/ by default"""
+
+    def __init__(
+        self, image_name, provider_name, playbook_path, settings, status_callback=None
+    ):
+        self.settings = settings
+        self.image_name = image_name
+        self.provider_name = provider_name
+        self.playbook_path = playbook_path
+        self.uuid = str(uuid4())
+        self.creation_time = datetime.now().timestamp()
+        self.upload_log = ""
+        self.image_path = None
+        self.upload_pid = None
+        self.set_status(UploadStatus.WAITING, status_callback)
+
+    def _log(self, message, callback=None):
+        """Logs something to the upload log
+
+        :param message: the object to log
+        :type message: object
+        """
+        LOG.info(str(message))
+        self.upload_log += f"{message}\n"
+        if callback:
+            callback(self)
+
+    def summary(self):
+        """Return a dict with useful information about the upload
+
+        :returns: upload information
+        :rtype: dict
+        """
+
+        return {
+            "uuid": self.uuid,
+            "status": self.status.value,
+            "provider_name": self.provider_name,
+            "image_name": self.image_name,
+            "image_path": self.image_path,
+            "creation_time": self.creation_time,
+            "settings": self.settings,
+        }
+
+    def set_status(self, status, status_callback=None):
+        """Sets the status of the upload with an optional callback
+
+        :param status: the new status
+        :type status: UploadStatus
+        :param status_callback: a function of the form callback(self)
+        :type status_callback: function
+        """
+        self.status = status
+        if status_callback:
+            status_callback(self)
+
+    def ready(self, image_path, status_callback):
+        """Provide an image_path and mark the upload as ready to execute
+
+        :param image_path: path of the image to upload
+        :type image_path: str
+        :param status_callback: a function of the form callback(self)
+        :type status_callback: function
+        """
+        self.image_path = image_path
+        if self.status is UploadStatus.WAITING:
+            self.set_status(UploadStatus.READY, status_callback)
+
+    def reset(self, status_callback):
+        """Reset the upload so it can be attempted again
+
+        :param status_callback: a function of the form callback(self)
+        :type status_callback: function
+        """
+        if self.is_cancellable():
+            raise RuntimeError(f"Can't reset, status is {self.status.value}!")
+        if not self.image_path:
+            raise RuntimeError(f"Can't reset, no image supplied yet!")
+        # self.error = None
+        self._log("Resetting...")
+        self.set_status(UploadStatus.READY, status_callback)
+
+    def is_cancellable(self):
+        """Is the upload in a cancellable state?
+
+        :returns: whether the upload is cancellable
+        :rtype: bool
+        """
+        return self.status in (
+            UploadStatus.WAITING,
+            UploadStatus.READY,
+            UploadStatus.RUNNING,
+        )
+
+    def cancel(self, status_callback=None):
+        """Cancel the upload. Sends a SIGINT to self.upload_pid.
+
+        :param status_callback: a function of the form callback(self)
+        :type status_callback: function
+        """
+        if not self.is_cancellable():
+            raise RuntimeError(f"Can't cancel, status is already {self.status.value}!")
+        if self.upload_pid:
+            os.kill(self.upload_pid, signal.SIGINT)
+        self.set_status(UploadStatus.CANCELLED, status_callback)
+
+    def execute(self, status_callback=None):
+        """Execute the upload. Meant to be called from a dedicated process so
+        that the upload can be cancelled by sending a SIGINT to
+        self.upload_pid.
+
+        :param status_callback: a function of the form callback(self)
+        :type status_callback: function
+        """
+        if self.status is not UploadStatus.READY:
+            raise RuntimeError("This upload is not ready!")
+        self.upload_pid = current_process().pid
+        self.set_status(UploadStatus.RUNNING, status_callback)
+
+        logger = partial(self._log, callback=status_callback)
+
+        runner = ansible_run(
+            playbook=self.playbook_path,
+            extravars={
+                **self.settings,
+                "image_name": self.image_name,
+                "image_path": self.image_path,
+            },
+            event_handler=logger,
+        )
+        if runner.status == "successful":
+            self.set_status(UploadStatus.FINISHED, status_callback)
+        else:
+            self.set_status(UploadStatus.FAILED, status_callback)

--- a/src/lifted/upload.py
+++ b/src/lifted/upload.py
@@ -63,10 +63,12 @@ class Upload:
             self.set_status("WAITING", status_callback)
 
     def _log(self, message, callback=None):
-        """Logs something to the upload log
+        """Logs something to the upload log with an optional callback
 
         :param message: the object to log
         :type message: object
+        :param callback: a function of the form callback(self)
+        :type callback: function
         """
         log.info(str(message))
         self.upload_log += f"{message}\n"

--- a/src/pylorax/api/config.py
+++ b/src/pylorax/api/config.py
@@ -54,6 +54,11 @@ def configure(conf_file="/etc/lorax/composer.conf", root_dir="/", test_config=Fa
     conf.add_section("users")
     conf.set("users", "root", "1")
 
+    conf.add_section("upload")
+    conf.set("upload", "providers_dir", os.path.realpath(joinpaths(root_dir, "/usr/share/lorax/lifted/providers/")))
+    conf.set("upload", "queue_dir", os.path.realpath(joinpaths(root_dir, "/var/lib/lorax/upload/queue")))
+    conf.set("upload", "settings_dir", os.path.realpath(joinpaths(root_dir, "/var/lib/lorax/upload/settings")))
+
     # Enable all available repo files by default
     conf.add_section("repos")
     conf.set("repos", "use_system_repos", "1")

--- a/src/pylorax/api/errors.py
+++ b/src/pylorax/api/errors.py
@@ -45,6 +45,9 @@ BUILD_MISSING_FILE = "BuildMissingFile"
 # Returned from the API for all other errors from a /compose/* route.
 COMPOSE_ERROR = "ComposeError"
 
+# Returned from the API for all errors from a /upload/* route.
+UPLOAD_ERROR = "UploadError"
+
 # Returned from the API when invalid characters are used in a route path or in
 # some identifier.
 INVALID_CHARS = "InvalidChars"

--- a/src/pylorax/api/errors.py
+++ b/src/pylorax/api/errors.py
@@ -46,7 +46,7 @@ BUILD_MISSING_FILE = "BuildMissingFile"
 COMPOSE_ERROR = "ComposeError"
 
 # Returned from the API for all errors from a /upload/* route.
-UPLOAD_ERROR = "UploadError"
+UPLOAD_ERROR = "UploadError" # TODO these errors should be more specific
 
 # Returned from the API when invalid characters are used in a route path or in
 # some identifier.

--- a/src/pylorax/api/queue.py
+++ b/src/pylorax/api/queue.py
@@ -452,18 +452,10 @@ def _upload_list_path(cfg, uuid):
         raise RuntimeError(f'"{uuid}" is not a valid build uuid!')
     return joinpaths(results_dir, "UPLOADS")
 
-def get_type_provider(compose_type):
-    return {
-        "qcow2": "openstack",
-        "vhd": "azure",
-        "vmdk": "vsphere",
-    }[compose_type]
-
-def uuid_schedule_upload(cfg, uuid, image_name, settings):
+def uuid_schedule_upload(cfg, uuid, provider_name, image_name, settings):
     status = uuid_status(cfg, uuid)
     if status is None:
         raise RuntimeError(f'"{uuid}" is not a valid build uuid!')
-    provider_name = get_type_provider(status["compose_type"])
 
     upload = create_upload(cfg["upload"], provider_name, image_name, settings)
     uuid_add_upload(cfg, uuid, upload.uuid)

--- a/src/pylorax/api/queue.py
+++ b/src/pylorax/api/queue.py
@@ -38,6 +38,8 @@ from pylorax.base import DataHolder
 from pylorax.creator import run_creator
 from pylorax.sysutils import joinpaths, read_tail
 
+from lifted.queue import create_upload, get_uploads, ready_upload, delete_upload
+
 def check_queues(cfg):
     """Check to make sure the new and run queue symlinks are correct
 
@@ -93,7 +95,7 @@ def start_queue_monitor(cfg, uid, gid):
     lib_dir = cfg.get("composer", "lib_dir")
     share_dir = cfg.get("composer", "share_dir")
     tmp = cfg.get("composer", "tmp")
-    monitor_cfg = DataHolder(composer_dir=lib_dir, share_dir=share_dir, uid=uid, gid=gid, tmp=tmp)
+    monitor_cfg = DataHolder(cfg=cfg, composer_dir=lib_dir, share_dir=share_dir, uid=uid, gid=gid, tmp=tmp)
     p = mp.Process(target=monitor, args=(monitor_cfg,))
     p.daemon = True
     p.start()
@@ -163,6 +165,11 @@ def monitor(cfg):
                 log.info("Finished building %s, results are in %s", dst, os.path.realpath(dst))
                 open(joinpaths(dst, "STATUS"), "w").write("FINISHED\n")
                 write_timestamp(dst, TS_FINISHED)
+
+                upload_cfg = cfg.cfg["upload"]
+                for upload in get_uploads(upload_cfg, uuid_get_uploads(cfg.cfg, uuids[0])):
+                    log.info("Readying upload %s", upload.uuid)
+                    uuid_ready_upload(cfg.cfg, uuids[0], upload.uuid)
             except Exception:
                 import traceback
                 log.error("traceback: %s", traceback.format_exc())
@@ -298,7 +305,7 @@ def get_compose_type(results_dir):
         raise RuntimeError("Cannot find ks template for build %s" % os.path.basename(results_dir))
     return t[0]
 
-def compose_detail(results_dir):
+def compose_detail(cfg, results_dir):
     """Return details about the build.
 
     :param results_dir: The directory containing the metadata and results for the build
@@ -338,6 +345,9 @@ def compose_detail(results_dir):
 
     times = timestamp_dict(results_dir)
 
+    upload_uuids = uuid_get_uploads(cfg, build_id)
+    summaries = [upload.summary() for upload in get_uploads(cfg["upload"], upload_uuids)]
+
     return {"id":           build_id,
             "queue_status": status,
             "job_created":  times.get(TS_CREATED),
@@ -346,7 +356,8 @@ def compose_detail(results_dir):
             "compose_type": compose_type,
             "blueprint":    blueprint["name"],
             "version":      blueprint["version"],
-            "image_size":   image_size
+            "image_size":   image_size,
+            "uploads":      summaries,
             }
 
 def queue_status(cfg):
@@ -367,7 +378,7 @@ def queue_status(cfg):
     new_details = []
     for n in new_queue:
         try:
-            d = compose_detail(n)
+            d = compose_detail(cfg, n)
         except IOError:
             continue
         new_details.append(d)
@@ -375,7 +386,7 @@ def queue_status(cfg):
     run_details = []
     for r in run_queue:
         try:
-            d = compose_detail(r)
+            d = compose_detail(cfg, r)
         except IOError:
             continue
         run_details.append(d)
@@ -399,7 +410,7 @@ def uuid_status(cfg, uuid):
     """
     uuid_dir = joinpaths(cfg.get("composer", "lib_dir"), "results", uuid)
     try:
-        return compose_detail(uuid_dir)
+        return compose_detail(cfg, uuid_dir)
     except IOError:
         return None
 
@@ -430,10 +441,63 @@ def build_status(cfg, status_filter=None):
         try:
             status = open(joinpaths(build, "STATUS"), "r").read().strip()
             if status in status_filter:
-                results.append(compose_detail(build))
+                results.append(compose_detail(cfg, build))
         except IOError:
             pass
     return results
+
+def _upload_list_path(cfg, uuid):
+    results_dir = joinpaths(cfg.get("composer", "lib_dir"), "results", uuid)
+    if not os.path.isdir(results_dir):
+        raise RuntimeError(f'"{uuid}" is not a valid build uuid!')
+    return joinpaths(results_dir, "UPLOADS")
+
+def get_type_provider(compose_type):
+    return {
+        "qcow2": "openstack",
+        "vhd": "azure",
+        "vmdk": "vsphere",
+    }[compose_type]
+
+def uuid_schedule_upload(cfg, uuid, image_name, settings):
+    status = uuid_status(cfg, uuid)
+    if status is None:
+        raise RuntimeError(f'"{uuid}" is not a valid build uuid!')
+    provider_name = get_type_provider(status["compose_type"])
+
+    upload = create_upload(cfg["upload"], provider_name, image_name, settings)
+    uuid_add_upload(cfg, uuid, upload.uuid)
+    return upload.uuid
+
+def uuid_get_uploads(cfg, uuid):
+    try:
+        with open(_upload_list_path(cfg, uuid)) as uploads_file:
+            return frozenset(uploads_file.read().split())
+    except FileNotFoundError:
+        return frozenset()
+
+def uuid_add_upload(cfg, uuid, upload_uuid):
+    if upload_uuid not in uuid_get_uploads(cfg, uuid):
+        with open(_upload_list_path(cfg, uuid), "a") as uploads_file:
+            print(upload_uuid, file=uploads_file)
+        status = uuid_status(cfg, uuid)
+        if status and status["queue_status"] == "FINISHED":
+            uuid_ready_upload(cfg, uuid, upload_uuid)
+
+def uuid_remove_upload(cfg, uuid, upload_uuid):
+    uploads = uuid_get_uploads(cfg, uuid) - frozenset((upload_uuid,))
+    with open(_upload_list_path(cfg, uuid), "w") as uploads_file:
+        for upload in uploads:
+            print(upload, file=uploads_file)
+
+def uuid_ready_upload(cfg, uuid, upload_uuid):
+    status = uuid_status(cfg, uuid)
+    if not status:
+        raise RuntimeError(f"{uuid} is not a valid build id!")
+    if status["queue_status"] != "FINISHED":
+        raise RuntimeError(f"Build {uuid} is not finished!")
+    _, image_path = uuid_image(cfg, uuid)
+    ready_upload(cfg["upload"], upload_uuid, image_path)
 
 def uuid_cancel(cfg, uuid):
     """Cancel a build and delete its results
@@ -510,6 +574,10 @@ def uuid_delete(cfg, uuid):
     uuid_dir = joinpaths(cfg.get("composer", "lib_dir"), "results", uuid)
     if not uuid_dir or len(uuid_dir) < 10:
         raise RuntimeError("Directory length is too short: %s" % uuid_dir)
+
+    for upload in get_uploads(cfg["upload"], uuid_get_uploads(cfg, uuid)):
+        delete_upload(cfg["upload"], upload.uuid)
+
     shutil.rmtree(uuid_dir)
     return True
 
@@ -554,12 +622,15 @@ def uuid_info(cfg, uuid):
         raise RuntimeError("Missing deps.toml for %s" % uuid)
     deps_dict = toml.loads(open(deps_path, "r").read())
 
-    details = compose_detail(uuid_dir)
+    details = compose_detail(cfg, uuid_dir)
 
     commit_path = joinpaths(uuid_dir, "COMMIT")
     if not os.path.exists(commit_path):
         raise RuntimeError("Missing commit hash for %s" % uuid)
     commit_id = open(commit_path, "r").read().strip()
+
+    upload_uuids = uuid_get_uploads(cfg, uuid)
+    summaries = [upload.summary() for upload in get_uploads(cfg["upload"], upload_uuids)]
 
     return {"id":           uuid,
             "config":       cfg_dict,
@@ -568,7 +639,8 @@ def uuid_info(cfg, uuid):
             "deps":         deps_dict,
             "compose_type": details["compose_type"],
             "queue_status": details["queue_status"],
-            "image_size":   details["image_size"]
+            "image_size":   details["image_size"],
+            "uploads":      summaries,
     }
 
 def uuid_tar(cfg, uuid, metadata=False, image=False, logs=False):

--- a/src/pylorax/api/server.py
+++ b/src/pylorax/api/server.py
@@ -89,6 +89,10 @@ server.register_blueprint(v0_api, url_prefix="/api/v0/")
 
 # Register the v1 API on /api/v1/
 # Use v0 routes by default
-server.register_blueprint(v0_api, url_prefix="/api/v1/",
-                          skip_rules=["/projects/source/info/<source_names>", "/projects/source/new"])
+skip_rules = [
+    "/compose",
+    "/projects/source/info/<source_names>",
+    "/projects/source/new",
+]
+server.register_blueprint(v0_api, url_prefix="/api/v1/", skip_rules=skip_rules)
 server.register_blueprint(v1_api, url_prefix="/api/v1/")

--- a/src/pylorax/api/toml.py
+++ b/src/pylorax/api/toml.py
@@ -31,3 +31,12 @@ def loads(s):
 def dumps(o):
     # strip the result, because `toml.dumps` adds a lot of newlines
     return toml.dumps(o, encoder=toml.TomlEncoder(dict)).strip()
+
+def load(file):
+    try:
+        return toml.load(file)
+    except toml.TomlDecodeError as e:
+        raise TomlError(e.msg, e.doc, e.pos)
+
+def dump(o, file):
+    return toml.dump(o, file)

--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -64,7 +64,7 @@ from pylorax.api.projects import projects_list, projects_info, projects_depsolve
 from pylorax.api.projects import modules_list, modules_info, ProjectsError, repo_to_source
 from pylorax.api.projects import get_repo_sources, delete_repo_source, source_to_repo, dnf_repo_to_file_repo
 from pylorax.api.queue import queue_status, build_status, uuid_delete, uuid_status, uuid_info
-from pylorax.api.queue import uuid_tar, uuid_image, uuid_cancel, uuid_log
+from pylorax.api.queue import uuid_tar, uuid_image, uuid_cancel, uuid_log, uuid_schedule_upload, uuid_remove_upload, get_type_provider
 from pylorax.api.recipes import list_branch_files, read_recipe_commit, recipe_filename, list_commits
 from pylorax.api.recipes import recipe_from_dict, recipe_from_toml, commit_recipe, delete_recipe, revert_recipe
 from pylorax.api.recipes import tag_recipe_commit, recipe_diff, RecipeFileError
@@ -72,6 +72,9 @@ from pylorax.api.regexes import VALID_API_STRING, VALID_BLUEPRINT_NAME
 import pylorax.api.toml as toml
 from pylorax.api.utils import take_limits, blueprint_exists
 from pylorax.api.workspace import workspace_read, workspace_write, workspace_delete
+
+from lifted.queue import get_upload, reset_upload, cancel_upload, delete_upload
+from lifted.providers import list_providers, resolve_provider, validate_settings, save_settings
 
 # The API functions don't actually get called by any code here
 # pylint: disable=unused-variable
@@ -1496,6 +1499,18 @@ def v0_compose_start():
     if not blueprint_exists(api, branch, blueprint_name):
         errors.append({"id": UNKNOWN_BLUEPRINT, "msg": "Unknown blueprint name: %s" % blueprint_name})
 
+    if "upload" in compose:
+        try:
+            image_name = compose["upload"]["image_name"]
+            settings = compose["upload"]["settings"]
+        except KeyError as e:
+            errors.append({"id": UPLOAD_ERROR, "msg": str(e)})
+        provider_name = get_type_provider(compose_type)
+        try:
+            validate_settings(api.config["COMPOSER_CFG"]["upload"], provider_name, settings, image_name)
+        except ValueError as e:
+            errors.append({"id": UPLOAD_ERROR, "msg": str(e)})
+
     if errors:
         return jsonify(status=False, errors=errors), 400
 
@@ -1507,6 +1522,14 @@ def v0_compose_start():
             return jsonify(status=False, errors=[{"id": BAD_COMPOSE_TYPE, "msg": str(e)}]), 400
         else:
             return jsonify(status=False, errors=[{"id": BUILD_FAILED, "msg": str(e)}]), 400
+
+    if "upload" in compose:
+        upload_uuid = uuid_schedule_upload(
+            api.config["COMPOSER_CFG"],
+            build_id,
+            image_name,
+            settings
+        )
 
     return jsonify(status=True, build_id=build_id)
 
@@ -2021,3 +2044,142 @@ def v0_compose_log_tail(uuid):
         return Response(uuid_log(api.config["COMPOSER_CFG"], uuid, size), direct_passthrough=True)
     except RuntimeError as e:
         return jsonify(status=False, errors=[{"id": COMPOSE_ERROR, "msg": str(e)}]), 400
+
+@v0_api.route("/compose/uploads/schedule", defaults={'compose_uuid': ""}, methods=["POST"])
+@v0_api.route("/compose/uploads/schedule/<compose_uuid>", methods=["POST"])
+@checkparams([("compose_uuid", "", "no compose UUID given")])
+def v0_compose_uploads_schedule(compose_uuid):
+    """Schedule an upload of a compose to the associated cloud provider"""
+    if VALID_API_STRING.match(compose_uuid) is None:
+        return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
+
+    parsed = request.get_json(cache=False)
+    if not parsed:
+        return jsonify(status=False, errors=[{"id": MISSING_POST, "msg": "Missing POST body"}]), 400
+    try:
+        image_name = parsed["image_name"]
+        settings = parsed["settings"]
+    except KeyError as e:
+        return jsonify(status=False, errors=[{"id": UPLOAD_ERROR, "msg": str(e)}]), 400
+
+    try:
+        upload_uuid = uuid_schedule_upload(
+            api.config["COMPOSER_CFG"],
+            compose_uuid,
+            image_name,
+            settings
+        )
+    except RuntimeError as e:
+        return jsonify(status=False, errors=[{"id": UPLOAD_ERROR, "msg": str(e)}]), 400
+    return jsonify(status=True, upload_uuid=upload_uuid)
+
+@v0_api.route("/compose/uploads/delete", defaults={"compose_uuid": "", "upload_uuid": ""}, methods=["DELETE"])
+@v0_api.route("/compose/uploads/delete/<compose_uuid>/<upload_uuid>", methods=["DELETE"])
+@checkparams([("compose_uuid", "", "no compose UUID given"), ("upload_uuid", "", "no upload UUID given")])
+def v0_compose_uploads_delete(compose_uuid, upload_uuid):
+    """Delete an upload and disassociate it from its compose"""
+    if None in (VALID_API_STRING.match(compose_uuid), VALID_API_STRING.match(upload_uuid)):
+        return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
+
+    if not uuid_status(api.config["COMPOSER_CFG"], compose_uuid):
+        return jsonify(status=False, errors=[{"id": UNKNOWN_UUID, "msg": "%s is not a valid build uuid" % compose_uuid}]), 400
+    uuid_remove_upload(api.config["COMPOSER_CFG"], compose_uuid, upload_uuid)
+    try:
+        delete_upload(api.config["COMPOSER_CFG"]["upload"], upload_uuid)
+    except RuntimeError as error:
+        return jsonify(status=False, errors=[{"id": UPLOAD_ERROR, "msg": str(error)}])
+    return jsonify(status=True, upload_uuid=upload_uuid)
+
+@v0_api.route("/upload/info", defaults={"uuid": ""})
+@v0_api.route("/upload/info/<uuid>")
+@checkparams([("uuid", "", "no UUID given")])
+def v0_upload_info(uuid):
+    """Returns information about a given upload"""
+    if VALID_API_STRING.match(uuid) is None:
+        return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
+
+    try:
+        upload = get_upload(api.config["COMPOSER_CFG"]["upload"], uuid).summary()
+    except RuntimeError as error:
+        return jsonify(status=False, errors=[{"id": UPLOAD_ERROR, "msg": str(error)}])
+    return jsonify(status=True, upload=upload)
+
+@v0_api.route("/upload/log", defaults={"uuid": ""})
+@v0_api.route("/upload/log/<uuid>")
+@checkparams([("uuid", "", "no UUID given")])
+def v0_upload_log(uuid):
+    """Returns an upload's log"""
+    if VALID_API_STRING.match(uuid) is None:
+        return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
+
+    try:
+        upload = get_upload(api.config["COMPOSER_CFG"]["upload"], uuid)
+    except RuntimeError as error:
+        return jsonify(status=False, errors=[{"id": UPLOAD_ERROR, "msg": str(error)}])
+    return jsonify(status=True, log=upload.upload_log)
+
+@v0_api.route("/upload/reset", defaults={"uuid": ""}, methods=["POST"])
+@v0_api.route("/upload/reset/<uuid>", methods=["POST"])
+@checkparams([("uuid", "", "no UUID given")])
+def v0_upload_reset(uuid):
+    """Reset an upload so it can be attempted again"""
+    if VALID_API_STRING.match(uuid) is None:
+        return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
+
+    parsed = request.get_json(cache=False)
+    image_name = parsed.get("image_name") if parsed else None
+    settings = parsed.get("settings") if parsed else None
+
+    try:
+        reset_upload(api.config["COMPOSER_CFG"]["upload"], uuid, image_name, settings)
+    except RuntimeError as error:
+        # TODO more specific errors
+        return jsonify(status=False, errors=[{"id": UPLOAD_ERROR, "msg": str(error)}])
+    return jsonify(status=True, uuid=uuid)
+
+@v0_api.route("/upload/cancel", defaults={"uuid": ""}, methods=["DELETE"])
+@v0_api.route("/upload/cancel/<uuid>", methods=["DELETE"])
+@checkparams([("uuid", "", "no UUID given")])
+def v0_upload_cancel(uuid):
+    """Cancel an upload that is either queued or in progress"""
+    if VALID_API_STRING.match(uuid) is None:
+        return jsonify(status=False, errors=[{"id": INVALID_CHARS, "msg": "Invalid characters in API path"}]), 400
+
+    try:
+        cancel_upload(api.config["COMPOSER_CFG"]["upload"], uuid)
+    except RuntimeError as error:
+        # TODO more specific errors
+        return jsonify(status=False, errors=[{"id": UPLOAD_ERROR, "msg": str(error)}])
+    return jsonify(status=True, uuid=uuid)
+
+@v0_api.route("/upload/providers")
+def v0_upload_providers():
+    """Return the list of available upload providers"""
+    return jsonify(providers=list_providers(api.config["COMPOSER_CFG"]["upload"]))
+
+@v0_api.route("/upload/provider/info", defaults={"provider_name": ""})
+@v0_api.route("/upload/provider/info/<provider_name>")
+@checkparams([("provider_name", "", "no provider given")])
+def v0_provider_info(provider_name):
+    """Return information about a provider, including its display name and
+    settings. Refer to the `resolve_provider` function."""
+    try:
+        provider = resolve_provider(api.config["COMPOSER_CFG"]["upload"], provider_name)
+    except RuntimeError as error:
+        return jsonify(status=False, errors=[{"id": UPLOAD_ERROR, "msg": str(error)}])
+    return jsonify(status=True, provider=provider)
+
+@v0_api.route("/upload/provider/update", defaults={"provider_name": ""}, methods=["POST"])
+@v0_api.route("/upload/provider/update/<provider_name>", methods=["POST"])
+@checkparams([("provider_name", "", "no provider given")])
+def v0_provider_update(provider_name):
+    """Update a provider's saved settings"""
+    parsed = request.get_json(cache=False)
+    if parsed is None:
+        return jsonify(status=False, errors=[{"id": MISSING_POST, "msg": "Missing POST body"}]), 400
+
+    try:
+        save_settings(api.config["COMPOSER_CFG"]["upload"], provider_name, parsed)
+    except (RuntimeError, ValueError) as error:
+        return jsonify(status=False, errors=[{"id": UPLOAD_ERROR, "msg": str(error)}])
+    return jsonify(status=True)

--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -2161,25 +2161,26 @@ def v0_upload_providers():
 @v0_api.route("/upload/provider/info/<provider_name>")
 @checkparams([("provider_name", "", "no provider given")])
 def v0_provider_info(provider_name):
-    """Return information about a provider, including its display name and
-    settings. Refer to the `resolve_provider` function."""
+    """Return information about a provider, including its display name,
+    expected settings, and saved profiles. Refer to the `resolve_provider`
+    function."""
     try:
         provider = resolve_provider(api.config["COMPOSER_CFG"]["upload"], provider_name)
     except RuntimeError as error:
         return jsonify(status=False, errors=[{"id": UPLOAD_ERROR, "msg": str(error)}])
     return jsonify(status=True, provider=provider)
 
-@v0_api.route("/upload/provider/update", defaults={"provider_name": ""}, methods=["POST"])
-@v0_api.route("/upload/provider/update/<provider_name>", methods=["POST"])
-@checkparams([("provider_name", "", "no provider given")])
-def v0_provider_update(provider_name):
+@v0_api.route("/upload/provider/save", defaults={"provider_name": ""}, methods=["POST"])
+@v0_api.route("/upload/provider/save/<provider_name>/<profile>", methods=["POST"])
+@checkparams([("provider_name", "", "no provider given"), ("profile", "", "no profile given")])
+def v0_provider_save(provider_name, profile):
     """Update a provider's saved settings"""
     parsed = request.get_json(cache=False)
     if parsed is None:
         return jsonify(status=False, errors=[{"id": MISSING_POST, "msg": "Missing POST body"}]), 400
 
     try:
-        save_settings(api.config["COMPOSER_CFG"]["upload"], provider_name, parsed)
+        save_settings(api.config["COMPOSER_CFG"]["upload"], provider_name, profile, parsed)
     except (RuntimeError, ValueError) as error:
         return jsonify(status=False, errors=[{"id": UPLOAD_ERROR, "msg": str(error)}])
     return jsonify(status=True)

--- a/src/sbin/lorax-composer
+++ b/src/sbin/lorax-composer
@@ -23,6 +23,7 @@ program_log = logging.getLogger("program")
 pylorax_log = logging.getLogger("pylorax")
 server_log = logging.getLogger("server")
 dnf_log = logging.getLogger("dnf")
+lifted_log = logging.getLogger("lifted")
 
 import grp
 import os
@@ -43,12 +44,15 @@ from pylorax.api.queue import start_queue_monitor
 from pylorax.api.recipes import open_or_create_repo, commit_recipe_directory
 from pylorax.api.server import server, GitLock
 
+from lifted.queue import start_upload_monitor
+
 VERSION = "{0}-{1}".format(os.path.basename(sys.argv[0]), vernum)
 
 def setup_logging(logfile):
     # Setup logging to console and to logfile
     log.setLevel(logging.DEBUG)
     pylorax_log.setLevel(logging.DEBUG)
+    lifted_log.setLevel(logging.DEBUG)
 
     sh = logging.StreamHandler()
     sh.setLevel(logging.INFO)
@@ -56,6 +60,7 @@ def setup_logging(logfile):
     sh.setFormatter(fmt)
     log.addHandler(sh)
     pylorax_log.addHandler(sh)
+    lifted_log.addHandler(sh)
 
     fh = logging.FileHandler(filename=logfile)
     fh.setLevel(logging.DEBUG)
@@ -63,6 +68,7 @@ def setup_logging(logfile):
     fh.setFormatter(fmt)
     log.addHandler(fh)
     pylorax_log.addHandler(fh)
+    lifted_log.addHandler(fh)
 
     # External program output log
     program_log.setLevel(logging.DEBUG)
@@ -243,6 +249,8 @@ if __name__ == '__main__':
         listener.listen(socket.SOMAXCONN)
 
     start_queue_monitor(server.config["COMPOSER_CFG"], uid, gid)
+
+    start_upload_monitor(server.config["COMPOSER_CFG"]["upload"])
 
     # Change user and group on the main process.  Note that this still happens even if
     # --user and --group were passed in, but changing to the same user should be fine.


### PR DESCRIPTION
Thought now would be an appropriate time to start a conversation about the progress on cloud upload so far. I'll start by describing the high-level design and then lay out what I think still needs to be done.

I've managed to keep the bulk of the upload logic separate from the rest of lorax. It currently exists as a package called "lifted" in [src/lifted](https://github.com/evan-goode/lorax/tree/lifted/src/lifted). Uploads are [queued and stored ](https://github.com/evan-goode/lorax/blob/e6431430abcd46acf2dd5034663cb09c5fcaf886/src/lifted/queue.py) in a way similar to how composes are. When an upload is scheduled, an [Upload object](https://github.com/evan-goode/lorax/blob/e6431430abcd46acf2dd5034663cb09c5fcaf886/src/lifted/upload.py#L47) is created with the upload's settings and state, and this object gets serialized and written to `/var/lib/lorax/upload/queue/$upload_uuid`. If an upload is scheduled from a compose that isn't finished yet, the upload starts with a status of "WAITING". As soon as the associated compose finishes, the upload gets marked "READY". A [monitor thread](https://github.com/evan-goode/lorax/blob/e6431430abcd46acf2dd5034663cb09c5fcaf886/src/lifted/queue.py#L242) watches for "READY" uploads, kicks each one off as separate process, and marks them as "RUNNING". Since each running upload gets its own PID, we can [cancel an upload](https://github.com/evan-goode/lorax/blob/e6431430abcd46acf2dd5034663cb09c5fcaf886/src/lifted/upload.py#L144) simply by sending it a SIGINT. 

The actual uploading is done using Ansible playbooks and the [Ansible cloud modules](https://docs.ansible.com/ansible/latest/modules/list_of_cloud_modules.html). I currently have uploads to Azure, vSphere, and OpenStack working. [Each cloud provider](https://github.com/evan-goode/lorax/tree/e6431430abcd46acf2dd5034663cb09c5fcaf886/share/lifted/providers) has both a `provider.toml` file containing some metadata (mostly describing the credentials and settings it expects) and a `playbook.yaml`. When a provider's settings get [saved](https://github.com/evan-goode/lorax/blob/e6431430abcd46acf2dd5034663cb09c5fcaf886/src/pylorax/api/v0.py#L2205) for future use, they're written to `/var/lib/lorax/upload/settings/$provider_name.toml`.

The API should now support most of what we'll need on the front end, including:

- Scheduling an upload to run as soon as a compose finishes, or immediately from a finished compose
- Cancelling uploads
- Retrying a failed upload with new settings
- Fetching an upload's Ansible logs
- Validating, storing, and retrieving settings per cloud provider

Some things we still need to work on:

- Gracefully handling missing dependencies: any upload needs `python3-ansible-runner` installed, and right now lorax-composer just crashes if it's missing. Furthermore, each cloud provider has its own set of dependencies. API routes should return some special error if any required package is missing, and Cockpit would ideally offer a one-click install.
- The Ansible cloud modules themselves need a little work:
     - The Azure modules depend on an older version of the Azure Python SDK than is packaged in Fedora.
     - The AWS modules are missing some functionality we need; see https://github.com/ansible/ansible/issues/53453. I'm not sure the solution mentioned there addresses our problem.
     - We'll need to write a couple new modules if we want to support Alibaba Cloud. There isn't anything yet for uploading or importing VM images. 
- Configuration: I just tacked on an "upload" section to the composer config, so let me know if you think there's a more appropriate way to pass paths to lifted.
- Scheduling and managing uploads from composer-cli
- Uploads should be run as an unprivileged user
- Logs should probably not contain sensitive API tokens

For now, the following installations should be all you need to get Azure, OpenStack, and vSphere working:
```
sudo dnf install -y python3-ansible-runner python3-openstacksdk
sudo pip3 install ansible[azure]
```
