### PR TITLE
pylint: whitelist the rpm module

### DIFF
--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -28,6 +28,10 @@ class LoraxLintConfig(PocketLintConfig):
     def ignoreNames(self):
         return { "bots", "rpmbuild" }
 
+    @property
+    def extraArgs(self):
+        return ["--extension-pkg-whitelist=rpm"]
+
 if __name__ == "__main__":
     conf = LoraxLintConfig()
     linter = PocketLinter(conf)


### PR DESCRIPTION
Without this, depending on which version of pylint is used, you may see
errors related to the rpm.RPMTAG_* constants. This makes sure that
pylint allows loading the rpm module.