### PR TITLE
Always remove RPMs before installing them & allow using arbitrary repositories, incl. system repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ ci: check test
 
 $(VM_IMAGE): TAG=HEAD
 $(VM_IMAGE): srpm bots
+	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
 	srpm=$(shell rpm --qf '%{Name}-%{Version}-%{Release}.src.rpm\n' -q --specfile lorax.spec | head -n1) ; \
 	bots/image-customize -v \
 		--resize 20G \

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ endif
 export TEST_OS
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 
+ifeq ($(REPOS_DIR),)
+REPOS_DIR = /etc/yum.repos.d
+endif
+
 default: all
 
 src/composer/version.py: lorax.spec
@@ -166,8 +170,14 @@ vm: $(VM_IMAGE)
 # sure VM_IMAGE is as close as possible to the host!
 vm-local-repos: vm
 	bots/image-customize -v \
-		--upload /etc/yum.repos.d:/etc/yum.repos.d/ \
+		--run-command "rm -rf /etc/yum.repos.d" \
+		$(TEST_OS)
+	bots/image-customize -v \
+		--upload $(REPOS_DIR):/etc/yum.repos.d \
+		--run-command "yum -y remove composer-cli lorax-composer" \
 		--run-command "yum -y update" \
+		--run-command "yum -y install composer-cli lorax-composer" \
+		--run-command "systemctl enable lorax-composer" \
 		$(TEST_OS)
 
 vm-reset:

--- a/test/README.md
+++ b/test/README.md
@@ -41,12 +41,13 @@ To delete the generated image, run
 Base images are stored in `bots/images`. Set `TEST_DATA` to override this
 directory.
 
-Use
+To configure the image with all repositories found on the host system use
 
     $ make vm-local-repos
 
-to configure the image with all repositories found on the host system! This
-is mostly useful when running tests by hand on a downstream snapshot!
+You may also define `REPOS_DIR` variable to point to another directory
+containing yum .repo files. By default the value is `/etc/yum.repos.d`!
+This is mostly useful when running tests by hand on a downstream snapshot!
 
 ## Running tests
 

--- a/test/vm.install
+++ b/test/vm.install
@@ -2,6 +2,10 @@
 
 SRPM="$1"
 
+# always remove older versions of these RPMs if they exist
+# to ensure newly built packages have been installed
+yum -y remove lorax lorax-composer composer-cli
+
 if ! rpm -q beakerlib; then
     if [ $(. /etc/os-release && echo $ID) = "rhel" ]; then
         (cd /etc/yum.repos.d; curl -O -L http://download.devel.redhat.com/beakerrepos/beaker-client-RedHatEnterpriseLinux.repo)
@@ -33,7 +37,6 @@ rm -rf build-results
 su builder -c "/usr/bin/mock --verbose --no-clean --resultdir build-results --rebuild $SRPM"
 
 packages=$(find build-results -name '*.rpm' -not -name '*.src.rpm')
-rpm -e --verbose $(basename -a ${packages[@]} | sed 's/-[0-9].*.rpm$//') || true
 yum install -y $packages
 
 systemctl enable lorax-composer.socket


### PR DESCRIPTION
1) Remove whatever packages happen to be there in the image so they can be installed later from the locally built RPMs

2) I also want to adjust Makefile (vm-local-repos)/vm.install so that when testing downstream snapshots we don't build & install from source but instead install from the repos copied from the host machine.

cc @bcl, @martinpitt, @jikortus 