### PR TITLE
Unskip tar kickstart test

### DIFF
--- a/test/check-cli
+++ b/test/check-cli
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 
-import unittest
 import composertest
 
 
@@ -45,7 +44,6 @@ class TestTar(composertest.ComposerTestCase):
     def test_tar(self):
         self.runCliTest("/tests/cli/test_compose_tar.sh")
 
-    @unittest.skip("No such file: 'new-kernel-pkg' in Fedora 30 anaconda. Enable with Fedora 31")
     def test_tar_kickstart(self):
         self.runCliTest("/tests/cli/test_compose_tar_kickstart.sh")
 

--- a/test/vm.install
+++ b/test/vm.install
@@ -32,4 +32,11 @@ rpm -e --verbose $(basename -a ${packages[@]} | sed 's/-[0-9].*.rpm$//') || true
 yum install -y $packages
 
 systemctl enable lorax-composer.socket
-systemctl enable docker.service
+
+if [ -f /usr/bin/docker ]; then
+    yum remove -y $(rpm -qf /usr/bin/docker)
+fi
+
+if ! rpm -q podman-docker; then
+    yum install -y podman-docker
+fi

--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -30,14 +30,6 @@ rlJournalStart
 
     rlPhaseStartTest "compose finished"
         wait_for_compose $UUID
-
-        # Running a compose can lead to a different selinux policy in the
-        # kernel, which may break docker. Reload the policy from the host and
-        # restart docker as a workaround.
-        # See https://bugzilla.redhat.com/show_bug.cgi?id=1711813
-        semodule -R
-        systemctl restart docker
-
         rlRun -t -c "$CLI compose image $UUID"
         IMAGE="$UUID-root.tar.xz"
     rlPhaseEnd

--- a/tests/cli/test_compose_tar_kickstart.sh
+++ b/tests/cli/test_compose_tar_kickstart.sh
@@ -67,15 +67,7 @@ __EOF__
     rlPhaseEnd
 
     rlPhaseStartTest "compose finished"
-        if [ -n "$uuid" ]; then
-            until $CLI compose info $uuid | grep 'FINISHED\|FAILED'; do
-                sleep 60
-                rlLogInfo "Waiting for compose to finish ..."
-            done;
-            check_compose_status "$UUID"
-        else
-            rlFail "Compose uuid is empty!"
-        fi
+        wait_for_compose "$uuid"
 
         rlRun -t -c "$CLI compose image $uuid"
         image="$uuid-root.tar.xz"

--- a/tests/cli/test_compose_tar_kickstart.sh
+++ b/tests/cli/test_compose_tar_kickstart.sh
@@ -37,6 +37,13 @@ description = "tar image test"
 version = "0.0.1"
 modules = []
 
+[[groups]]
+name = "anaconda-tools"
+
+[[packages]]
+name = "kernel"
+version = "*"
+
 [[packages]]
 name = "openssh-server"
 version = "*"

--- a/tests/cli/test_compose_tar_kickstart.sh
+++ b/tests/cli/test_compose_tar_kickstart.sh
@@ -104,8 +104,10 @@ __EOF__
         mv $image $image_path
         restorecon $image_path
         rlLogInfo "Starting installation from tar image in a VM"
-        $QEMU -m 2048 -drive file=disk.img,format=raw -nographic -kernel vmlinuz -initrd initrd.img \
-            -append "inst.ks=http://10.0.2.2/ks-tar.cfg inst.stage2=$baseurl console=ttyS0" --no-reboot
+        $QEMU -m 2048 -drive file=disk.img,format=raw -kernel vmlinuz -initrd initrd.img \
+            -append "inst.ks=http://10.0.2.2/ks-tar.cfg inst.stage2=$baseurl console=ttyS0" --no-reboot \
+            -nographic -monitor none -chardev null,id=log0,mux=on,logfile=/var/log$TEST/qemu.log,logappend=on \
+            -serial chardev:log0
 
         rlLogInfo "Installation of the image finished."
     rlPhaseEnd


### PR DESCRIPTION
b/c we've switched to using Fedora-31 for testing and the known
bugs should be fixed