### PR TITLE
composer-cli: Return int from handle_api_result not bool

### DIFF
--- a/src/composer/cli/utilities.py
+++ b/src/composer/cli/utilities.py
@@ -73,9 +73,9 @@ def handle_api_result(result, show_json=False):
     # What's the rc? If status is present, use that
     # If not, use length of errors
     if "status" in result:
-        rc = bool(not result["status"])
+        rc = int(not result["status"])
     else:
-        rc = bool(len(result.get("errors", [])) > 0)
+        rc = int(len(result.get("errors", [])) > 0)
 
     # Caller should return if showing json, or status was present and False
     exit_now = show_json or ("status" in result and rc)

--- a/tests/composer/test_utilities.py
+++ b/tests/composer/test_utilities.py
@@ -52,11 +52,13 @@ class CliUtilitiesTest(unittest.TestCase):
         """Test a result with no status and no error fields"""
         result = {"foo": "bar"}
         self.assertEqual(handle_api_result(result, show_json=False), (0, False))
+        self.assertTrue(handle_api_result(result, show_json=False)[0] is 0)
 
     def test_api_result_2(self):
         """Test a result with errors=[{"id": INVALID_CHARS, "msg": "some error"}], and no status field"""
         result = {"foo": "bar", "errors": [{"id": INVALID_CHARS, "msg": "some error"}]}
         self.assertEqual(handle_api_result(result, show_json=False), (1, False))
+        self.assertTrue(handle_api_result(result, show_json=False)[0] is 1)
 
     def test_api_result_3(self):
         """Test a result with status=True, and errors=[]"""


### PR DESCRIPTION
The callers, and the documentation, all expect int 0/1 to use as the
exit status for the program. Not True/False, even though that works most
of the time.