### PR TITLE
tests: enable compose_ext4 test to use CDN repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 *.pyc
+*.rpm
 src/pylorax/version.py*
 _build/
 tests/pylint/.pylint.d/
 __pycache__/
 .coverage
 pylint-log
+/lorax-*.tar.gz
+/bots
+/test/images
+/tmp


### PR DESCRIPTION
This enables to run compose_ext4 test with CDN repos only. The idea is that the system gets subscribed against stage candlepin and consumes from production CDNs if the required environmental variables are set.