### PR TITLE
Disable some compose types on other architectures

### DIFF
--- a/src/pylorax/api/v0.py
+++ b/src/pylorax/api/v0.py
@@ -1495,7 +1495,7 @@ def v0_compose_types():
           }
     """
     share_dir = api.config["COMPOSER_CFG"].get("composer", "share_dir")
-    return jsonify(types=[{"name": k, "enabled": True} for k in compose_types(share_dir)])
+    return jsonify(types=[{"name": t, "enabled": e} for t, e in compose_types(share_dir)])
 
 @v0_api.route("/compose/queue")
 def v0_compose_queue():

--- a/tests/pylorax/test_compose.py
+++ b/tests/pylorax/test_compose.py
@@ -744,7 +744,7 @@ disabled = ["postfix", "telnetd"]
         # Test against all of the available templates
         share_dir = "./share/"
         errors = []
-        for compose_type in compose_types(share_dir):
+        for compose_type, _enabled in compose_types(share_dir):
             # Read the kickstart template for this type
             ks_template_path = joinpaths(share_dir, "composer", compose_type) + ".ks"
             ks_template = open(ks_template_path, "r").read()
@@ -837,3 +837,11 @@ class ExtraPkgsTest(unittest.TestCase):
         """Test that non-live doesn't parse live-install.tmpl"""
         extra_pkgs = get_extra_pkgs(self.dbo, "./share/", "qcow2")
         self.assertEqual(extra_pkgs, [])
+
+class ComposeTypesTest(unittest.TestCase):
+    def test_compose_types(self):
+        types = compose_types("./share/")
+        self.assertTrue(("qcow2", True) in types)
+
+        if os.uname().machine != 'x86_64':
+            self.assertTrue(("alibaba", False) in types)

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -960,6 +960,10 @@ class ServerAPIV0TestCase(unittest.TestCase):
         self.assertNotEqual(data, None)
         self.assertEqual({"name": "tar", "enabled": True} in data["types"], True)
 
+        # All of the non-x86 compose types disable alibaba
+        if os.uname().machine != 'x86_64':
+            self.assertEqual({"name": "alibaba", "enabled": False} in data["types"], True)
+
     def test_compose_02_bad_type(self):
         """Test that using an unsupported image type failes"""
         test_compose = {"blueprint_name": "example-glusterfs",


### PR DESCRIPTION
The 'enabled' field in the /compose/types output now reflects whether or
not the type is supported on the current architecture. Disabled types
are not allowed to be built, and will raise an error like:

Compose type 'alibaba' is disabled on this architecture