### PR TITLE
[7.9] Add test for canceling a running compose

### DIFF
--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -16,6 +16,30 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose start"
+        UUID=`$CLI compose start example-http-server ami`
+        rlAssertEquals "exit code should be zero" $? 0
+        UUID=`echo $UUID | cut -f 2 -d' '`
+
+        if [ -n "$UUID" ]; then
+            until $CLI compose details $UUID | grep 'RUNNING'; do
+                sleep 20
+                rlLogInfo "Waiting for compose to start running..."
+                if $CLI compose info $UUID | grep 'FAILED'; then
+                    rlFail "Compose FAILED!"
+                    break
+                fi
+            done;
+        else
+            rlFail "Compose UUID is empty!"
+        fi
+    rlPhaseEnd
+
+    rlPhaseStartTest "cancel compose"
+        rlRun -t -c "$CLI compose cancel $UUID"
+        rlRun -t -c "$CLI compose details $UUID" 1 "compose is canceled"
+    rlPhaseEnd
+
+    rlPhaseStartTest "compose start again"
         UUID=`$CLI --test=2 compose start example-http-server tar`
         rlAssertEquals "exit code should be zero" $? 0
 

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -32,6 +32,12 @@ rlJournalStart
         else
             rlFail "Compose UUID is empty!"
         fi
+
+        # check if anaconda is really running
+        until ps -axo comm,pid | grep '^anaconda'; do
+            sleep 10
+            rlLogInfo "Waiting for anaconda to start running..."
+        done;
     rlPhaseEnd
 
     rlPhaseStartTest "cancel compose"
@@ -40,7 +46,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose start again"
-        UUID=`$CLI --test=2 compose start example-http-server tar`
+        UUID=`$CLI compose start example-http-server tar`
         rlAssertEquals "exit code should be zero" $? 0
 
         UUID=`echo $UUID | cut -f 2 -d' '`


### PR DESCRIPTION
This is a modification of an existing test for compose sanity.
Cherry picked from 8c9f528cd42fd8dd61e64572eda89e6168c409a0

Related: rhbz#1789451