### PR TITLE
Backport kickstart tar image installation test to RHEL-8

### DIFF
--- a/test/check-cli
+++ b/test/check-cli
@@ -27,9 +27,6 @@ class TestImages(composertest.ComposerTestCase):
     def test_partitioned_disk(self):
         self.runCliTest("/tests/cli/test_compose_partitioned-disk.sh")
 
-    def test_tar(self):
-        self.runCliTest("/tests/cli/test_compose_tar.sh")
-
 
 @unittest.skip('Nested KVM seems to be buggy and software emulation is too slow')
 class TestQcow2(composertest.ComposerTestCase):
@@ -41,6 +38,14 @@ class TestQcow2(composertest.ComposerTestCase):
 class TestLiveIso(composertest.ComposerTestCase):
     def test_live_iso(self):
         self.runCliTest("/tests/cli/test_compose_live-iso.sh")
+
+
+class TestTar(composertest.ComposerTestCase):
+    def test_tar(self):
+        self.runCliTest("/tests/cli/test_compose_tar.sh")
+
+    def test_tar_kickstart(self):
+        self.runCliTest("/tests/cli/test_compose_tar_kickstart.sh")
 
 
 if __name__ == '__main__':

--- a/test/run
+++ b/test/run
@@ -9,6 +9,8 @@ if [ -n "$TEST_SCENARIO" ]; then
     test/check-cli TestLiveIso
   elif [ "$TEST_SCENARIO" == "qcow2" ]; then
     test/check-cli TestQcow2
+  elif [ "$TEST_SCENARIO" == "tar" ]; then
+    test/check-cli TestTar
   else
     test/check-cloud TestCloud.test_$TEST_SCENARIO
   fi

--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -46,7 +46,9 @@ verify_image() {
     SSH_OPTS="-o StrictHostKeyChecking=no $3"
     rlLogInfo "verify_image: SSH_OPTS:'$SSH_OPTS' SSH_USER:'$SSH_USER' SSH_MACHINE: '$SSH_MACHINE'"
     check_root_account "$@"
-    check_kernel_cmdline "$@"
+    if [ "$CHECK_CMDLINE" != 0 ]; then
+        check_kernel_cmdline "$@"
+    fi
 }
 
 check_root_account() {

--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -16,6 +16,28 @@ if [ "$COMPOSER_TEST_FAIL_FAST" == "1" ]; then
   }
 fi
 
+export QEMU_BIN="/usr/libexec/qemu-kvm"
+export QEMU="$QEMU_BIN -machine accel=kvm:tcg"
+export SSH_PORT=2222
+
+boot_image() {
+    QEMU_BOOT=$1
+    TIMEOUT=$2
+    rlRun -t -c "$QEMU -m 2048 $QEMU_BOOT -nographic -monitor none \
+                 -net user,id=nic0,hostfwd=tcp::$SSH_PORT-:22 -net nic &"
+    # wait for ssh to become ready (yes, http is the wrong protocol, but it returns the header)
+    tries=0
+    until curl -sS -m 15 "http://localhost:$SSH_PORT/" | grep 'OpenSSH'; do
+        tries=$((tries + 1))
+        if [ $tries -gt $TIMEOUT ]; then
+            exit 1
+        fi
+        sleep 1
+        echo "DEBUG: Waiting for ssh become ready before testing ..."
+    done;
+}
+
+
 # a generic helper function unifying the specific checks executed on a running
 # image instance
 verify_image() {

--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -23,7 +23,7 @@ export SSH_PORT=2222
 boot_image() {
     QEMU_BOOT=$1
     TIMEOUT=$2
-    rlRun -t -c "$QEMU -m 2048 $QEMU_BOOT -nographic -monitor none \
+    rlRun -t -c "$QEMU -m 2048 $QEMU_BOOT -nographic \
                  -net user,id=nic0,hostfwd=tcp::$SSH_PORT-:22 -net nic &"
     # wait for ssh to become ready (yes, http is the wrong protocol, but it returns the header)
     tries=0

--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -13,7 +13,6 @@ set -e
 . $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
-QEMU="/usr/libexec/qemu-kvm"
 
 rlJournalStart
     rlPhaseStartSetup
@@ -46,16 +45,12 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Start VM instance"
-        rlRun -t -c "$QEMU -m 2048 -boot d -cdrom $IMAGE -nographic -monitor none \
-                           -net user,id=nic0,hostfwd=tcp::2222-:22 -net nic &"
-        # 60 seconds timeout at boot menu screen
-        # then media check + boot ~ 30 seconds
-        sleep 120
+        boot_image "-boot d -cdrom $IMAGE" 120
     rlPhaseEnd
 
     rlPhaseStartTest "Verify VM instance"
         # run generic tests to verify the instance
-        ROOT_ACCOUNT_LOCKED=0 verify_image root localhost "-p 2222"
+        ROOT_ACCOUNT_LOCKED=0 verify_image liveuser localhost "-p $SSH_PORT"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/cli/test_compose_qcow2.sh
+++ b/tests/cli/test_compose_qcow2.sh
@@ -13,7 +13,6 @@ set -e
 . $(dirname $0)/lib/lib.sh
 
 CLI="${CLI:-./src/bin/composer-cli}"
-QEMU="/usr/libexec/qemu-kvm"
 
 rlJournalStart
     rlPhaseStartSetup
@@ -74,14 +73,12 @@ __EOF__
     rlPhaseEnd
 
     rlPhaseStartTest "Start VM instance"
-        rlRun -t -c "$QEMU -m 2048 -boot c -hda $IMAGE -nographic -monitor none \
-                           -net user,id=nic0,hostfwd=tcp::2222-:22 -net nic &"
-        sleep 60
+        boot_image "-boot c -hda $IMAGE" 60
     rlPhaseEnd
 
     rlPhaseStartTest "Verify VM instance"
         # run generic tests to verify the instance
-        verify_image root localhost "-i $SSH_KEY_DIR/id_rsa -p 2222"
+        verify_image root localhost "-i $SSH_KEY_DIR/id_rsa -p $SSH_PORT"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/cli/test_compose_tar_kickstart.sh
+++ b/tests/cli/test_compose_tar_kickstart.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# Note: execute this file from the project root directory
+
+#####
+#
+# Build tar image and install it using liveimg kickstart command
+#
+#####
+
+set -e
+
+. /usr/share/beakerlib/beakerlib.sh
+. $(dirname $0)/lib/lib.sh
+
+CLI="${CLI:-./src/bin/composer-cli}"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertExists $QEMU_BIN
+        if ! rlCheckRpm httpd; then
+            yum -y install httpd
+        fi
+        systemctl start httpd
+
+        ks_path="/var/www/html/ks-tar.cfg"
+        tmp_dir=$(mktemp -d /tmp/composer.XXXXX)
+        ssh_key_dir=$(mktemp -d /tmp/composer-ssh-keys.XXXXXX)
+
+        rlRun -t -c "ssh-keygen -t rsa -N '' -f $ssh_key_dir/id_rsa"
+        pub_key=$(cat $ssh_key_dir/id_rsa.pub)
+
+        bp_name="test-tar"
+        blueprint="$bp_name.toml"
+        cat > $blueprint << __EOF__
+name = "$bp_name"
+description = "tar image test"
+version = "0.0.1"
+modules = []
+
+[[packages]]
+name = "openssh-server"
+version = "*"
+
+# sudo and auditd are needed for checks performed on the installed image instance
+[[packages]]
+name = "sudo"
+version = "*"
+
+[[packages]]
+name = "audit"
+version = "*"
+
+[[groups]]
+name = "anaconda-tools"
+version = "*"
+
+[[customizations.user]]
+name = "root"
+key = "$pub_key"
+
+__EOF__
+        rlRun -t -c "$CLI blueprints push $blueprint"
+        image_path="/var/www/html/root.tar.xz"
+
+        version=$(awk -F = '$1 == "VERSION_ID" { print $2 }' /etc/os-release | tr -d \")
+        arch=$(uname -m)
+        baseurl="http://download.eng.bos.redhat.com/rel-eng/latest-RHEL-${version}/compose/BaseOS/x86_64/os/"
+        rlRun -t -c "curl --remote-name-all $baseurl/images/pxeboot/{vmlinuz,initrd.img}"
+
+        rlRun -t -c "fallocate -l 5G disk.img"
+    rlPhaseEnd
+
+    rlPhaseStartTest "compose start"
+        rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
+        uuid=$($CLI compose start $bp_name tar)
+        rlAssertEquals "exit code should be zero" $? 0
+
+        uuid=$(echo $uuid | cut -f 2 -d' ')
+    rlPhaseEnd
+
+    rlPhaseStartTest "compose finished"
+        if [ -n "$uuid" ]; then
+            until $CLI compose status | grep -E "$uuid (FINISHED|FAILED)"; do
+                sleep 60
+                rlLogInfo "Waiting for compose to finish ..."
+            done;
+        else
+            rlFail "Compose uuid is empty!"
+        fi
+
+        rlRun -t -c "$CLI compose image $uuid"
+        image="$uuid-root.tar.xz"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Install tar image using kickstart liveimg command"
+        cat > $ks_path << __EOF__
+cmdline
+lang en_US.UTF-8
+timezone America/New_York
+keyboard us
+rootpw --lock
+sshkey --username root "$pub_key"
+bootloader --location=mbr
+zerombr
+clearpart --initlabel --all
+autopart
+# reboot is used together with --no-reboot qemu-kvm parameter, which makes the qemu-kvm
+# process exit after the installation is complete and anaconda reboots the system
+# (using 'poweroff' ks command just halted the machine without powering it off)
+reboot
+
+liveimg --url http://10.0.2.2/root.tar.xz
+
+__EOF__
+        mv $image $image_path
+        restorecon $image_path
+        rlLogInfo "Starting installation from tar image in a VM"
+        $QEMU -m 2048 -drive file=disk.img,format=raw -nographic -kernel vmlinuz -initrd initrd.img \
+            -append "inst.ks=http://10.0.2.2/ks-tar.cfg inst.stage2=$baseurl console=ttyS0" --no-reboot
+
+        rlLogInfo "Installation of the image finished."
+    rlPhaseEnd
+
+    rlPhaseStartTest "Boot and check the installed system"
+        boot_image "-drive file=disk.img,format=raw" 600
+        # run generic tests to verify the instance
+        CHECK_CMDLINE=0 verify_image root localhost "-i $ssh_key_dir/id_rsa -p 2222"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun -t -c "killall -9 $QEMU_BIN"
+        rlRun -t -c "rm -rf $image $blueprint $image_path vmlinuz initrd.img disk.img $ks_path"
+        rlRun -t -c "$CLI blueprints delete $bp_name"
+        rlRun -t -c "$CLI compose delete $uuid"
+        rlRun -t -c "systemctl stop httpd"
+    rlPhaseEnd
+
+rlJournalEnd
+rlJournalPrintText


### PR DESCRIPTION
I'll execute the tests once the related update in `testmap.py` is merged in cockpit/bots.