### PR TITLE
AWS test: take into account different instance type for non x86

### DIFF
--- a/tests/cli/playbooks/aws/instance.yml
+++ b/tests/cli/playbooks/aws/instance.yml
@@ -7,10 +7,10 @@
 
   - name: Create instance
     ec2_instance:
-      name: "{{ ami_id }}"
+      name: "Composer-Test-{{ ami_id }}"
       image_id: "{{ ami_id }}"
       key_name: "{{ key_name }}"
-      instance_type: t2.small
+      instance_type: "{{ instance_type }}"
       security_group: allow-ssh
       instance_initiated_shutdown_behavior: terminate
       state: present

--- a/tests/cli/test_build_and_deploy_aws.sh
+++ b/tests/cli/test_build_and_deploy_aws.sh
@@ -146,6 +146,10 @@ __EOF__
     rlPhaseEnd
 
     rlPhaseStartTest "Start EC2 instance"
+        INSTANCE_TYPE="t2.small"
+        if [ "$(uname -m)" == "aarch64" ]; then
+            INSTANCE_TYPE="a1.medium"
+        fi
         # generate new ssh key
         KEY_NAME=composer-$UUID
         SSH_KEY_DIR=`mktemp -d /tmp/composer-ssh-keys.XXXXXX`
@@ -155,6 +159,7 @@ __EOF__
                        'key_name=$KEY_NAME \
                         ssh_key_dir=$SSH_KEY_DIR \
                         ami_id=$AMI_ID \
+                        instance_type=$INSTANCE_TYPE \
                         tmp_dir=$TMP_DIR' \
                      $PLAYBOOKS_DIR/instance.yml"
 

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -11,7 +11,7 @@ CLI="${CLI:-./src/bin/composer-cli}"
 
 rlJournalStart
     rlPhaseStartTest "compose types"
-        if [ "$(uname -m)" = "x86_64" ]; then
+        if [ "$(uname -m)" == "x86_64" ]; then
             rlAssertEquals "lists all supported types" \
                     "`$CLI compose types | xargs`" "alibaba ami ext4-filesystem google hyper-v live-iso liveimg-tar openstack partitioned-disk qcow2 tar vhd vmdk"
         else


### PR DESCRIPTION
- also updates VM name used in playbook to be more descriptive
- also fix equality comparison to use == for consistency