### PR TITLE
Add support for dnf variables to repo sources

### DIFF
--- a/src/pylorax/api/dnfbase.py
+++ b/src/pylorax/api/dnfbase.py
@@ -104,6 +104,11 @@ def get_base_object(conf):
     if conf.has_option("dnf", "sslverify") and not conf.getboolean("dnf", "sslverify"):
         dbc.sslverify = False
 
+    # If the system repos are enabled read the dnf vars from /etc/dnf/vars/
+    if not conf.has_option("repos", "use_system_repos") or conf.getboolean("repos", "use_system_repos"):
+        dbc.substitutions.update_from_etc("/")
+        log.info("dnf vars: %s", dbc.substitutions)
+
     _releasever = conf.get_default("composer", "releasever", None)
     if not _releasever:
         # Use the releasever of the host system

--- a/tests/pylorax/source/test-repo-v1-vars.toml
+++ b/tests/pylorax/source/test-repo-v1-vars.toml
@@ -1,0 +1,7 @@
+id = "new-repo-2-v1-vars"
+name = "API v1 toml new repo with vars"
+url = "file:///tmp/lorax-empty-repo-v1-$releasever-$basearch/"
+type = "yum-baseurl"
+check_ssl = true
+check_gpg = true
+gpgkey_urls = ["file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch"]

--- a/tests/pylorax/source/test-repo-vars.toml
+++ b/tests/pylorax/source/test-repo-vars.toml
@@ -1,0 +1,6 @@
+name = "new-repo-2-vars"
+url = "file:///tmp/lorax-empty-repo-$releasever-$basearch/"
+type = "yum-baseurl"
+check_ssl = true
+check_gpg = true
+gpgkey_urls = ["file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch"]

--- a/tests/pylorax/test_projects.py
+++ b/tests/pylorax/test_projects.py
@@ -28,7 +28,7 @@ from pylorax.api.projects import api_time, api_changelog, pkg_to_project, pkg_to
 from pylorax.api.projects import proj_to_module, projects_list, projects_info, projects_depsolve
 from pylorax.api.projects import modules_list, modules_info, ProjectsError, dep_evra, dep_nevra
 from pylorax.api.projects import repo_to_source, get_repo_sources, delete_repo_source, source_to_repo
-from pylorax.api.projects import dnf_repo_to_file_repo
+from pylorax.api.projects import source_to_repodict, dnf_repo_to_file_repo
 from pylorax.api.dnfbase import get_base_object
 
 class Package(object):
@@ -202,7 +202,6 @@ class ProjectsTest(unittest.TestCase):
         self.assertTrue("ctags" in names)               # default package
         self.assertFalse("cmake" in names)              # optional package
 
-
 class ConfigureTest(unittest.TestCase):
     @classmethod
     def setUpClass(self):
@@ -341,6 +340,25 @@ def singlerepo_v1():
     d["name"] = "One repo in the file"
     return d
 
+def singlerepo_vars_v0():
+    return {
+        "check_gpg": True,
+        "check_ssl": True,
+        "gpgkey_urls": [
+            "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch"
+        ],
+        "name": "single-repo",
+        "system": False,
+        "type": "yum-baseurl",
+        "url": "file:///tmp/lorax-empty-repo-$releasever-$basearch/"
+    }
+
+def singlerepo_vars_v1():
+    d = singlerepo_v0()
+    d["id"] = "single-repo"
+    d["name"] = "One repo in the file"
+    return d
+
 class SourceTest(unittest.TestCase):
     @classmethod
     def setUpClass(self):
@@ -443,50 +461,100 @@ class SourceTest(unittest.TestCase):
         repo = source_to_repo(fakerepo_baseurl_v0(), self.dbo.conf)
         self.assertEqual(repo.baseurl[0], fakerepo_baseurl_v0()["url"])
 
+    def test_source_to_repodict_baseurl(self):
+        """Test creating a repodict with a baseurl API v0"""
+        repo = source_to_repodict(fakerepo_baseurl_v0())
+        self.assertEqual(repo[1][0], fakerepo_baseurl_v0()["url"])
+
     def test_source_to_repo_baseurl_v1(self):
         """Test creating a dnf.Repo with a baseurl API v1"""
         repo = source_to_repo(fakerepo_baseurl_v1(), self.dbo.conf)
         self.assertEqual(repo.baseurl[0], fakerepo_baseurl_v1()["url"])
+
+    def test_source_to_repodict_baseurl_v1(self):
+        """Test creating a repodict with a baseurl API v1"""
+        repo = source_to_repodict(fakerepo_baseurl_v1())
+        self.assertEqual(repo[1][0], fakerepo_baseurl_v1()["url"])
 
     def test_source_to_repo_metalink(self):
         """Test creating a dnf.Repo with a metalink API v0"""
         repo = source_to_repo(fakerepo_metalink_v0(), self.dbo.conf)
         self.assertEqual(repo.metalink, fakerepo_metalink_v0()["url"])
 
+    def test_source_to_repodict_metalink(self):
+        """Test creating a repodict with a metalink API v0"""
+        repo = source_to_repodict(fakerepo_metalink_v0())
+        self.assertEqual(repo[2]["metalink"], fakerepo_metalink_v0()["url"])
+
     def test_source_to_repo_metalink_v1(self):
         """Test creating a dnf.Repo with a metalink API v1"""
         repo = source_to_repo(fakerepo_metalink_v1(), self.dbo.conf)
         self.assertEqual(repo.metalink, fakerepo_metalink_v1()["url"])
+
+    def test_source_to_repodict_metalink_v1(self):
+        """Test creating a repodict with a metalink API v1"""
+        repo = source_to_repodict(fakerepo_metalink_v1())
+        self.assertEqual(repo[2]["metalink"], fakerepo_metalink_v1()["url"])
 
     def test_source_to_repo_mirrorlist(self):
         """Test creating a dnf.Repo with a mirrorlist API v0"""
         repo = source_to_repo(fakerepo_mirrorlist_v0(), self.dbo.conf)
         self.assertEqual(repo.mirrorlist, fakerepo_mirrorlist_v0()["url"])
 
+    def test_source_to_repodict_mirrorlist(self):
+        """Test creating a repodict with a mirrorlist API v0"""
+        repo = source_to_repodict(fakerepo_mirrorlist_v0())
+        self.assertEqual(repo[2]["mirrorlist"], fakerepo_mirrorlist_v0()["url"])
+
     def test_source_to_repo_mirrorlist_v1(self):
         """Test creating a dnf.Repo with a mirrorlist"""
         repo = source_to_repo(fakerepo_mirrorlist_v1(), self.dbo.conf)
         self.assertEqual(repo.mirrorlist, fakerepo_mirrorlist_v1()["url"])
+
+    def test_source_to_repodict_mirrorlist_v1(self):
+        """Test creating a repodict with a mirrorlist"""
+        repo = source_to_repodict(fakerepo_mirrorlist_v1())
+        self.assertEqual(repo[2]["mirrorlist"], fakerepo_mirrorlist_v1()["url"])
 
     def test_source_to_repo_proxy(self):
         """Test creating a dnf.Repo with a proxy API v0"""
         repo = source_to_repo(fakerepo_proxy_v0(), self.dbo.conf)
         self.assertEqual(repo.proxy, fakerepo_proxy_v0()["proxy"])
 
+    def test_source_to_repodict_proxy(self):
+        """Test creating a repodict with a proxy API v0"""
+        repo = source_to_repodict(fakerepo_proxy_v0())
+        self.assertEqual(repo[2]["proxy"], fakerepo_proxy_v0()["proxy"])
+
     def test_source_to_repo_proxy_v1(self):
         """Test creating a dnf.Repo with a proxy API v1"""
         repo = source_to_repo(fakerepo_proxy_v1(), self.dbo.conf)
         self.assertEqual(repo.proxy, fakerepo_proxy_v1()["proxy"])
+
+    def test_source_to_repodict_proxy_v1(self):
+        """Test creating a repodict with a proxy API v1"""
+        repo = source_to_repodict(fakerepo_proxy_v1())
+        self.assertEqual(repo[2]["proxy"], fakerepo_proxy_v1()["proxy"])
 
     def test_source_to_repo_gpgkey(self):
         """Test creating a dnf.Repo with a proxy API v0"""
         repo = source_to_repo(fakerepo_gpgkey_v0(), self.dbo.conf)
         self.assertEqual(repo.gpgkey[0], fakerepo_gpgkey_v0()["gpgkey_urls"][0])
 
+    def test_source_to_repodict_gpgkey(self):
+        """Test creating a repodict with a proxy API v0"""
+        repo = source_to_repodict(fakerepo_gpgkey_v0())
+        self.assertEqual(repo[2]["gpgkey"][0], fakerepo_gpgkey_v0()["gpgkey_urls"][0])
+
     def test_source_to_repo_gpgkey_v1(self):
         """Test creating a dnf.Repo with a proxy API v1"""
         repo = source_to_repo(fakerepo_gpgkey_v1(), self.dbo.conf)
         self.assertEqual(repo.gpgkey[0], fakerepo_gpgkey_v1()["gpgkey_urls"][0])
+
+    def test_source_to_repodict_gpgkey_v1(self):
+        """Test creating a repodict with a proxy API v1"""
+        repo = source_to_repodict(fakerepo_gpgkey_v1())
+        self.assertEqual(repo[2]["gpgkey"][0], fakerepo_gpgkey_v1()["gpgkey_urls"][0])
 
     def test_drtfr_baseurl(self):
         """Test creating a dnf .repo file from a baseurl Repo object"""


### PR DESCRIPTION
This now loads the system dnf vars from /etc/dnf/vars at startup, if
system repos are enabled, and it substitutes the values in the sources
when loaded, as well as when added.

Also includes tests.