### PR TITLE
Makefile: Update bots target for moved GitHub project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,15 +170,17 @@ vm: $(VM_IMAGE)
 vm-reset:
 	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
 
-# checkout Cockpit's bots/ directory for standard test VM images and API to launch them
-# must be from cockpit's master, as only that has current and existing images; but testvm.py API is stable
+# checkout Cockpit's bots for standard test VM images and API to launch them
+# must be from master, as only that has current and existing images; but testvm.py API is stable
 bots:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git
-	git checkout --force FETCH_HEAD -- bots/
-	git reset bots
+	if [ ! -d bots ]; then \
+		git clone --depth=1 https://github.com/cockpit-project/bots.git; \
+	else \
+		cd bots && git fetch && git reset --hard origin/master; \
+        fi
 
 .PHONY: ci_after_success
 ci_after_success:
 # nothing to do here, but Jenkins expects this to be present, otherwise fails
 
-.PHONY: docs check test srpm vm vm-reset
+.PHONY: docs check test srpm vm vm-reset bots


### PR DESCRIPTION
Cockpit bots are in their own project now.

Make the target phony so that `make bots` updates an existing checkout.