### PR TITLE
lorax: Remove vmlinuz from install.img /boot

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -41,7 +41,7 @@ Requires:       xz-lzma-compat
 Requires:       xz
 Requires:       pigz
 Requires:       pbzip2
-Requires:       dracut >= 030
+Requires:       dracut >= 050
 Requires:       kpartx
 
 # Python modules

--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -328,9 +328,8 @@ removefrom ${product.name}-logos /usr/share/{firstboot,gnome-screensaver,kde4,pi
 runcmd find ${root} -name "*.pyo" -type f -delete
 runcmd find ${root} -name "*.pyc" -type f -exec ln -sf /dev/null {} \;
 
-## cleanup /boot/ leaving vmlinuz, and .*hmac files
-runcmd chroot ${root} find /boot \! -name "vmlinuz*" \
-                            -and \! -name ".vmlinuz*" \
+## cleanup /boot/ leaving vmlinuz*hmac files
+runcmd chroot ${root} find /boot \! -name ".vmlinuz*hmac" \
                             -and \! -name boot -delete
 
 ## remove any broken links in /etc or /usr


### PR DESCRIPTION
The kernel in /boot is not needed. Keep the .vmlinuz*hmac file so that
fips mode can check it (this requires an updated dracut, see
https://github.com/dracutdevs/dracut/pull/696).

Related: rhbz#1782737