### PR TITLE
tests: remove --test=2 from compose_sanity

### DIFF
--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -42,15 +42,22 @@ rlJournalStart
         else
             rlFail "Compose UUID is empty!"
         fi
+
+        # check if anaconda is really running
+        until ps -axo comm,pid | grep '^anaconda'; do
+            sleep 10
+            rlLogInfo "Waiting for anaconda to start running..."
+        done;
     rlPhaseEnd
 
     rlPhaseStartTest "cancel compose"
         rlRun -t -c "$CLI compose cancel $UUID"
         rlRun -t -c "$CLI compose info $UUID" 1 "compose is canceled"
+        rlAssertNotExists "/var/run/anaconda.pid"
     rlPhaseEnd
 
     rlPhaseStartTest "compose start again"
-        UUID=`$CLI --test=2 compose start example-http-server tar`
+        UUID=`$CLI compose start example-http-server tar`
         rlAssertEquals "exit code should be zero" $? 0
 
         UUID=`echo $UUID | cut -f 2 -d' '`


### PR DESCRIPTION
This ensures that after canceling a compose, the next one can be finished.

(cherry picked from commit 2ee92b75b0d0bcb79535615d9020453726b97867)

Related: rhbz#1788461

@bcl This is a backport of test created for master branch which was related to https://bugzilla.redhat.com/show_bug.cgi?id=1788501 You did not backport the fix to this branch since it was not happening on rhel8, am I right? I'm asking because if there is a better related rhbz for this commit I would use that in the commit message.