### PR TITLE
When launching AWS instances wait for the one we just launched

### DIFF
--- a/tests/cli/playbooks/aws/instance.yml
+++ b/tests/cli/playbooks/aws/instance.yml
@@ -22,11 +22,14 @@
       port: 22
       state: started
     with_items: "{{ ec2.instances }}"
+    when: item.image_id == ami_id
 
   - name: Save instance ID
     local_action: copy content={{ item.instance_id }} dest={{ tmp_dir }}/instance_id
     with_items: "{{ ec2.instances }}"
+    when: item.image_id == ami_id
 
   - name: Save public IP
     local_action: copy content={{ item.public_ip_address }} dest={{ tmp_dir }}/public_ip
     with_items: "{{ ec2.instances }}"
+    when: item.image_id == ami_id

--- a/tests/cli/test_build_and_deploy_aws.sh
+++ b/tests/cli/test_build_and_deploy_aws.sh
@@ -162,7 +162,6 @@ __EOF__
                        'key_name=$KEY_NAME \
                         ssh_key_dir=$SSH_KEY_DIR \
                         ami_id=$AMI_ID \
-                        key_name=$KEY_NAME \
                         tmp_dir=$TMP_DIR' \
                      $PLAYBOOKS_DIR/instance.yml"
 


### PR DESCRIPTION
because the ec2.instances variable will return all that are
currently running