### PR TITLE
[7.9] Add test for running composer with --no-system-repos option

### DIFF
--- a/test/check-cli
+++ b/test/check-cli
@@ -74,6 +74,11 @@ class TestLiveIso(composertest.ComposerTestCase):
             self.runImageTest("/tests/cli/test_boot_live-iso.sh")
 
 
+class TestRepos(composertest.ComposerTestCase):
+    def test_repos_sanity(self):
+        self.runCliTest("/tests/cli/test_repos_sanity.sh")
+
+
 class TestTar(composertest.ComposerTestCase):
     def test_tar(self):
         self.runCliTest("/tests/cli/test_compose_tar.sh")

--- a/test/run
+++ b/test/run
@@ -17,4 +17,5 @@ if [ -n "$TEST_SCENARIO" ]; then
 else
   test/check-cli TestImages
   test/check-api
+  test/check-cli TestRepos
 fi

--- a/tests/cli/test_repos_sanity.sh
+++ b/tests/cli/test_repos_sanity.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Note: execute this file from the project root directory
+
+set -e
+
+. /usr/share/beakerlib/beakerlib.sh
+. $(dirname $0)/lib/lib.sh
+
+CLI="${CLI:-./src/bin/composer-cli}"
+
+rlJournalStart
+    rlPhaseStartSetup
+        repodir_backup=$(mktemp -d composerrepos-XXXXX)
+        composer_stop
+        rlRun -t -c "mv /var/lib/lorax/composer/repos.d/* $repodir_backup"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Run lorax-composer with --no-system-repos option and empty repos.d"
+        composer_start --no-system-repos
+
+        # check that there are no composer repos available
+        rlRun -t -c "$CLI sources list | grep -v '^$' | wc -l | grep '^0$'"
+        present_repos=$(ls /var/lib/lorax/composer/repos.d)
+        if [ -z "$present_repos" ]; then
+            rlPass "No repos found in repos.d"
+        else
+            rlFail "The following repos were found in repos.d: $present_repos"
+        fi
+
+        # starting a compose without available repos should fail due to a depsolving error
+        rlRun -t -c "tmp_output='$($CLI compose start example-http-server partitioned-disk 2>&1)'"
+        rlRun -t -c "echo '$tmp_output' | grep -q 'Problem depsolving example-http-server:'"
+        MANUAL=1 composer_stop
+    rlPhaseEnd
+
+    rlPhaseStartTest "Run lorax-composer with --no-system-repos and manually created content in repos.d"
+    echo '[server]
+name=Server
+baseurl=http://download.devel.redhat.com/rhel-7/nightly/RHEL-7/latest-RHEL-7/compose/Server/$basearch/os/
+enabled=1
+gpgcheck=0
+
+[server-optional]
+name=Server-optional
+baseurl=http://download.devel.redhat.com/rhel-7/nightly/RHEL-7/latest-RHEL-7/compose/Server-optional/$basearch/os/
+enabled=1
+gpgcheck=0
+
+' > /var/lib/lorax/composer/repos.d/test.repo
+
+        composer_start --no-system-repos
+        present_repos=$(ls /var/lib/lorax/composer/repos.d/)
+        rlAssertEquals "Only test.repo found in repos.d" "$present_repos" "test.repo"
+
+        UUID=$(composer-cli compose start example-http-server partitioned-disk)
+        rlAssertEquals "exit code should be zero" $? 0
+        UUID=$(echo $UUID | cut -f 2 -d' ')
+
+        wait_for_compose $UUID
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        $CLI compose delete $UUID
+        MANUAL=1 composer_stop
+        rlRun -t -c "rm -rf /var/lib/lorax/composer/repos.d"
+        rlRun -t -c "mv $repodir_backup /var/lib/lorax/composer/repos.d"
+        composer_start
+    rlPhaseEnd
+rlJournalEnd
+rlJournalPrintText


### PR DESCRIPTION
- add test coverage for rhbz#1650363
- cherry-picked from 5322664432631f61af831d1eef5f400ffb65b3f9

Related: rhbz#1785159