### PR TITLE
Don't depsolve output types at startup

### DIFF
--- a/src/pylorax/api/compose.py
+++ b/src/pylorax/api/compose.py
@@ -46,7 +46,7 @@ from pykickstart.version import makeVersion
 
 from pylorax import ArchData, find_templates, get_buildarch
 from pylorax.api.gitrpm import create_gitrpm_repo
-from pylorax.api.projects import projects_depsolve, projects_depsolve_with_size, dep_nevra
+from pylorax.api.projects import projects_depsolve_with_size, dep_nevra
 from pylorax.api.projects import ProjectsError
 from pylorax.api.recipes import read_recipe_and_id
 from pylorax.api.timestamp import TS_CREATED, write_timestamp
@@ -55,36 +55,6 @@ from pylorax.base import DataHolder
 from pylorax.imgutils import default_image_name
 from pylorax.ltmpl import LiveTemplateRunner
 from pylorax.sysutils import joinpaths, flatconfig
-
-
-def test_templates(dbo, share_dir):
-    """ Try depsolving each of the the templates and report any errors
-
-    :param dbo: dnf base object
-    :type dbo: dnf.Base
-    :returns: List of template types and errors
-    :rtype: List of errors
-
-    Return a list of templates and errors encountered or an empty list
-    """
-    template_errors = []
-    for compose_type in compose_types(share_dir):
-        # Read the kickstart template for this type
-        ks_template_path = joinpaths(share_dir, "composer", compose_type) + ".ks"
-        ks_template = open(ks_template_path, "r").read()
-
-        # How much space will the packages in the default template take?
-        ks_version = makeVersion()
-        ks = KickstartParser(ks_version, errorsAreFatal=False, missingIncludeIsFatal=False)
-        ks.readKickstartFromString(ks_template+"\n%end\n")
-        pkgs = [(name, "*") for name in ks.handler.packages.packageList]
-        grps = [grp.name for grp in ks.handler.packages.groupList]
-        try:
-            projects_depsolve(dbo, pkgs, grps)
-        except ProjectsError as e:
-            template_errors.append("Error depsolving %s: %s" % (compose_type, str(e)))
-
-    return template_errors
 
 
 def repo_to_ks(r, url="url"):

--- a/src/pylorax/api/server.py
+++ b/src/pylorax/api/server.py
@@ -69,8 +69,7 @@ def api_status():
             "msgs": []}
 
     The 'msgs' field can be a list of strings describing startup problems or status that
-    should be displayed to the user. eg. if the compose templates are not depsolving properly
-    the errors will be in 'msgs'.
+    should be displayed to the user.
     """
     return jsonify(backend="lorax-composer",
                    build=vernum,
@@ -78,7 +77,7 @@ def api_status():
                    db_version="0",
                    schema_version="0",
                    db_supported=True,
-                   msgs=server.config["TEMPLATE_ERRORS"])
+                   msgs=[])
 
 @server.errorhandler(werkzeug.exceptions.HTTPException)
 def bad_request(error):

--- a/src/sbin/lorax-composer
+++ b/src/sbin/lorax-composer
@@ -37,7 +37,6 @@ from gevent.pywsgi import WSGIServer
 from pylorax import vernum, log_selinux_state
 from pylorax.api.cmdline import lorax_composer_parser
 from pylorax.api.config import configure, make_dnf_dirs, make_queue_dirs, make_owned_dir
-from pylorax.api.compose import test_templates
 from pylorax.api.dnfbase import DNFLock
 from pylorax.api.queue import start_queue_monitor
 from pylorax.api.recipes import open_or_create_repo, commit_recipe_directory
@@ -266,10 +265,6 @@ if __name__ == '__main__':
     except RuntimeError:
         # Error has already been logged. Just exit cleanly.
         sys.exit(1)
-
-    # Depsolve the templates and make a note of the failures for /api/status to report
-    with server.config["DNFLOCK"].lock:
-        server.config["TEMPLATE_ERRORS"] = test_templates(server.config["DNFLOCK"].dbo, server.config["COMPOSER_CFG"].get("composer", "share_dir"))
 
     log.info("Starting %s on %s with blueprints from %s", VERSION, opts.socket, opts.BLUEPRINTS)
     http_server = WSGIServer(listener, server, log=LogWrapper(server_log))

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -151,9 +151,6 @@ class ServerTestCase(unittest.TestCase):
         if "releasever" not in self.substitutions or "basearch" not in self.substitutions:
             raise RuntimeError("DNF is missing the releasever and basearch substitutions")
 
-        # Include a message in /api/status output
-        server.config["TEMPLATE_ERRORS"] = ["Test message"]
-
         server.config['TESTING'] = True
         self.server = server.test_client()
         self.repo_dir = repo_dir
@@ -187,9 +184,6 @@ class ServerTestCase(unittest.TestCase):
         data = json.loads(resp.data)
         # Make sure the fields are present
         self.assertEqual(sorted(data.keys()), sorted(status_fields))
-
-        # Check for test message
-        self.assertEqual(data["msgs"], ["Test message"])
 
 
     def test_02_blueprints_list(self):
@@ -1961,9 +1955,6 @@ class RepoCacheTestCase(unittest.TestCase):
 
         server.config["DNFLOCK"] = DNFLock(server.config["COMPOSER_CFG"], expire_secs=10)
 
-        # Include a message in /api/status output
-        server.config["TEMPLATE_ERRORS"] = ["Test message"]
-
         server.config['TESTING'] = True
         self.server = server.test_client()
         self.repo_dir = repo_dir
@@ -2096,9 +2087,6 @@ class GitRPMBlueprintTestCase(unittest.TestCase):
             self.rawhide = True
 
         server.config["DNFLOCK"] = DNFLock(server.config["COMPOSER_CFG"], expire_secs=10)
-
-        # Include a message in /api/status output
-        server.config["TEMPLATE_ERRORS"] = ["Test message"]
 
         server.config['TESTING'] = True
         self.server = server.test_client()


### PR DESCRIPTION
Templates installed into /usr/share ought to depsolve correctly.

This is also redundant, because composer depsolves when a compose is
started. Only then does it have the full list of packages and up to date
metadata.

The returned errors were not used anywhere except in the status call.