### PR TITLE
Use smarter multipath detection logic during OS installation.

### DIFF
--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -106,7 +106,7 @@ symlink ../run/install mnt/install
 append etc/depmod.d/dd.conf "search updates built-in"
 
 ## create multipath.conf so multipath gets auto-started
-append etc/multipath.conf "defaults {\n\tfind_multipaths yes\n\tuser_friendly_names yes\n}\n"
+append etc/multipath.conf "defaults {\n\tfind_multipaths smart\n\tuser_friendly_names yes\n}\n"
 append etc/multipath.conf "blacklist_exceptions {\n\tproperty \"(SCSI_IDENT_|ID_WWN)\"\n}\n"
 
 ## make lvm auto-activate


### PR DESCRIPTION
This new setting for 'find_multipaths' tries to prevent things like
LVM from going ahead and activating LVM on the individual disks/paths
until there is reasonable certainty (via a timeout) that the device
is not a component of a multipath set.