### PR TITLE
Add dmidecode on supported architectures

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -134,6 +134,10 @@ installpkg pcmciautils
     installpkg libmlx4 rdma-core
 %endif
 installpkg rng-tools
+%if basearch in ("i386", "x86_64", "aarch64"):
+installpkg dmidecode
+%endif
+
 
 ## fonts & themes
 installpkg bitmap-fangsongti-fonts


### PR DESCRIPTION
Currently supported on i386, x86_64, aarch64

Related: rhbz#1714793