### PR TITLE
composer-cli: Increase DELETE timeout to 120s

### DIFF
--- a/src/composer/http_client.py
+++ b/src/composer/http_client.py
@@ -126,7 +126,7 @@ def get_url_json_unlimited(socket_path, url, total_fn=None):
     r_unlimited = http.request("GET", unlimited_url)
     return json.loads(r_unlimited.data.decode('utf-8'))
 
-def delete_url_json(socket_path, url):
+def delete_url_json(socket_path, url, timeout=120):
     """Send a DELETE request to the url and return JSON response
 
     :param socket_path: Path to the Unix socket to use for API communication
@@ -136,7 +136,7 @@ def delete_url_json(socket_path, url):
     :returns: The json response from the server
     :rtype: dict
     """
-    http = UnixHTTPConnectionPool(socket_path)
+    http = UnixHTTPConnectionPool(socket_path, timeout=timeout)
     r = http.request("DELETE", url)
     return json.loads(r.data.decode("utf-8"))
 


### PR DESCRIPTION
When the timeout is too short the http library sends the request again.
We return the last response to the user so even if the cancel works they
get an error about the UUID not being valid.

Resolves: rhbz#1788461