### PR TITLE
Add new test to run 'test' and 'check' in cockpit ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 services:
   - docker
 
+env:
+  - DOCKER=docker
+
 script:
   - make test-in-docker
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON ?= /usr/bin/python3
 DESTDIR ?= /
 PREFIX ?= /usr
 mandir ?= $(PREFIX)/share/man
-DOCKER ?= docker
+DOCKER ?= podman
 DOCS_VERSION ?= next
 RUN_TESTS ?= ci
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ TAG = lorax-$(VERSION)-$(RELEASE)
 IMAGE_RELEASE = $(shell awk -F: '/FROM/ { print $$2}' Dockerfile.test)
 
 ifeq ($(TEST_OS),)
-TEST_OS = fedora-30
+OS_ID = $(shell awk -F= '/^ID/ {print $$2}' /etc/os-release)
+OS_VERSION = $(shell awk -F= '/^VERSION_ID/ {print $$2}' /etc/os-release)
+TEST_OS = $(OS_ID)-$(OS_VERSION)
 endif
 export TEST_OS
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)

--- a/tests/composer/test_blueprints.py
+++ b/tests/composer/test_blueprints.py
@@ -232,7 +232,7 @@ class BlueprintsTest(unittest.TestCase):
     @unittest.skipUnless(os.path.exists("/run/weldr/api.socket"), "Test requires a running API server")
     def test_tag(self):
         """blueprints tag"""
-        rc = blueprints_tag("/run/weldr/api.socket", 0, ["glusterfs"], show_json=False)
+        rc = blueprints_tag("/run/weldr/api.socket", 0, ["example-http-server"], show_json=False)
         self.assertTrue(rc == 0)
 
     @unittest.skipUnless(os.path.exists("/run/weldr/api.socket"), "Test requires a running API server")

--- a/tests/pylorax/test_projects.py
+++ b/tests/pylorax/test_projects.py
@@ -330,7 +330,7 @@ def singlerepo_v0():
         "check_gpg": True,
         "check_ssl": True,
         "gpgkey_urls": [
-            "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-32-x86_64"
+            "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-" + os.environ['TEST_OS'] + "-x86_64"
         ],
         "name": "single-repo",
         "system": False,


### PR DESCRIPTION
I want to move the tests that ran in travis CI to cockpit CI. I created a new test for that and I want it to do the same as "make check" and "make test" which is what was running in the docker container in travis.

Right now I am stuck on "check". It gives me this traceback:

:: [ 04:41:07 ] :: [   LOG    ] :: --------------- OUTPUT START ---------------
:: [ 04:41:07 ] :: [   LOG    ] :: STDERR: Traceback (most recent call last):
:: [ 04:41:07 ] :: [   LOG    ] :: STDERR:   File "/tests/pylint/runpylint.py", line 34, in <module>
:: [ 04:41:07 ] :: [   LOG    ] :: STDERR:     rc = linter.run()
:: [ 04:41:07 ] :: [   LOG    ] :: STDERR:   File "/usr/lib/python3.7/site-packages/pocketlint/__init__.py", line 339, in run
:: [ 04:41:07 ] :: [   LOG    ] :: STDERR:     files = self._files
:: [ 04:41:07 ] :: [   LOG    ] :: STDERR:   File "/usr/lib/python3.7/site-packages/pocketlint/__init__.py", line 166, in _files
:: [ 04:41:07 ] :: [   LOG    ] :: STDERR:     lines = fo.readlines()
:: [ 04:41:07 ] :: [   LOG    ] :: STDERR: OSError: [Errno 22] Invalid argument
:: [ 04:41:07 ] :: [   LOG    ] :: ---------------  OUTPUT END  ---------------

I am not sure what causes the error. I am running the test by first building the vm "make vm" and then  "./test/check-cli TestPylint.test_ci"