### PR TITLE
Backport 871 & 885, removal of nested virt in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,15 @@ $(VM_IMAGE): srpm bots
 vm: $(VM_IMAGE)
 	echo $(VM_IMAGE)
 
+# grab all repositories from the host system, overwriting what's inside the VM
+# and update the image. Mostly used when testing downstream snapshots to make
+# sure VM_IMAGE is as close as possible to the host!
+vm-local-repos: vm
+	bots/image-customize -v \
+		--upload /etc/yum.repos.d:/etc/yum.repos.d/ \
+		--run-command "yum -y update" \
+		$(TEST_OS)
+
 vm-reset:
 	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
 

--- a/Makefile
+++ b/Makefile
@@ -58,17 +58,8 @@ test_images:
 				    tests/cli/test_compose_qcow2.sh            \
 				    tests/cli/test_compose_live-iso.sh
 
-test_aws:
-	sudo -E ./tests/test_cli.sh tests/cli/test_build_and_deploy_aws.sh
-
-test_azure:
-	sudo -E ./tests/test_cli.sh tests/cli/test_build_and_deploy_azure.sh
-
-test_openstack:
-	sudo -E ./tests/test_cli.sh tests/cli/test_build_and_deploy_openstack.sh
-
-test_vmware:
-	sudo -E ./tests/test_cli.sh tests/cli/test_build_and_deploy_vmware.sh
+test_cli:
+	sudo -E ./tests/test_cli.sh
 
 clean:
 	-rm -rf build src/pylorax/version.py

--- a/test/README.md
+++ b/test/README.md
@@ -1,12 +1,14 @@
 # Integration Tests
 
 lorax uses Cockpit's integration test framework and infrastructure. To do this,
-we're checking out Cockpit's `bots/` subdirectory. It contains links to test
+we're checking out
+[cockpit-project/bots/](https://github.com/cockpit-project/bots) repository.
+It contains links to test
 images and tools to manipulate and start virtual machines from them.
 
 Each test is run on a new instance of a virtual machine.
-Branch/test matrix is configured in `bots/tests-scan` inside the
-[cockpit repository](https://github.com/cockpit-project/cockpit).
+Branch/test scenario matrix is configured in
+[testmap.py](https://github.com/cockpit-project/bots/blob/master/task/testmap.py).
 
 ## Dependencies
 
@@ -28,7 +30,8 @@ This downloads a base image from Cockpit's infrastructure. You can control
 which image is downloaded with the `TEST_OS` environment variable. Cockpit's
 [documentation](https://github.com/cockpit-project/cockpit/blob/master/test/README.md#test-configuration)
 lists accepted values. It then creates a new image based on that (a qemu
-snapshot) in `tests/images`, which contain the current `tests/` directory and
+snapshot) in `test/images`, which contain the current `test/` and `tests/`
+directories and
 have newly built rpms from the current checkout installed.
 
 To delete the generated image, run

--- a/test/README.md
+++ b/test/README.md
@@ -38,6 +38,13 @@ To delete the generated image, run
 Base images are stored in `bots/images`. Set `TEST_DATA` to override this
 directory.
 
+Use
+
+    $ make vm-local-repos
+
+to configure the image with all repositories found on the host system! This
+is mostly useful when running tests by hand on a downstream snapshot!
+
 ## Running tests
 
 After building a test image, run

--- a/test/check-cli
+++ b/test/check-cli
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import tempfile
 import unittest
 
 import composertest
@@ -30,14 +31,46 @@ class TestImages(composertest.ComposerTestCase):
 
 @unittest.skip('Nested KVM seems to be buggy and software emulation is too slow')
 class TestQcow2(composertest.ComposerTestCase):
+    def tearDown(self):
+        super().tearDownTestMachine()
+
     def test_qcow2(self):
         self.runCliTest("/tests/cli/test_compose_qcow2.sh")
+
+        with tempfile.TemporaryDirectory(prefix="/var/tmp/lorax-test.") as tmpdir:
+            # Copy the resulting qcow2 image and shut down the VM
+            self.tearDownVirt(virt_dir="/var/tmp/test-results/*", local_dir=tmpdir)
+
+            # Boot the image
+            self.setUpTestMachine(tmpdir + "/disk.qcow2", tmpdir + "/id_rsa")
+
+            # Upload the contents of the ./tests/ directory to the machine
+            self.machine.upload(["../tests"], "/")
+
+            # Run the test, on the booted image
+            self.runImageTest("/tests/cli/test_boot_qcow2.sh")
 
 
 @unittest.skip('Nested KVM seems to be buggy and software emulation is too slow')
 class TestLiveIso(composertest.ComposerTestCase):
+    def tearDown(self):
+        super().tearDownTestMachine()
+
     def test_live_iso(self):
         self.runCliTest("/tests/cli/test_compose_live-iso.sh")
+
+        with tempfile.TemporaryDirectory(prefix="/var/tmp/lorax-test.") as tmpdir:
+            # Copy the resulting iso and shut down the VM
+            self.tearDownVirt(virt_dir="/var/tmp/test-results/*", local_dir=tmpdir)
+
+            # Boot the image
+            self.setUpTestMachine(tmpdir + "/live.iso")
+
+            # Upload the contents of the ./tests/ directory to the machine
+            self.machine.upload(["../tests"], "/")
+
+            # Run the test, on the booted image
+            self.runImageTest("/tests/cli/test_boot_live-iso.sh")
 
 
 class TestTar(composertest.ComposerTestCase):

--- a/test/check-cli
+++ b/test/check-cli
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
 import tempfile
-import unittest
 
 import composertest
 
@@ -29,7 +28,6 @@ class TestImages(composertest.ComposerTestCase):
         self.runCliTest("/tests/cli/test_compose_partitioned-disk.sh")
 
 
-@unittest.skip('Nested KVM seems to be buggy and software emulation is too slow')
 class TestQcow2(composertest.ComposerTestCase):
     def tearDown(self):
         super().tearDownTestMachine()
@@ -55,7 +53,6 @@ class TestQcow2(composertest.ComposerTestCase):
             self.runImageTest("/tests/cli/test_boot_qcow2.sh")
 
 
-@unittest.skip('Nested KVM seems to be buggy and software emulation is too slow')
 class TestLiveIso(composertest.ComposerTestCase):
     def tearDown(self):
         super().tearDownTestMachine()

--- a/test/check-cli
+++ b/test/check-cli
@@ -44,6 +44,10 @@ class TestQcow2(composertest.ComposerTestCase):
             # Boot the image
             self.setUpTestMachine(tmpdir + "/disk.qcow2", tmpdir + "/id_rsa")
 
+            # Upload SSH keys to the machine so we can use the existing assertions
+            # by ssh'ing to localhost
+            self.machine.upload([tmpdir + "/id_rsa", tmpdir + "/id_rsa.pub"], "/root/.ssh")
+
             # Upload the contents of the ./tests/ directory to the machine
             self.machine.upload(["../tests"], "/")
 
@@ -86,6 +90,10 @@ class TestTar(composertest.ComposerTestCase):
 
             # Boot the image, login using the ssh key
             self.setUpTestMachine(tmpdir + "/disk.img", tmpdir + "/id_rsa")
+
+            # Upload SSH keys to the machine so we can use the existing assertions
+            # by ssh'ing to localhost
+            self.machine.upload([tmpdir + "/id_rsa", tmpdir + "/id_rsa.pub"], "/root/.ssh")
 
             # Upload the contents of the ./tests/ directory to the machine
             self.machine.upload(["../tests"], "/")

--- a/test/check-cli
+++ b/test/check-cli
@@ -80,6 +80,19 @@ class TestTar(composertest.ComposerTestCase):
     def test_tar_kickstart(self):
         self.runCliTest("/tests/cli/test_compose_tar_kickstart.sh")
 
+        with tempfile.TemporaryDirectory(prefix="/var/tmp/lorax-test.") as tmpdir:
+            # Copy the resulting disk image and shut down the VM
+            self.tearDownVirt(virt_dir="/var/tmp/test-results/*", local_dir=tmpdir)
+
+            # Boot the image, login using the ssh key
+            self.setUpTestMachine(tmpdir + "/disk.img", tmpdir + "/id_rsa")
+
+            # Upload the contents of the ./tests/ directory to the machine
+            self.machine.upload(["../tests"], "/")
+
+            # Run the test, on the booted image
+            self.runImageTest("/tests/cli/test_boot_tar_kickstart.sh")
+
 
 if __name__ == '__main__':
     composertest.main()

--- a/test/check-cli
+++ b/test/check-cli
@@ -63,8 +63,8 @@ class TestLiveIso(composertest.ComposerTestCase):
             # Copy the resulting iso and shut down the VM
             self.tearDownVirt(virt_dir="/var/tmp/test-results/*", local_dir=tmpdir)
 
-            # Boot the image
-            self.setUpTestMachine(tmpdir + "/live.iso")
+            # Boot the image, login using the ssh key
+            self.setUpTestMachine(tmpdir + "/live.iso", tmpdir + "/id_rsa")
 
             # Upload the contents of the ./tests/ directory to the machine
             self.machine.upload(["../tests"], "/")

--- a/test/composertest.py
+++ b/test/composertest.py
@@ -23,15 +23,20 @@ def print_exception(etype, value, tb):
     traceback.print_exception(etype, value, tb, limit=limit)
 
 
-class ComposerTestCase(unittest.TestCase):
-    image = testvm.DEFAULT_IMAGE
+class VirtMachineTestCase(unittest.TestCase):
     sit = False
+    network = None
+    machine = None
+    ssh_command = None
 
-    def setUp(self):
+    def setUpTestMachine(self, image, identity_file=None):
         self.network = testvm.VirtNetwork(0)
-        self.machine = testvm.VirtMachine(self.image, networking=self.network.host(), memory_mb=2048)
+        if identity_file:
+            self.machine = testvm.VirtMachine(image, networking=self.network.host(), cpus=2, memory_mb=2048, identity_file=identity_file)
+        else:
+            self.machine = testvm.VirtMachine(image, networking=self.network.host(), cpus=2, memory_mb=2048)
 
-        print(f"Starting virtual machine '{self.image}'")
+        print("Starting virtual machine '{}'".format(image))
         self.machine.start()
         self.machine.wait_boot()
 
@@ -46,15 +51,7 @@ class ComposerTestCase(unittest.TestCase):
         print(" ".join(self.ssh_command))
         print()
 
-        print("Waiting for lorax-composer to become ready...")
-        curl_command = ["curl", "--max-time", "360",
-                                "--silent",
-                                "--unix-socket", "/run/weldr/api.socket",
-                                "http://localhost/api/status"]
-        r = subprocess.run(self.ssh_command + curl_command, stdout=subprocess.DEVNULL)
-        self.assertEqual(r.returncode, 0)
-
-    def tearDown(self):
+    def tearDownTestMachine(self):
         if os.environ.get('TEST_ATTACHMENTS'):
             self.machine.download_dir('/var/log/tests', os.environ.get('TEST_ATTACHMENTS'))
 
@@ -79,6 +76,35 @@ class ComposerTestCase(unittest.TestCase):
         """
         return subprocess.run(self.ssh_command + command, **args)
 
+
+class ComposerTestCase(VirtMachineTestCase):
+    def setUp(self):
+        self.setUpTestMachine(testvm.DEFAULT_IMAGE)
+
+        # Upload the contents of the ./tests/ directory to the machine (it must have beakerlib already installed)
+        self.machine.upload(["../tests"], "/")
+
+        print("Waiting for lorax-composer to become ready...")
+        curl_command = ["curl", "--max-time", "360",
+                                "--silent",
+                                "--unix-socket", "/run/weldr/api.socket",
+                                "http://localhost/api/status"]
+        r = subprocess.run(self.ssh_command + curl_command, stdout=subprocess.DEVNULL)
+        self.assertEqual(r.returncode, 0)
+
+    def tearDown(self):
+        self.tearDownVirt()
+
+    def tearDownVirt(self, virt_dir=None, local_dir=None):
+        if os.environ.get('TEST_ATTACHMENTS'):
+            self.machine.download_dir('/var/log/tests', os.environ.get('TEST_ATTACHMENTS'))
+
+        if virt_dir and local_dir:
+            self.machine.download_dir(virt_dir, local_dir)
+
+        self.tearDownTestMachine()
+        return local_dir
+
     def runCliTest(self, script):
         extra_env = []
         if self.sit:
@@ -89,6 +115,16 @@ class ComposerTestCase(unittest.TestCase):
                           "PACKAGE=composer-cli",
                           *extra_env,
                           "/tests/test_cli.sh", script])
+        self.assertEqual(r.returncode, 0)
+
+    def runImageTest(self, script):
+        extra_env = []
+        if self.sit:
+            extra_env.append("COMPOSER_TEST_FAIL_FAST=1")
+
+        r = self.execute(["TEST=" + self.id(),
+                          *extra_env,
+                          "/tests/test_image.sh", script])
         self.assertEqual(r.returncode, 0)
 
 

--- a/test/composertest.py
+++ b/test/composertest.py
@@ -55,6 +55,9 @@ class ComposerTestCase(unittest.TestCase):
         self.assertEqual(r.returncode, 0)
 
     def tearDown(self):
+        if os.environ.get('TEST_ATTACHMENTS'):
+            self.machine.download_dir('/var/log/tests', os.environ.get('TEST_ATTACHMENTS'))
+
         # Peek into internal data structure, because there's no way to get the
         # TestResult at this point. `errors` is a list of tuples (method, error)
         errors = list(e[1] for e in self._outcome.errors if e[1])

--- a/test/vm.install
+++ b/test/vm.install
@@ -5,16 +5,13 @@ SRPM="$1"
 if ! rpm -q beakerlib; then
     if [ $(. /etc/os-release && echo $ID) = "rhel" ]; then
         (cd /etc/yum.repos.d; curl -O -L http://download.devel.redhat.com/beakerrepos/beaker-client-RedHatEnterpriseLinux.repo)
-
-         # The beaker repository doesn't include repos for minor releases
-         VERSION=$(. /etc/os-release && echo ${VERSION_ID%.*})
-         yum install -y --releasever=$VERSION --setopt=sslverify=0 beakerlib
-
-         # prevent yum from trying to sync the cache again later (it fails without sslverify=0)
-         rm /etc/yum.repos.d/beaker-client-RedHatEnterpriseLinux.repo
-     else
-         yum install -y beakerlib
+        # disable sslverify b/c yum will fail to sync metadata otherwise
+        sed -i "s/\(gpgcheck=0\)/\1\nsslverify=0/" /etc/yum.repos.d/beaker-client-RedHatEnterpriseLinux.repo
+        # do not remove the repo file. We now have tests which use beakerlib
+        # inside their blueprints so this needs to stay on the VM
     fi
+
+    yum install -y beakerlib
 fi
 
 if ! rpm -q git; then

--- a/test/vm.install
+++ b/test/vm.install
@@ -17,10 +17,6 @@ if ! rpm -q beakerlib; then
     fi
 fi
 
-if ! rpm -q podman-docker; then
-    yum install -y podman-docker
-fi
-
 if ! rpm -q git; then
     yum install -y git
 fi
@@ -44,3 +40,11 @@ rpm -e --verbose $(basename -a ${packages[@]} | sed 's/-[0-9].*.rpm$//') || true
 yum install -y $packages
 
 systemctl enable lorax-composer.socket
+
+if [ -f /usr/bin/docker ]; then
+    yum remove -y $(rpm -qf /usr/bin/docker)
+fi
+
+if ! rpm -q podman-docker; then
+    yum install -y podman-docker
+fi

--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -122,7 +122,7 @@ check_root_account() {
     fi
 
     if [ $ROOT_ACCOUNT_LOCKED == 0 ]; then
-        rlRun -t -c "ssh $SSH_OPTS ${SSH_USER}@${SSH_MACHINE} \"sudo grep '^root::' /etc/shadow\"" \
+        rlRun -t -c "ssh $SSH_OPTS ${SSH_USER}@${SSH_MACHINE} \"sudo passwd --status root | grep -E '^root\s+NP?'\"" \
             0 "Password for root account in /etc/shadow is empty"
     else
         # ssh returns 255 in case of any ssh error, so it's better to grep the specific error message

--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -137,7 +137,7 @@ check_root_account() {
             0 "Can't ssh to '$SSH_MACHINE' as root using password-based auth"
         rlRun -t -c "ssh $SSH_OPTS ${SSH_USER}@${SSH_MACHINE} \"$SUDO passwd --status root | grep -E '^root\s+LK?'\"" \
             0 "root account is disabled in /etc/shadow"
-        rlRun -t -c "ssh $SSH_OPTS ${SSH_USER}@${SSH_MACHINE} \"$SUDO grep 'USER_LOGIN.*acct=\\\"root\\\".*terminal=ssh.*res=failed' /var/log/audit/audit.log\"" \
+        rlRun -t -c "ssh $SSH_OPTS ${SSH_USER}@${SSH_MACHINE} \"$SUDO journalctl -g 'USER_LOGIN.*acct=\\\"root\\\".*terminal=ssh.*res=failed'\"" \
             0 "audit.log contains entry about unsuccessful root login"
         # We modify the default sshd settings on live ISO, so we can only check the default empty password setting
         # outside of live ISO

--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -37,6 +37,9 @@ run_beakerlib_tests() {
 }
 
 parse_beakerlib_results() {
+    if [ ! -f "$BEAKERLIB_DIR/TestResults" ]; then
+        exit "$BEAKERLIB_DIR/TestResults not found" 1
+    fi
     . $BEAKERLIB_DIR/TestResults
 
     TESTRESULT_RESULT_ECODE="${TESTRESULT_RESULT_ECODE:-}"

--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -152,3 +152,18 @@ check_compose_status() {
         return 1
     fi
 }
+
+# Wait until the compose is done (finished or failed)
+wait_for_compose() {
+    local UUID=$1
+    if [ -n "$UUID" ]; then
+        until $CLI compose info $UUID | grep 'FINISHED\|FAILED'; do
+            sleep 20
+            rlLogInfo "Waiting for compose to finish ..."
+        done;
+        check_compose_status "$UUID"
+    else
+        rlFail "Compose UUID is empty!"
+    fi
+}
+

--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -19,6 +19,35 @@ if [ "$COMPOSER_TEST_FAIL_FAST" == "1" ]; then
   }
 fi
 
+
+setup_beakerlib_env() {
+    export BEAKERLIB_DIR=$(mktemp -d /tmp/composer-test.XXXXXX)
+    export BEAKERLIB_JOURNAL=0
+}
+
+run_beakerlib_tests() {
+    if [ -z "$*" ]; then
+        echo "run_beakerlib_tests() requires a test to execute"
+    else
+        # execute tests
+        for TEST in "$@"; do
+            $TEST
+        done
+    fi
+}
+
+parse_beakerlib_results() {
+    . $BEAKERLIB_DIR/TestResults
+
+    TESTRESULT_RESULT_ECODE="${TESTRESULT_RESULT_ECODE:-}"
+    if [ $TESTRESULT_RESULT_ECODE != 0 ]; then
+      echo "Test failed. Leaving log in $BEAKERLIB_DIR"
+      exit $TESTRESULT_RESULT_ECODE
+    fi
+
+    rm -rf $BEAKERLIB_DIR
+}
+
 export QEMU_BIN="/usr/libexec/qemu-kvm"
 export QEMU="$QEMU_BIN -machine accel=kvm:tcg"
 export SSH_PORT=2222

--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -32,7 +32,7 @@ boot_image() {
                  -serial chardev:log0 &"
     # wait for ssh to become ready (yes, http is the wrong protocol, but it returns the header)
     tries=0
-    until curl -sS -m 15 "http://localhost:$SSH_PORT/" | grep 'OpenSSH'; do
+    until curl --http0.9 -sS -m 15 "http://localhost:$SSH_PORT/" | grep 'OpenSSH'; do
         tries=$((tries + 1))
         if [ $tries -gt $TIMEOUT ]; then
             exit 1

--- a/tests/cli/test_boot_live-iso.sh
+++ b/tests/cli/test_boot_live-iso.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Note: execute this file from the project root directory
+
+#####
+#
+# Test the live-iso image
+#
+#####
+
+set -e
+
+. /usr/share/beakerlib/beakerlib.sh
+. $(dirname $0)/lib/lib.sh
+
+rlJournalStart
+    rlPhaseStartTest "Verify live iso"
+        # Just the fact that this is running means the image can boot and ssh is working
+        rlRun -t -c "passwd --status root | grep -E '^root\s+NP?'" 0 "root account has no password set"
+        rlAssertGrep "liveuser" /etc/passwd
+        rlAssertGrep "custom_cmdline_arg" /proc/cmdline
+    rlPhaseEnd
+rlJournalEnd
+rlJournalPrintText

--- a/tests/cli/test_boot_live-iso.sh
+++ b/tests/cli/test_boot_live-iso.sh
@@ -15,7 +15,7 @@ set -e
 rlJournalStart
     rlPhaseStartTest "Verify live iso"
         # Just the fact that this is running means the image can boot and ssh is working
-        rlRun -t -c "passwd --status root | grep -E '^root\s+NP?'" 0 "root account has no password set"
+        ROOT_ACCOUNT_LOCKED=0 verify_image liveuser localhost "-p 22"
         rlAssertGrep "liveuser" /etc/passwd
         rlAssertGrep "custom_cmdline_arg" /proc/cmdline
     rlPhaseEnd

--- a/tests/cli/test_boot_qcow2.sh
+++ b/tests/cli/test_boot_qcow2.sh
@@ -15,8 +15,8 @@ set -e
 rlJournalStart
     rlPhaseStartTest "Verify VM instance"
         # Just the fact that this is running means the image can boot and ssh is working
+        verify_image root localhost "-p 22"
         rlAssertExists "/root/.ssh/authorized_keys"
-        rlAssertGrep "custom_cmdline_arg" /proc/cmdline
     rlPhaseEnd
 rlJournalEnd
 rlJournalPrintText

--- a/tests/cli/test_boot_qcow2.sh
+++ b/tests/cli/test_boot_qcow2.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Note: execute this file from the project root directory
+
+#####
+#
+# Test the qcow2 image
+#
+#####
+
+set -e
+
+. /usr/share/beakerlib/beakerlib.sh
+. $(dirname $0)/lib/lib.sh
+
+rlJournalStart
+    rlPhaseStartTest "Verify VM instance"
+        # Just the fact that this is running means the image can boot and ssh is working
+        rlAssertExists "/root/.ssh/authorized_keys"
+        rlAssertGrep "custom_cmdline_arg" /proc/cmdline
+    rlPhaseEnd
+rlJournalEnd
+rlJournalPrintText

--- a/tests/cli/test_boot_tar_kickstart.sh
+++ b/tests/cli/test_boot_tar_kickstart.sh
@@ -15,6 +15,7 @@ set -e
 rlJournalStart
     rlPhaseStartTest "Verify VM instance"
         # Just the fact that this is running means the image can boot and ssh is working
+        CHECK_CMDLINE=0 verify_image root localhost "-p 22"
         rlAssertExists "/root/.ssh/authorized_keys"
     rlPhaseEnd
 rlJournalEnd

--- a/tests/cli/test_boot_tar_kickstart.sh
+++ b/tests/cli/test_boot_tar_kickstart.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Note: execute this file from the project root directory
+
+#####
+#
+# Test the liveimg installed tar disk image
+#
+#####
+
+set -e
+
+. /usr/share/beakerlib/beakerlib.sh
+. $(dirname $0)/lib/lib.sh
+
+rlJournalStart
+    rlPhaseStartTest "Verify VM instance"
+        # Just the fact that this is running means the image can boot and ssh is working
+        rlAssertExists "/root/.ssh/authorized_keys"
+    rlPhaseEnd
+rlJournalEnd
+rlJournalPrintText

--- a/tests/cli/test_build_and_deploy_aws.sh
+++ b/tests/cli/test_build_and_deploy_aws.sh
@@ -82,14 +82,7 @@ __EOF__
     rlPhaseEnd
 
     rlPhaseStartTest "compose finished"
-        if [ -n "$UUID" ]; then
-            until $CLI compose info $UUID | grep 'FINISHED\|FAILED'; do
-                rlLogInfo "Waiting for compose to finish ..."
-                sleep 30
-            done;
-        else
-            rlFail "Compose UUID is empty!"
-        fi
+        wait_for_compose $UUID
     rlPhaseEnd
 
     rlPhaseStartTest "Import AMI image in AWS"

--- a/tests/cli/test_build_and_deploy_azure.sh
+++ b/tests/cli/test_build_and_deploy_azure.sh
@@ -69,14 +69,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose finished"
-        if [ -n "$UUID" ]; then
-            until $CLI compose info $UUID | grep 'FINISHED\|FAILED'; do
-                rlLogInfo "Waiting for compose to finish ..."
-                sleep 30
-            done;
-        else
-            rlFail "Compose UUID is empty!"
-        fi
+        wait_for_compose $UUID
     rlPhaseEnd
 
     rlPhaseStartTest "Upload image to Azure"

--- a/tests/cli/test_build_and_deploy_openstack.sh
+++ b/tests/cli/test_build_and_deploy_openstack.sh
@@ -77,14 +77,7 @@ __EOF__
     rlPhaseEnd
 
     rlPhaseStartTest "compose finished"
-        if [ -n "$UUID" ]; then
-            until $CLI compose info $UUID | grep 'FINISHED\|FAILED'; do
-                rlLogInfo "Waiting for compose to finish ..."
-                sleep 30
-            done;
-        else
-            rlFail "Compose UUID is empty!"
-        fi
+      wait_for_compose $UUID
     rlPhaseEnd
 
     rlPhaseStartTest "Upload QCOW2 image to OpenStack"

--- a/tests/cli/test_build_and_deploy_vmware.sh
+++ b/tests/cli/test_build_and_deploy_vmware.sh
@@ -98,14 +98,7 @@ __EOF__
     rlPhaseEnd
 
     rlPhaseStartTest "compose finished"
-        if [ -n "$UUID" ]; then
-            until $CLI compose info $UUID | grep 'FINISHED\|FAILED'; do
-                rlLogInfo "Waiting for compose to finish ..."
-                sleep 30
-            done;
-        else
-            rlFail "Compose UUID is empty!"
-        fi
+        wait_for_compose $UUID
     rlPhaseEnd
 
     rlPhaseStartTest "Upload VMDK image in vCenter"

--- a/tests/cli/test_compose_ext4-filesystem.sh
+++ b/tests/cli/test_compose_ext4-filesystem.sh
@@ -27,15 +27,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose finished"
-        if [ -n "$UUID" ]; then
-            until $CLI compose info $UUID | grep 'FINISHED\|FAILED'; do
-                sleep 10
-                rlLogInfo "Waiting for compose to finish ..."
-            done;
-            check_compose_status "$UUID"
-        else
-            rlFail "Compose UUID is empty!"
-        fi
+        wait_for_compose $UUID
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/cli/test_compose_google.sh
+++ b/tests/cli/test_compose_google.sh
@@ -23,15 +23,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStart "compose finished"
-        if [ -n "$UUID" ]; then
-            until $CLI compose info $UUID | grep 'FINISHED\|FAILED'; do
-                sleep 10
-                rlLogInfo "Waiting for compose to finish..."
-            done
-            check_compose_status "$UUID"
-        else
-            flFail "Compose UUID is empty!"
-        fi
+        wait_for_compose $UUID
     rlPhaseEnd
 
     rlPhaseStart "compose check"

--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -15,40 +15,66 @@ set -e
 CLI="${CLI:-./src/bin/composer-cli}"
 
 rlJournalStart
-    rlPhaseStartSetup
-        rlAssertExists $QEMU
-    rlPhaseEnd
-
     rlPhaseStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
 
+        TMP_DIR=$(mktemp -d /tmp/composer.XXXXX)
+        SSH_KEY_DIR=$(mktemp -d /tmp/composer-ssh-keys.XXXXXX)
+
+        rlRun -t -c "ssh-keygen -t rsa -N '' -f $SSH_KEY_DIR/id_rsa"
+        PUB_KEY=$(cat "$SSH_KEY_DIR/id_rsa.pub")
+
+        cat > "$TMP_DIR/with-ssh.toml" << __EOF__
+name = "with-ssh"
+description = "HTTP image with SSH"
+version = "0.0.1"
+
+[[packages]]
+name = "httpd"
+version = "*"
+
+[[packages]]
+name = "openssh-server"
+version = "*"
+
+[[packages]]
+name = "beakerlib"
+version = "*"
+
+[customizations.services]
+enabled = ["sshd"]
+
+[[customizations.user]]
+name = "root"
+key = "$PUB_KEY"
+
+[customizations.kernel]
+append = "custom_cmdline_arg"
+__EOF__
+
+        rlRun -t -c "$CLI blueprints push $TMP_DIR/with-ssh.toml"
+
         # NOTE: live-iso.ks explicitly disables sshd but test_cli.sh enables it
-        UUID=`$CLI compose start example-http-server live-iso`
+        UUID=$($CLI compose start with-ssh live-iso)
         rlAssertEquals "exit code should be zero" $? 0
 
-        UUID=`echo $UUID | cut -f 2 -d' '`
+        UUID=$(echo "$UUID" | cut -f 2 -d' ')
     rlPhaseEnd
 
     rlPhaseStartTest "compose finished"
-        wait_for_compose $UUID
+        wait_for_compose "$UUID"
 
-        rlRun -t -c "$CLI compose image $UUID"
-        IMAGE="$UUID-live.iso"
-    rlPhaseEnd
-
-    rlPhaseStartTest "Start VM instance"
-        boot_image "-boot d -cdrom $IMAGE" 120
-    rlPhaseEnd
-
-    rlPhaseStartTest "Verify VM instance"
-        # run generic tests to verify the instance
-        ROOT_ACCOUNT_LOCKED=0 verify_image liveuser localhost "-p $SSH_PORT"
+        # Save the results for boot test
+        rlAssertExists "/var/lib/lorax/composer/results/$UUID/live.iso"
+        rlRun -t -c "mkdir -p /var/tmp/test-results/"
+        rlRun -t -c "cp /var/lib/lorax/composer/results/$UUID/live.iso /var/tmp/test-results/"
+        # Include the ssh key needed to log into the image
+        rlRun -t -c "cp $SSH_KEY_DIR/* /var/tmp/test-results"
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        rlRun -t -c "killall -9 qemu-kvm"
         rlRun -t -c "$CLI compose delete $UUID"
-        rlRun -t -c "rm -rf $IMAGE"
+        rlRun -t -c "rm -rf $TMP_DIR $SSH_KEY_DIR"
     rlPhaseEnd
 
 rlJournalEnd

--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -30,15 +30,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose finished"
-        if [ -n "$UUID" ]; then
-            until $CLI compose info $UUID | grep 'FINISHED\|FAILED'; do
-                sleep 20
-                rlLogInfo "Waiting for compose to finish ..."
-            done;
-            check_compose_status "$UUID"
-        else
-            rlFail "Compose UUID is empty!"
-        fi
+        wait_for_compose $UUID
 
         rlRun -t -c "$CLI compose image $UUID"
         IMAGE="$UUID-live.iso"

--- a/tests/cli/test_compose_partitioned-disk.sh
+++ b/tests/cli/test_compose_partitioned-disk.sh
@@ -27,15 +27,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose finished"
-        if [ -n "$UUID" ]; then
-            until $CLI compose info $UUID | grep 'FINISHED\|FAILED'; do
-                sleep 10
-                rlLogInfo "Waiting for compose to finish ..."
-            done;
-            check_compose_status "$UUID"
-        else
-            rlFail "Compose UUID is empty!"
-        fi
+        wait_for_compose $UUID
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -3,7 +3,7 @@
 
 #####
 #
-# Builds qcow2 images and tests them with QEMU-KVM
+# Builds qcow2 images
 #
 #####
 
@@ -15,20 +15,16 @@ set -e
 CLI="${CLI:-./src/bin/composer-cli}"
 
 rlJournalStart
-    rlPhaseStartSetup
-        rlAssertExists $QEMU
-    rlPhaseEnd
-
     rlPhaseStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
 
-        TMP_DIR=`mktemp -d /tmp/composer.XXXXX`
-        SSH_KEY_DIR=`mktemp -d /tmp/composer-ssh-keys.XXXXXX`
+        TMP_DIR=$(mktemp -d /tmp/composer.XXXXX)
+        SSH_KEY_DIR=$(mktemp -d /tmp/composer-ssh-keys.XXXXXX)
 
         rlRun -t -c "ssh-keygen -t rsa -N '' -f $SSH_KEY_DIR/id_rsa"
-        PUB_KEY=`cat $SSH_KEY_DIR/id_rsa.pub`
+        PUB_KEY=$(cat "$SSH_KEY_DIR/id_rsa.pub")
 
-        cat > $TMP_DIR/with-ssh.toml << __EOF__
+        cat > "$TMP_DIR/with-ssh.toml" << __EOF__
 name = "with-ssh"
 description = "HTTP image with SSH"
 version = "0.0.1"
@@ -41,6 +37,10 @@ version = "*"
 name = "openssh-server"
 version = "*"
 
+[[packages]]
+name = "beakerlib"
+version = "*"
+
 [[customizations.user]]
 name = "root"
 key = "$PUB_KEY"
@@ -51,31 +51,26 @@ __EOF__
 
         rlRun -t -c "$CLI blueprints push $TMP_DIR/with-ssh.toml"
 
-        UUID=`$CLI compose start with-ssh qcow2`
+        UUID=$($CLI compose start with-ssh qcow2)
         rlAssertEquals "exit code should be zero" $? 0
 
-        UUID=`echo $UUID | cut -f 2 -d' '`
+        UUID=$(echo "$UUID" | cut -f 2 -d' ')
     rlPhaseEnd
 
     rlPhaseStartTest "compose finished"
-        wait_for_compose $UUID
-        rlRun -t -c "$CLI compose image $UUID"
-        IMAGE="$UUID-disk.qcow2"
-    rlPhaseEnd
+        wait_for_compose "$UUID"
 
-    rlPhaseStartTest "Start VM instance"
-        boot_image "-boot c -hda $IMAGE" 60
-    rlPhaseEnd
-
-    rlPhaseStartTest "Verify VM instance"
-        # run generic tests to verify the instance
-        verify_image root localhost "-i $SSH_KEY_DIR/id_rsa -p $SSH_PORT"
+        # Save the results for boot test
+        rlAssertExists "/var/lib/lorax/composer/results/$UUID/disk.qcow2"
+        rlRun -t -c "mkdir -p /var/tmp/test-results/"
+        rlRun -t -c "cp /var/lib/lorax/composer/results/$UUID/disk.qcow2 /var/tmp/test-results/"
+        # Include the ssh key needed to log into the image
+        rlRun -t -c "cp $SSH_KEY_DIR/* /var/tmp/test-results"
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        rlRun -t -c "killall -9 qemu-kvm"
         rlRun -t -c "$CLI compose delete $UUID"
-        rlRun -t -c "rm -rf $IMAGE $TMP_DIR $SSH_KEY_DIR"
+        rlRun -t -c "rm -rf $TMP_DIR $SSH_KEY_DIR"
     rlPhaseEnd
 
 rlJournalEnd

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -58,16 +58,7 @@ __EOF__
     rlPhaseEnd
 
     rlPhaseStartTest "compose finished"
-        if [ -n "$UUID" ]; then
-            until $CLI compose info $UUID | grep 'FINISHED\|FAILED'; do
-                sleep 20
-                rlLogInfo "Waiting for compose to finish ..."
-            done;
-            check_compose_status "$UUID"
-        else
-            rlFail "Compose UUID is empty!"
-        fi
-
+        wait_for_compose $UUID
         rlRun -t -c "$CLI compose image $UUID"
         IMAGE="$UUID-disk.qcow2"
     rlPhaseEnd

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -31,11 +31,8 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose image"
+        wait_for_compose $UUID
         if [ -n "$UUID" ]; then
-            until $CLI compose info $UUID | grep 'FINISHED\|FAILED'; do
-                sleep 5
-                rlLogInfo "Waiting for compose to finish ..."
-            done;
             check_compose_status "$UUID"
 
             rlRun -t -c "$CLI compose image $UUID"
@@ -45,8 +42,6 @@ rlJournalStart
             rlAssertExists    "/var/lib/lorax/composer/results/$UUID/"
             rlAssertExists    "/var/lib/lorax/composer/results/$UUID/root.tar.xz"
             rlAssertNotDiffer "/var/lib/lorax/composer/results/$UUID/root.tar.xz" "$UUID-root.tar.xz"
-        else
-            rlFail "Compose UUID is empty!"
         fi
     rlPhaseEnd
 

--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -29,15 +29,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose finished"
-        if [ -n "$UUID" ]; then
-            until $CLI compose info $UUID | grep 'FINISHED\|FAILED'; do
-                sleep 10
-                rlLogInfo "Waiting for compose to finish ..."
-            done;
-            check_compose_status "$UUID"
-        else
-            rlFail "Compose UUID is empty!"
-        fi
+        wait_for_compose $UUID
 
         # Running a compose can lead to a different selinux policy in the
         # kernel, which may break docker. Reload the policy from the host and

--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -30,14 +30,6 @@ rlJournalStart
 
     rlPhaseStartTest "compose finished"
         wait_for_compose $UUID
-
-        # Running a compose can lead to a different selinux policy in the
-        # kernel, which may break docker. Reload the policy from the host and
-        # restart docker as a workaround.
-        # See https://bugzilla.redhat.com/show_bug.cgi?id=1711813
-        semodule -R
-        systemctl restart docker
-
         rlRun -t -c "$CLI compose image $UUID"
         IMAGE="$UUID-root.tar.xz"
     rlPhaseEnd

--- a/tests/cli/test_compose_tar_kickstart.sh
+++ b/tests/cli/test_compose_tar_kickstart.sh
@@ -16,26 +16,28 @@ CLI="${CLI:-./src/bin/composer-cli}"
 
 rlJournalStart
     rlPhaseStartSetup
-        rlAssertExists $QEMU_BIN
-        if ! rlCheckRpm httpd; then
-            yum -y install httpd
-        fi
-        systemctl start httpd
+        TMP_DIR=$(mktemp -d /tmp/composer.XXXXX)
+        SSH_KEY_DIR=$(mktemp -d /tmp/composer-ssh-keys.XXXXXX)
 
-        ks_path="/var/www/html/ks-tar.cfg"
-        tmp_dir=$(mktemp -d /tmp/composer.XXXXX)
-        ssh_key_dir=$(mktemp -d /tmp/composer-ssh-keys.XXXXXX)
+        rlRun -t -c "ssh-keygen -t rsa -N '' -f $SSH_KEY_DIR/id_rsa"
+        PUB_KEY=$(cat "$SSH_KEY_DIR/id_rsa.pub")
 
-        rlRun -t -c "ssh-keygen -t rsa -N '' -f $ssh_key_dir/id_rsa"
-        pub_key=$(cat $ssh_key_dir/id_rsa.pub)
-
-        bp_name="test-tar"
-        blueprint="$bp_name.toml"
-        cat > $blueprint << __EOF__
-name = "$bp_name"
+        cat > "$TMP_DIR/test-tar.toml" << __EOF__
+name = "test-tar"
 description = "tar image test"
 version = "0.0.1"
 modules = []
+
+[[groups]]
+name = "anaconda-tools"
+
+[[packages]]
+name = "kernel"
+version = "*"
+
+[[packages]]
+name = "beakerlib"
+version = "*"
 
 [[packages]]
 name = "openssh-server"
@@ -56,50 +58,32 @@ version = "*"
 
 [[customizations.user]]
 name = "root"
-key = "$pub_key"
+key = "$PUB_KEY"
 
 __EOF__
-        rlRun -t -c "$CLI blueprints push $blueprint"
-        image_path="/var/www/html/root.tar.xz"
-
-        version=$(awk -F = '$1 == "VERSION_ID" { print $2 }' /etc/os-release | tr -d \")
-        arch=$(uname -m)
-        baseurl="http://download.eng.bos.redhat.com/rel-eng/latest-RHEL-${version}/compose/BaseOS/x86_64/os/"
-        rlRun -t -c "curl --remote-name-all $baseurl/images/pxeboot/{vmlinuz,initrd.img}"
-
-        rlRun -t -c "fallocate -l 5G disk.img"
+        rlRun -t -c "$CLI blueprints push $TMP_DIR/test-tar.toml"
     rlPhaseEnd
 
     rlPhaseStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
-        uuid=$($CLI compose start $bp_name tar)
+        UUID=$($CLI compose start test-tar tar)
         rlAssertEquals "exit code should be zero" $? 0
 
-        uuid=$(echo $uuid | cut -f 2 -d' ')
+        UUID=$(echo "$UUID" | cut -f 2 -d' ')
     rlPhaseEnd
 
     rlPhaseStartTest "compose finished"
-        if [ -n "$uuid" ]; then
-            until $CLI compose status | grep -E "$uuid (FINISHED|FAILED)"; do
-                sleep 60
-                rlLogInfo "Waiting for compose to finish ..."
-            done;
-        else
-            rlFail "Compose uuid is empty!"
-        fi
-
-        rlRun -t -c "$CLI compose image $uuid"
-        image="$uuid-root.tar.xz"
+        wait_for_compose "$UUID"
     rlPhaseEnd
 
     rlPhaseStartTest "Install tar image using kickstart liveimg command"
-        cat > $ks_path << __EOF__
+        cat > "$TMP_DIR/test-liveimg.ks" << __EOF__
 cmdline
 lang en_US.UTF-8
 timezone America/New_York
 keyboard us
 rootpw --lock
-sshkey --username root "$pub_key"
+sshkey --username root "$PUB_KEY"
 bootloader --location=mbr
 zerombr
 clearpart --initlabel --all
@@ -109,31 +93,24 @@ autopart
 # (using 'poweroff' ks command just halted the machine without powering it off)
 reboot
 
-liveimg --url http://10.0.2.2/root.tar.xz
+liveimg --url file:///var/lib/lorax/composer/results/$UUID/root.tar.xz
 
 __EOF__
-        mv $image $image_path
-        restorecon $image_path
-        rlLogInfo "Starting installation from tar image in a VM"
-        $QEMU -m 2048 -drive file=disk.img,format=raw -nographic -kernel vmlinuz -initrd initrd.img \
-            -append "inst.ks=http://10.0.2.2/ks-tar.cfg inst.stage2=$baseurl console=ttyS0" --no-reboot
+        # Build the disk image directly in the results directory
+        rlRun -t -c "mkdir -p /var/tmp/test-results/"
+        rlRun -t -c "fallocate -l 5G /var/tmp/test-results/disk.img"
 
+        rlLogInfo "Starting installation from tar image using anaconda"
+        rlRun -t -c "anaconda --image=/var/tmp/test-results/disk.img --kickstart=$TMP_DIR/test-liveimg.ks"
         rlLogInfo "Installation of the image finished."
-    rlPhaseEnd
 
-    rlPhaseStartTest "Boot and check the installed system"
-        boot_image "-drive file=disk.img,format=raw" 600
-        # run generic tests to verify the instance
-        CHECK_CMDLINE=0 verify_image root localhost "-i $ssh_key_dir/id_rsa -p 2222"
+        # Include the ssh key needed to log into the image
+        rlRun -t -c "cp $SSH_KEY_DIR/* /var/tmp/test-results"
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        rlRun -t -c "killall -9 $QEMU_BIN"
-        rlRun -t -c "rm -rf $image $blueprint $image_path vmlinuz initrd.img disk.img $ks_path"
-        rlRun -t -c "$CLI blueprints delete $bp_name"
-        rlRun -t -c "$CLI compose delete $uuid"
-        rlRun -t -c "systemctl stop httpd"
+        rlRun -t -c "$CLI compose delete $UUID"
+        rlRun -t -c "rm -rf $TMP_DIR $SSH_KEY_DIR"
     rlPhaseEnd
-
 rlJournalEnd
 rlJournalPrintText

--- a/tests/cli/test_compose_tar_kickstart.sh
+++ b/tests/cli/test_compose_tar_kickstart.sh
@@ -43,17 +43,12 @@ version = "*"
 name = "openssh-server"
 version = "*"
 
-# sudo and auditd are needed for checks performed on the installed image instance
 [[packages]]
-name = "sudo"
+name = "openssh-clients"
 version = "*"
 
 [[packages]]
-name = "audit"
-version = "*"
-
-[[groups]]
-name = "anaconda-tools"
+name = "passwd"
 version = "*"
 
 [[customizations.user]]

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -15,6 +15,22 @@ function setup_tests {
     # explicitly enable sshd for live-iso b/c it is disabled by default
     # due to security concerns (no root password required)
     sed -i.orig 's/^services.*/services --disabled="network" --enabled="NetworkManager,sshd"/' $share_dir/composer/live-iso.ks
+
+    # Make the live-iso boot more quickly (isolinux.cfg)
+    for cfg in "$share_dir"/templates.d/99-generic/live/config_files/*/isolinux.cfg; do
+        sed -i.orig 's/^timeout.*/timeout 20/' "$cfg"
+    done
+
+    # Make the live-iso boot more quickly (grub.cfg)
+    for cfg in "$share_dir"/templates.d/99-generic/live/config_files/*/grub.conf; do
+        sed -i.orig 's/^timeout.*/timeout 2/' "$cfg"
+    done
+
+    # Make the live-iso boot more quickly (grub2-efi.cfg)
+    for cfg in "$share_dir"/templates.d/99-generic/live/config_files/*/grub2-efi.cfg; do
+        sed -i.orig 's/^set timeout.*/set timeout=2/' "$cfg"
+    done
+
     # explicitly enable logging in with empty passwords via ssh, because
     # the default sshd setting for PermitEmptyPasswords is 'no'
     awk -i inplace "
@@ -43,6 +59,12 @@ function teardown_tests {
     local blueprints_dir=$2
 
     mv $share_dir/composer/live-iso.ks.orig $share_dir/composer/live-iso.ks
+
+    # Restore all the configuration files
+    for cfg in "$share_dir"/templates.d/99-generic/live/config_files/*/*.orig; do
+        mv "$cfg" "${cfg%%.orig}"
+    done
+
     rm -rf $blueprints_dir
     mv ${blueprints_dir}.orig $blueprints_dir
 }

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -78,6 +78,10 @@ else
     composer_start
 fi
 
+# Clean out the test-results directory
+if [ -e "/var/tmp/test-results" ]; then
+    rm -rf "/var/tmp/test-results"
+fi
 
 export BEAKERLIB_JOURNAL=0
 export PATH="/usr/local/bin:$PATH"

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -3,6 +3,8 @@
 
 set -eu
 
+. $(dirname $0)/cli/lib/lib.sh
+
 export BEAKERLIB_DIR=$(mktemp -d /tmp/composer-test.XXXXXX)
 CLI="${CLI:-}"
 
@@ -58,36 +60,23 @@ if [ -z "$CLI" ]; then
     export top_srcdir=`pwd`
     . ./tests/testenv.sh
 
-    BLUEPRINTS_DIR=`mktemp -d '/tmp/composer-blueprints.XXXXX'`
-    export BLUEPRINTS_DIR
+    export BLUEPRINTS_DIR=`mktemp -d '/tmp/composer-blueprints.XXXXX'`
     cp ./tests/pylorax/blueprints/*.toml $BLUEPRINTS_DIR
 
-    SHARE_DIR=`mktemp -d '/tmp/composer-share.XXXXX'`
+    export SHARE_DIR=`mktemp -d '/tmp/composer-share.XXXXX'`
     cp -R ./share/* $SHARE_DIR
     chmod a+rx -R $SHARE_DIR
 
     setup_tests $SHARE_DIR $BLUEPRINTS_DIR
     # start the lorax-composer daemon
-    ./src/sbin/lorax-composer --sharedir $SHARE_DIR $BLUEPRINTS_DIR &
+    composer_start
 else
     export PACKAGE="composer-cli"
     export BLUEPRINTS_DIR="/var/lib/lorax/composer/blueprints"
-    systemctl stop lorax-composer
+    composer_stop
     setup_tests /usr/share/lorax /var/lib/lorax/composer/blueprints
-    systemctl start lorax-composer
+    composer_start
 fi
-
-
-# wait for the backend to become ready
-tries=0
-until curl -m 15 --unix-socket /run/weldr/api.socket http://localhost:4000/api/status | grep 'db_supported.*true'; do
-    tries=$((tries + 1))
-    if [ $tries -gt 50 ]; then
-        exit 1
-    fi
-    sleep 5
-    echo "DEBUG: Waiting for backend API to become ready before testing ..."
-done;
 
 
 export BEAKERLIB_JOURNAL=0
@@ -108,15 +97,14 @@ fi
 if [ -z "$CLI" ]; then
     # stop lorax-composer and remove /run/weldr/api.socket
     # only if running against source
-    pkill -9 lorax-composer
-    rm -f /run/weldr/api.socket
+    composer_stop
     teardown_tests $SHARE_DIR $BLUEPRINTS_DIR
 else
-    systemctl stop lorax-composer
+    composer_stop
     teardown_tests /usr/share/lorax /var/lib/lorax/composer/blueprints
     # start lorax-composer again so we can continue with manual or other kinds
     # of testing on the same system
-    systemctl start lorax-composer
+    composer_start
 fi
 
 . $BEAKERLIB_DIR/TestResults

--- a/tests/test_image.sh
+++ b/tests/test_image.sh
@@ -1,26 +1,14 @@
 #!/bin/bash
 # Note: execute this file from the project root directory
+# Used for running a beakerlib test script inside a running VM
+# without setting up composer first!
 
 set -eu
 
 . $(dirname $0)/cli/lib/lib.sh
 
-export BEAKERLIB_DIR=$(mktemp -d /tmp/composer-test.XXXXXX)
-export BEAKERLIB_JOURNAL=0
-if [ -z "$*" ]; then
-    echo "test_image.sh requires a test to execute"
-else
-    # execute tests
-    for TEST in "$@"; do
-        $TEST
-    done
-fi
+setup_beakerlib_env
 
-. $BEAKERLIB_DIR/TestResults
+run_beakerlib_tests "$@"
 
-if [ $TESTRESULT_RESULT_ECODE != 0 ]; then
-  echo "Test failed. Leaving log in $BEAKERLIB_DIR"
-  exit $TESTRESULT_RESULT_ECODE
-fi
-
-rm -rf $BEAKERLIB_DIR
+parse_beakerlib_results

--- a/tests/test_image.sh
+++ b/tests/test_image.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Note: execute this file from the project root directory
+
+set -eu
+
+. $(dirname $0)/cli/lib/lib.sh
+
+export BEAKERLIB_DIR=$(mktemp -d /tmp/composer-test.XXXXXX)
+export BEAKERLIB_JOURNAL=0
+if [ -z "$*" ]; then
+    echo "test_image.sh requires a test to execute"
+else
+    # execute tests
+    for TEST in "$@"; do
+        $TEST
+    done
+fi
+
+. $BEAKERLIB_DIR/TestResults
+
+if [ $TESTRESULT_RESULT_ECODE != 0 ]; then
+  echo "Test failed. Leaving log in $BEAKERLIB_DIR"
+  exit $TESTRESULT_RESULT_ECODE
+fi
+
+rm -rf $BEAKERLIB_DIR


### PR DESCRIPTION
cc @martinpitt - in case the `rhel-8` scenario fails can you rerun on cockpit-7 manually and see if that makes a difference.