### PR TITLE
livemedia-creator: workaround glibc limitation when starting anaconda

### DIFF
--- a/src/pylorax/installer.py
+++ b/src/pylorax/installer.py
@@ -398,12 +398,14 @@ def novirt_install(opts, disk_img, disk_size, cancel_func=None, tar_img=None):
         cancel_funcs.append(cancel_func)
 
     # Make sure anaconda has the right product and release
+    # Preload libgomp.so.1 to workaround rhbz#1722181
     log.info("Running anaconda.")
     try:
         unshare_args = [ "--pid", "--kill-child", "--mount", "--propagation", "unchanged", "anaconda" ] + args
         for line in execReadlines("unshare", unshare_args, reset_lang=False,
                                   env_add={"ANACONDA_PRODUCTNAME": opts.project,
-                                           "ANACONDA_PRODUCTVERSION": opts.releasever},
+                                           "ANACONDA_PRODUCTVERSION": opts.releasever,
+                                           "LD_PRELOAD": "libgomp.so.1"},
                                   callback=lambda p: not novirt_cancel_check(cancel_funcs, p)):
             log.info(line)
 


### PR DESCRIPTION
On some platforms (aarch64, ppc64le) toolchain limitations/optimizations can break anaconda startup, as discussed in https://bugzilla.redhat.com/show_bug.cgi?id=1722181. The workaround is to preload libgomp.so before starting anaconda.

This is similar to what anaconda did in https://github.com/rhinstaller/anaconda/commit/ff06b13c273bcabd538eec2095d480867166f0fd#diff-99e21f9d36672308692521fc7b57de14 (plus fixed typo)