### PR TITLE
Add workaround for AWS deployment test

### DIFF
--- a/test/check-cloud
+++ b/test/check-cloud
@@ -1,12 +1,9 @@
 #!/usr/bin/python3
 
-import unittest
-
 import composertest
 
 
 class TestCloud(composertest.ComposerTestCase):
-    @unittest.skip('Disabled b/c of RequestTimeTooSkewed issue')
     def test_aws(self):
         self.runCliTest("/tests/cli/test_build_and_deploy_aws.sh")
 


### PR DESCRIPTION
This is a workaround for the 'RequestTimeTooSkewed' issue we sometimes get with AWS uploads. It's only meant as a temporary solution until the related BZ has been fixed. I tested it on a machine where I was hitting that issue and it seems to perform as expected.

I also wondered if I should modify the code to fail on RHEL-7.9+ when the issue is hit to make the test hit our attention again after RHEL-7.8 (otherwise the test would pass despite the presence of the time skew, and would only log the issue if present).