### PR TITLE
composer-cli: Only display the available compose types

### DIFF
--- a/src/composer/cli/compose.py
+++ b/src/composer/cli/compose.py
@@ -197,7 +197,7 @@ def compose_types(socket_path, api_version, args, show_json=False, testmode=0):
         return 0
 
     # output a plain list of identifiers, one per line
-    print("\n".join(t["name"] for t in result["types"]))
+    print("\n".join(t["name"] for t in result["types"] if t["enabled"]))
 
 def compose_start(socket_path, api_version, args, show_json=False, testmode=0):
     """Start a new compose using the selected blueprint and type

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -11,8 +11,14 @@ CLI="${CLI:-./src/bin/composer-cli}"
 
 rlJournalStart
     rlPhaseStartTest "compose types"
-        rlAssertEquals "lists all supported types" \
-                "`$CLI compose types | xargs`" "alibaba ami ext4-filesystem google hyper-v live-iso liveimg-tar openstack partitioned-disk qcow2 tar vhd vmdk"
+        if [ "$(uname -m)" = "x86_64" ]; then
+            rlAssertEquals "lists all supported types" \
+                    "`$CLI compose types | xargs`" "alibaba ami ext4-filesystem google hyper-v live-iso liveimg-tar openstack partitioned-disk qcow2 tar vhd vmdk"
+        else
+            # non-x86 architectures disable alibaba
+            rlAssertEquals "lists all supported types" \
+                    "`$CLI compose types | xargs`" "ext4-filesystem live-iso liveimg-tar openstack partitioned-disk qcow2 tar"
+        fi
     rlPhaseEnd
 
     rlPhaseStartTest "compose start"

--- a/tests/pylorax/blueprints/example-append.toml
+++ b/tests/pylorax/blueprints/example-append.toml
@@ -4,15 +4,15 @@ version = "0.0.1"
 
 [[packages]]
 name = "tmux"
-version = "2.9a"
+version = "*"
 
 [[packages]]
 name = "openssh-server"
-version = "8.*"
+version = "*"
 
 [[packages]]
 name = "rsync"
-version = "3.1.*"
+version = "*"
 
 [customizations.kernel]
 append = "nosmt=force"

--- a/tests/pylorax/blueprints/example-atlas.toml
+++ b/tests/pylorax/blueprints/example-atlas.toml
@@ -4,8 +4,8 @@ version = "0.0.1"
 
 [[modules]]
 name = "atlas"
-version = "3.10.*"
+version = "*"
 
 [[modules]]
 name = "python3-numpy"
-version = "1.15.*"
+version = "*"

--- a/tests/pylorax/blueprints/example-custom-base.toml
+++ b/tests/pylorax/blueprints/example-custom-base.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 
 [[packages]]
 name = "bash"
-version = "5.0.*"
+version = "*"
 
 [customizations]
 hostname = "custombase"

--- a/tests/pylorax/blueprints/example-glusterfs.toml
+++ b/tests/pylorax/blueprints/example-glusterfs.toml
@@ -3,12 +3,12 @@ description = "An example GlusterFS server with samba"
 
 [[modules]]
 name = "glusterfs"
-version = "7.*"
+version = "*"
 
 [[modules]]
 name = "glusterfs-cli"
-version = "7.*"
+version = "*"
 
 [[packages]]
 name = "samba"
-version = "4.*.*"
+version = "*"

--- a/tests/pylorax/blueprints/example-http-server.toml
+++ b/tests/pylorax/blueprints/example-http-server.toml
@@ -4,32 +4,32 @@ version = "0.0.1"
 
 [[modules]]
 name = "httpd"
-version = "2.4.*"
+version = "*"
 
 [[modules]]
 name = "mod_auth_openid"
-version = "0.8"
+version = "*"
 
 [[modules]]
 name = "mod_ssl"
-version = "2.4.*"
+version = "*"
 
 [[modules]]
 name = "php"
-version = "7.*"
+version = "*"
 
 [[modules]]
 name = "php-mysqlnd"
-version = "7.*"
+version = "*"
 
 [[packages]]
 name = "tmux"
-version = "2.9a"
+version = "*"
 
 [[packages]]
 name = "openssh-server"
-version = "8.*"
+version = "*"
 
 [[packages]]
 name = "rsync"
-version = "3.1.*"
+version = "*"

--- a/tests/pylorax/blueprints/example-jboss.toml
+++ b/tests/pylorax/blueprints/example-jboss.toml
@@ -4,12 +4,12 @@ version = "0.0.1"
 
 [[modules]]
 name = "jboss-servlet-3.1-api"
-version = "1.0.*"
+version = "*"
 
 [[modules]]
 name = "jboss-interceptors-1.2-api"
-version = "1.0.*"
+version = "*"
 
 [[modules]]
 name = "java-1.8.0-openjdk"
-version = "1.8.0.*"
+version = "*"

--- a/tests/pylorax/blueprints/example-kubernetes.toml
+++ b/tests/pylorax/blueprints/example-kubernetes.toml
@@ -4,24 +4,24 @@ version = "0.0.1"
 
 [[modules]]
 name = "kubernetes"
-version = "1.10.*"
+version = "*"
 
 [[modules]]
 name = "docker"
-version = "1.13.*"
+version = "*"
 
 [[modules]]
 name = "docker-lvm-plugin"
-version = "1.13.*"
+version = "*"
 
 [[modules]]
 name = "etcd"
-version = "3.2.*"
+version = "*"
 
 [[modules]]
 name = "flannel"
-version = "0.9.*"
+version = "*"
 
 [[packages]]
 name = "oci-systemd-hook"
-version = "0.1.*"
+version = "*"

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -46,17 +46,17 @@ UTF8_TEST_STRING = "I ｗ𝒊ll 𝟉ο𝘁 𝛠ａ𝔰ꜱ 𝘁𝒉𝝸𝚜"
 
 
 # HELPER CONSTANTS
-HTTP_GLOB = {"name":"httpd", "version":"2.4.*"}
-OPENID_GLOB = {"name":"mod_auth_openid", "version":"0.8"}
-MODSSL_GLOB = {"name":"mod_ssl", "version":"2.4.*"}
-PHP_GLOB = {"name":"php", "version":"7.*"}
-PHPMYSQL_GLOB = {"name": "php-mysqlnd", "version":"7.*"}
-OPENSSH_GLOB = {"name":"openssh-server", "version": "8.*"}
-RSYNC_GLOB = {"name": "rsync", "version": "3.1.*"}
-SAMBA_GLOB = {"name": "samba", "version": "4.*.*"}
-TMUX_GLOB = {"name": "tmux", "version": "2.9a"}
-GLUSTERFS_GLOB = {"name": "glusterfs", "version": "7.*"}
-GLUSTERFSCLI_GLOB = {"name": "glusterfs-cli", "version": "7.*"}
+HTTP_GLOB = {"name":"httpd", "version":"*"}
+OPENID_GLOB = {"name":"mod_auth_openid", "version":"*"}
+MODSSL_GLOB = {"name":"mod_ssl", "version":"*"}
+PHP_GLOB = {"name":"php", "version":"*"}
+PHPMYSQL_GLOB = {"name": "php-mysqlnd", "version":"*"}
+OPENSSH_GLOB = {"name":"openssh-server", "version": "*"}
+RSYNC_GLOB = {"name": "rsync", "version": "*"}
+SAMBA_GLOB = {"name": "samba", "version": "*"}
+TMUX_GLOB = {"name": "tmux", "version": "*"}
+GLUSTERFS_GLOB = {"name": "glusterfs", "version": "*"}
+GLUSTERFSCLI_GLOB = {"name": "glusterfs-cli", "version": "*"}
 
 
 def get_system_repo():


### PR DESCRIPTION
The enabled bool is now being used so the cli should only show the types
actually available on the architecture.

Also modifies the test in test_compose_sanity.sh

Related: rhbz#1751998