### PR TITLE
Add test for canceling a running compose

### DIFF
--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -22,6 +22,26 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose start"
+        UUID=`$CLI compose start example-http-server ami`
+        rlAssertEquals "exit code should be zero" $? 0
+        UUID=`echo $UUID | cut -f 2 -d' '`
+
+        if [ -n "$UUID" ]; then
+            until $CLI compose info $UUID | grep 'RUNNING'; do
+                sleep 20
+                rlLogInfo "Waiting for compose to start running..."
+            done;
+        else
+            rlFail "Compose UUID is empty!"
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartTest "cancel compose"
+        rlRun -t -c "$CLI compose cancel $UUID"
+        rlRun -t -c "$CLI compose info $UUID" 1 "compose is canceled"
+    rlPhaseEnd
+
+    rlPhaseStartTest "compose start again"
         UUID=`$CLI --test=2 compose start example-http-server tar`
         rlAssertEquals "exit code should be zero" $? 0
 


### PR DESCRIPTION
This is a modification of an existing test for compose sanity. This should now create the same test scenario like in https://bugzilla.redhat.com/show_bug.cgi?id=1656691 