### PR TITLE
tests: Enable Elastic Network Adapter support for AWS

### DIFF
--- a/tests/cli/test_build_and_deploy_aws.sh
+++ b/tests/cli/test_build_and_deploy_aws.sh
@@ -134,7 +134,12 @@ __EOF__
         fi
 
         # create an image from the imported selected snapshot
+        AMI_ARCH="$(uname -m)"
+        if [ "$AMI_ARCH" == "aarch64" ]; then
+            AMI_ARCH="arm64"
+        fi
         AMI_ID=`aws ec2 register-image --name "Composer-Test-$UUID" --virtualization-type hvm --root-device-name /dev/sda1 \
+                    --ena-support --architecture $AMI_ARCH \
                     --block-device-mappings "[{\"DeviceName\": \"/dev/sda1\", \"Ebs\": {\"SnapshotId\": \"$SNAPSHOT_ID\"}}]" | \
                     grep ImageId | cut -f4 -d'"'`
 


### PR DESCRIPTION
- this is required for arm64 but is present in all latest kernels
  so doesn't seem to hurt
- when registering the AMI mark its architecture properly

I've executed the test scripts manually and I can confirm these changes make it possible to test an aarch64 image in AWS.