### PR TITLE
Keep the zramctl utility from util-linux on boot.iso

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -313,7 +313,7 @@ removefrom usbutils /usr/bin/*
 removefrom util-linux --allbut \
     /usr/bin/{dmesg,getopt,kill,login,lsblk,more,mount,umount,mountpoint,findmnt} \
     /etc/mtab /etc/pam.d/login /etc/pam.d/remote \
-    /usr/sbin/{agetty,blkid,blockdev,clock,fdisk,fsck,fstrim,hwclock,losetup} \
+    /usr/sbin/{agetty,blkid,blockdev,clock,fdisk,fsck,fstrim,hwclock,losetup,zramctl} \
     /usr/sbin/{mkswap,swaplabel,nologin,sfdisk,swapoff,swapon,wipefs,partx,fsfreeze} \
     /usr/bin/{logger,hexdump,flock,chmem,lsmem,lscpu}
 removefrom volume_key-libs /usr/share/locale/*


### PR DESCRIPTION
Anaconda uses zram to allow installation on low memory systems.
We used to have a custom script called "zram-stats", that can be
used to test and debug zram usage during installation.

The script no longer works & zramctl now provides much better
output than our script ever did. So we decided to decommission
the old Anaconda provided script & use zramctl instead.

So change the cleanup rule in the Lorax boot.iso template
to keep the zramctl utility.

Related: rhbz#1561773