### PR TITLE
Test for --no-system-repos option for lorax-composer

### DIFF
--- a/test/check-cli
+++ b/test/check-cli
@@ -36,6 +36,10 @@ class TestLiveIso(composertest.ComposerTestCase):
     def test_live_iso(self):
         self.runCliTest("/tests/cli/test_compose_live-iso.sh")
 
+class TestRepos(composertest.ComposerTestCase):
+    def test_repos_sanity(self):
+        self.runCliTest("/tests/cli/test_repos_sanity.sh")
+
 
 class TestTar(composertest.ComposerTestCase):
     def test_tar(self):

--- a/test/run
+++ b/test/run
@@ -17,4 +17,5 @@ if [ -n "$TEST_SCENARIO" ]; then
 else
   test/check-cli TestImages
   test/check-api
+  test/check-cli TestRepos
 fi

--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+. /usr/share/beakerlib/beakerlib.sh
+
 # Monkey-patch beakerlib to exit on first failure if COMPOSER_TEST_FAIL_FAST is
 # set. https://github.com/beakerlib/beakerlib/issues/42
+COMPOSER_TEST_FAIL_FAST=${COMPOSER_TEST_FAIL_FAST:-0}
 if [ "$COMPOSER_TEST_FAIL_FAST" == "1" ]; then
   eval "original$(declare -f __INTERNAL_LogAndJournalFail)"
 
@@ -39,6 +42,58 @@ boot_image() {
     done;
 }
 
+wait_for_composer() {
+    tries=0
+    until curl -m 15 --unix-socket /run/weldr/api.socket http://localhost:4000/api/status | grep 'db_supported.*true'; do
+        tries=$((tries + 1))
+        if [ $tries -gt 50 ]; then
+            exit 1
+        fi
+        sleep 5
+        echo "DEBUG: Waiting for backend API to become ready before testing ..."
+    done;
+}
+
+composer_start() {
+    local rc
+    local params="$@"
+
+    if [[ -z "$CLI" || "$CLI" == "./src/bin/composer-cli" ]]; then
+        ./src/sbin/lorax-composer $params --sharedir $SHARE_DIR $BLUEPRINTS_DIR &
+    elif [ -n "$params" ]; then
+        /usr/sbin/lorax-composer $params /var/lib/lorax/composer/blueprints &
+    else
+        # socket stop/start seems to be necessary for a proper service restart
+        # after a previous direct manual run for it to work properly
+        systemctl start lorax-composer.socket
+        systemctl start lorax-composer
+    fi
+    rc=$?
+
+    # wait for the backend to become ready
+    if [ "$rc" -eq 0 ]; then
+        wait_for_composer
+    else
+        rlLogFail "Unable to start lorax-composer (exit code $rc)"
+    fi
+    return $rc
+}
+
+composer_stop() {
+    MANUAL=${MANUAL:-0}
+    # socket stop/start seems to be necessary for a proper service restart
+    # after a previous direct manual run for it to work properly
+    if systemctl list-units | grep -q lorax-composer.socket; then
+        systemctl stop lorax-composer.socket
+    fi
+
+    if [[ -z "$CLI" || "$CLI" == "./src/bin/composer-cli" || "$MANUAL" == "1" ]]; then
+        pkill -9 lorax-composer
+        rm -f /run/weldr/api.socket
+    else
+        systemctl stop lorax-composer
+    fi
+}
 
 # a generic helper function unifying the specific checks executed on a running
 # image instance

--- a/tests/cli/test_repos_sanity.sh
+++ b/tests/cli/test_repos_sanity.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Note: execute this file from the project root directory
+
+set -e
+
+. /usr/share/beakerlib/beakerlib.sh
+. $(dirname $0)/lib/lib.sh
+
+CLI="${CLI:-./src/bin/composer-cli}"
+
+rlJournalStart
+    rlPhaseStartSetup
+        repodir_backup=$(mktemp -d composerrepos-XXXXX)
+        composer_stop
+        rlRun -t -c "mv /var/lib/lorax/composer/repos.d/* $repodir_backup"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Run lorax-composer with --no-system-repos option and empty repos.d"
+        composer_start --no-system-repos
+
+        # check that there are no composer repos available
+        rlRun -t -c "$CLI sources list | grep -v '^$' | wc -l | grep '^0$'"
+        present_repos=$(ls /var/lib/lorax/composer/repos.d)
+        if [ -z "$present_repos" ]; then
+            rlPass "No repos found in repos.d"
+        else
+            rlFail "The following repos were found in repos.d: $present_repos"
+        fi
+
+        # starting a compose without available repos should fail due to a depsolving error
+        rlRun -t -c "tmp_output='$($CLI compose start example-http-server partitioned-disk 2>&1)'"
+        rlRun -t -c "echo '$tmp_output' | grep -q 'Problem depsolving example-http-server:'"
+        MANUAL=1 composer_stop
+    rlPhaseEnd
+
+    rlPhaseStartTest "Run lorax-composer with --no-system-repos and manually created content in repos.d"
+    echo '[fedora]
+name=Fedora $releasever - $basearch
+failovermethod=priority
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+enabled=1
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[fedora-modular]
+name=Fedora Modular $releasever - $basearch
+failovermethod=priority
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-$releasever&arch=$basearch
+enabled=1
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[updates]
+name=Fedora $releasever - $basearch - Updates
+failovermethod=priority
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
+enabled=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[updates-modular]
+name=Fedora Modular $releasever - $basearch - Updates
+failovermethod=priority
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f$releasever&arch=$basearch
+enabled=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+' > /var/lib/lorax/composer/repos.d/test.repo
+
+        composer_start --no-system-repos
+        present_repos=$(ls /var/lib/lorax/composer/repos.d/)
+        rlAssertEquals "Only test.repo found in repos.d" "$present_repos" "test.repo"
+
+        UUID=$(composer-cli compose start example-http-server partitioned-disk)
+        rlAssertEquals "exit code should be zero" $? 0
+        UUID=$(echo $UUID | cut -f 2 -d' ')
+
+        wait_for_compose $UUID
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        $CLI compose delete $UUID
+        MANUAL=1 composer_stop
+        rlRun -t -c "rm -rf /var/lib/lorax/composer/repos.d"
+        rlRun -t -c "mv $repodir_backup /var/lib/lorax/composer/repos.d"
+        composer_start
+    rlPhaseEnd
+rlJournalEnd
+rlJournalPrintText


### PR DESCRIPTION
The test seems to work fine. One drawback I'm aware of is the lack of `rlRun` use to run the various commands in the new functions in `lib.sh`, as it resulted in the test(s) failing due to unbound variable in beakerlib:
`/usr/share/beakerlib/testing.sh: line 799: $3: unbound variable`

I haven't figured out (yet) why this happens at that stage, but not later on when beakerlib functions are used.