### PR TITLE
lorax: Drop unused --title option

### DIFF
--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -296,8 +296,6 @@ def lmc_parser(dracut_default=""):
     vagrant_group.add_argument("--vagrantfile",
                                help="optional vagrantfile")
 
-    parser.add_argument("--title", default="Linux Live Media",
-                        help="Substituted for @TITLE@ in bootloader config files")
     parser.add_argument("--project", default="Linux",
                         help="substituted for @PROJECT@ in bootloader config files")
     parser.add_argument("--releasever", default="32",


### PR DESCRIPTION
It has never been hooked up to anything, let alone substitution @TITLE@
(which also hasn't ever been used in the config files).

Closes #863