### PR TITLE
lorax-composer: Handle RecipeError in commit_recipe_directory

### DIFF
--- a/src/pylorax/api/recipes.py
+++ b/src/pylorax/api/recipes.py
@@ -841,7 +841,7 @@ def commit_recipe_directory(repo, branch, directory):
         # Skip files with errors, but try the others
         try:
             commit_recipe_file(repo, branch, joinpaths(directory, f))
-        except (RecipeFileError, toml.TomlError):
+        except (RecipeError, RecipeFileError, toml.TomlError):
             pass
 
 def tag_recipe_commit(repo, branch, recipe_name):


### PR DESCRIPTION
A recipe that is valid TOML can still be an invalid recipe (eg. missing
the 'name' field) so this should also catch RecipeError.

Also added tests for this, as well as making sure commit_recipe_file()
raises the correct errors.

Resolves: rhbz#1755068