### PR TITLE
Backport of PR908 to RHEL 7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ TAG = lorax-$(VERSION)-$(RELEASE)
 IMAGE_RELEASE = $(shell awk -F: '/FROM/ { print $$2}' Dockerfile.test)
 
 ifeq ($(TEST_OS),)
-TEST_OS = rhel-7-7
+OS_ID = $(shell awk -F= '/^ID=/ {print $$2}' /etc/os-release)
+OS_VERSION = $(shell awk -F= '/^VERSION_ID/ {print $$2}' /etc/os-release | tr '.' '-')
+TEST_OS = $(OS_ID)-$(OS_VERSION)
 endif
 export TEST_OS
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ ci: check test
 
 $(VM_IMAGE): TAG=HEAD
 $(VM_IMAGE): srpm bots
+	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
 	srpm=$(shell rpm --qf '%{Name}-%{Version}-%{Release}.src.rpm\n' -q --specfile lorax-composer.spec | head -n1) ; \
 	bots/image-customize -v \
 		--resize 20G \

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ endif
 export TEST_OS
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 
+ifeq ($(REPOS_DIR),)
+REPOS_DIR = /etc/yum.repos.d
+endif
+
 default: all
 
 src/composer/version.py:
@@ -133,8 +137,14 @@ vm: $(VM_IMAGE)
 # sure VM_IMAGE is as close as possible to the host!
 vm-local-repos: vm
 	bots/image-customize -v \
-		--upload /etc/yum.repos.d:/etc/yum.repos.d/ \
+		--run-command "rm -rf /etc/yum.repos.d" \
+		$(TEST_OS)
+	bots/image-customize -v \
+		--upload $(REPOS_DIR):/etc/yum.repos.d \
+		--run-command "yum -y remove composer-cli lorax-composer" \
 		--run-command "yum -y update" \
+		--run-command "yum -y install composer-cli lorax-composer" \
+		--run-command "systemctl enable lorax-composer" \
 		$(TEST_OS)
 
 vm-reset:

--- a/test/README.md
+++ b/test/README.md
@@ -41,12 +41,13 @@ To delete the generated image, run
 Base images are stored in `bots/images`. Set `TEST_DATA` to override this
 directory.
 
-Use
+To configure the image with all repositories found on the host system use
 
     $ make vm-local-repos
 
-to configure the image with all repositories found on the host system! This
-is mostly useful when running tests by hand on a downstream snapshot!
+You may also define `REPOS_DIR` variable to point to another directory
+containing yum .repo files. By default the value is `/etc/yum.repos.d`!
+This is mostly useful when running tests by hand on a downstream snapshot!
 
 ## Running tests
 

--- a/test/vm.install
+++ b/test/vm.install
@@ -2,6 +2,10 @@
 
 SRPM="$1"
 
+# always remove older versions of these RPMs if they exist
+# to ensure newly built packages have been installed
+yum -y remove lorax lorax-composer composer-cli
+
 LATEST_REPO="/etc/yum.repos.d/rhel7-rel-eng-latest.repo"
 if [ ! -f "$LATEST_REPO" ]; then
     cat > $LATEST_REPO << __EOF__
@@ -74,7 +78,6 @@ rm -rf build-results
 su builder -c "/usr/bin/mock --no-clean --resultdir build-results --rebuild $SRPM"
 
 packages=$(find build-results -name '*.rpm' -not -name '*.src.rpm')
-rpm -e --verbose $(basename -a ${packages[@]} | sed 's/-[0-9].*.rpm$//') || true
 yum install -y $packages
 
 systemctl enable lorax-composer.socket


### PR DESCRIPTION
Same reasoning, we need this in a downstream branch b/c this is where snapshots testing happens.