### PR TITLE
Add --dracut-conf cmdline argument to lorax and livemedia-creator

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -13,7 +13,6 @@ RUN  dnf -y install \
   python3-gevent \
   python3-magic \
   python3-mako \
-  python3-mock \
   python3-pocketlint \
   python3-pycdlib \
   python3-pylint \

--- a/src/pylorax/api/queue.py
+++ b/src/pylorax/api/queue.py
@@ -236,7 +236,9 @@ def make_compose(cfg, results_dir):
 
     cfg_dict["lorax_templates"] = find_templates(cfg.share_dir)
     cfg_dict["tmp"] = cfg.tmp
-    cfg_dict["dracut_args"] = None                  # Use default args for dracut
+    # Use default args for dracut
+    cfg_dict["dracut_conf"] = None
+    cfg_dict["dracut_args"] = None
 
     # TODO How to support other arches?
     cfg_dict["arch"] = None

--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -113,12 +113,15 @@ def lorax_parser(dracut_default=""):
                           help="Use a plain squashfs filesystem for the runtime.")
 
     # dracut arguments
-    dracut_group = parser.add_argument_group("dracut arguments")
+    dracut_group = parser.add_argument_group("dracut arguments: (default: %s)" % dracut_default)
+    dracut_group.add_argument("--dracut-conf",
+                              help="Path to a dracut.conf file to use instead of the "
+                                   "default arguments. See the dracut.conf(5) manpage.")
     dracut_group.add_argument("--dracut-arg", action="append", dest="dracut_args",
                               help="Argument to pass to dracut when "
                                    "rebuilding the initramfs. Pass this "
                                    "once for each argument. NOTE: this "
-                                   "overrides the default. (default: %s)" % dracut_default)
+                                   "overrides the defaults.")
 
     # add the show version option
     parser.add_argument("-V", help="show program's version number and exit",
@@ -268,12 +271,15 @@ def lmc_parser(dracut_default=""):
                             help="RNG device for QEMU (none for no RNG)")
 
     # dracut arguments
-    dracut_group = parser.add_argument_group("dracut arguments")
+    dracut_group = parser.add_argument_group("dracut arguments: (default: %s)" % dracut_default)
+    dracut_group.add_argument("--dracut-conf",
+                              help="Path to a dracut.conf file to use instead of the "
+                                   "default arguments. See the dracut.conf(5) manpage.")
     dracut_group.add_argument("--dracut-arg", action="append", dest="dracut_args",
                               help="Argument to pass to dracut when "
                                    "rebuilding the initramfs. Pass this "
                                    "once for each argument. NOTE: this "
-                                   "overrides the default. (default: %s)" % dracut_default)
+                                   "overrides the defaults.")
 
     # pxe to live arguments
     pxelive_group = parser.add_argument_group("pxe to live arguments")

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -148,6 +148,9 @@ def main():
     if os.getuid() != 0:
         errors.append("You need to run this as root")
 
+    if opts.dracut_args and opts.dracut_conf:
+        errors.append("argument --dracut-arg: not allowed with argument --dracut-conf")
+
     if errors:
         list(log.error(e) for e in errors)
         sys.exit(1)

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -111,6 +111,10 @@ def main():
         parser.error("sharedir %s doesn't exist." % opts.sharedir)
     if opts.config and not os.path.exists(opts.config):
         parser.error("config file %s doesn't exist." % opts.config)
+    if opts.dracut_args and opts.dracut_conf:
+        parser.error("argument --dracut-arg: not allowed with argument --dracut-conf")
+    if opts.dracut_conf and not os.path.exists(opts.dracut_conf):
+        parser.error("dracut config file %s doesn't exist." % opts.dracut_conf)
 
     setup_logging(opts)
     log.debug(opts)
@@ -191,6 +195,12 @@ def main():
     with open(lorax.conf.get("lorax", "logdir") + '/lorax.conf', 'w') as f:
         lorax.conf.write(f)
 
+    # Use a dracut config file instead of the default arguments
+    if opts.dracut_conf:
+        user_dracut_args = ["--conf %s" % opts.dracut_conf]
+    else:
+        user_dracut_args = opts.dracut_args
+
     lorax.run(dnfbase, opts.product, opts.version, opts.release,
               opts.variant, opts.bugurl, opts.isfinal,
               workdir=tempdir, outputdir=opts.outputdir, buildarch=opts.buildarch,
@@ -202,7 +212,7 @@ def main():
               add_arch_templates=opts.add_arch_templates,
               add_arch_template_vars=parsed_add_arch_template_vars,
               remove_temp=True, verify=opts.verify,
-              user_dracut_args=opts.dracut_args,
+              user_dracut_args=user_dracut_args,
               squashfs_only=opts.squashfs_only)
 
     # Release the lock on the tempdir

--- a/tests/pylorax/test_recipes.py
+++ b/tests/pylorax/test_recipes.py
@@ -15,10 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import os
-import mock
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 import pylorax.api.recipes as recipes
 from pylorax.api.compose import add_customizations, customize_ks_template

--- a/tests/pylorax/test_workspace.py
+++ b/tests/pylorax/test_workspace.py
@@ -15,10 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import os
-import mock
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 import pylorax.api.recipes as recipes
 from pylorax.api.workspace import workspace_dir, workspace_read, workspace_write, workspace_delete


### PR DESCRIPTION
This adds the ability to use a dracut.conf file instead of passing
--dracut-arg on the cmdline multiple times.