### PR TITLE
creator.py: include dmsquash-live-ntfs by default

### DIFF
--- a/docs/html/_modules/pylorax/creator.html
+++ b/docs/html/_modules/pylorax/creator.html
@@ -206,7 +206,7 @@
 
 
 <span class="c1"># Default parameters for rebuilding initramfs, override with --dracut-args</span>
-<span class="n">DRACUT_DEFAULT</span> <span class="o">=</span> <span class="p">[</span><span class="s2">&quot;--xz&quot;</span><span class="p">,</span> <span class="s2">&quot;--add&quot;</span><span class="p">,</span> <span class="s2">&quot;livenet dmsquash-live convertfs pollcdrom qemu qemu-net&quot;</span><span class="p">,</span>
+<span class="n">DRACUT_DEFAULT</span> <span class="o">=</span> <span class="p">[</span><span class="s2">&quot;--xz&quot;</span><span class="p">,</span> <span class="s2">&quot;--add&quot;</span><span class="p">,</span> <span class="s2">&quot;livenet dmsquash-live dmsquash-live-ntfs convertfs pollcdrom qemu qemu-net&quot;</span><span class="p">,</span>
                   <span class="s2">&quot;--omit&quot;</span><span class="p">,</span> <span class="s2">&quot;plymouth&quot;</span><span class="p">,</span> <span class="s2">&quot;--no-hostonly&quot;</span><span class="p">,</span> <span class="s2">&quot;--debug&quot;</span><span class="p">,</span> <span class="s2">&quot;--no-early-microcode&quot;</span><span class="p">]</span>
 
 <span class="n">RUNTIME</span> <span class="o">=</span> <span class="s2">&quot;images/install.img&quot;</span>

--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -48,7 +48,7 @@ from pylorax.sysutils import joinpaths, remove
 
 
 # Default parameters for rebuilding initramfs, override with --dracut-args
-DRACUT_DEFAULT = ["--xz", "--add", "livenet dmsquash-live convertfs pollcdrom qemu qemu-net",
+DRACUT_DEFAULT = ["--xz", "--add", "livenet dmsquash-live dmsquash-live-ntfs convertfs pollcdrom qemu qemu-net",
                   "--omit", "plymouth", "--no-hostonly", "--debug", "--no-early-microcode"]
 
 RUNTIME = "images/install.img"


### PR DESCRIPTION
Add dmsquash-live-ntfs to the default dracut modules in livecd builds.

The omission of this is probably why:

  https://bugzilla.redhat.com/show_bug.cgi?id=1449410

didn't work out as intended (I suspect it was closed unfixed).

Without this, initramfs winds up with the ntfs-3g tools lying
around, but no hooks cause them to actually get used.

AFAICT, this is a legit bugfix, not a "proposed enhancement"
so to speak.  To test that this actually fixed the problem (well,
/a/ problem, at least), I used some scripts:

  https://github.com/gmt/test-respin-fedora-ntfsable-iso

Signed-off-by: Greg Turner <gmt@be-evil.net>