### PR TITLE
tests: If TEST_OS isn't specified then match the host OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ TAG = lorax-$(VERSION)-$(RELEASE)
 IMAGE_RELEASE = rhel8-latest
 
 ifeq ($(TEST_OS),)
-TEST_OS = rhel-8-1
+OS_ID = $(shell awk -F= '/^ID=/ {print $$2}' /etc/os-release)
+OS_VERSION = $(shell awk -F= '/^VERSION_ID/ {print $$2}' /etc/os-release | tr '.' '-')
+TEST_OS = $(OS_ID)-$(OS_VERSION)
 endif
 export TEST_OS
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)


### PR DESCRIPTION
this will help with downstream snapshots testing making
it easier to match the host OS snapshot

Cherry-picked from 6839390be262f5a51f17e1b8d728f88106385f39

Related: rhbz#1769525

This is an addition to #912 