### PR TITLE
Reflect fonts packages from comps

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -140,31 +140,32 @@ installpkg dmidecode
 
 
 ## fonts & themes
+installpkg aajohan-comfortaa-fonts
+installpkg abattis-cantarell-fonts
 installpkg bitmap-fangsongti-fonts
 installpkg dejavu-sans-fonts dejavu-sans-mono-fonts
-installpkg kacst-farsi-fonts
-installpkg kacst-qurn-fonts
-installpkg lklug-fonts
+installpkg google-noto-sans-cjk-ttc-fonts
+installpkg google-noto-sans-gurmukhi-fonts
+installpkg google-noto-sans-sinhala-vf-fonts
+installpkg jomolhari-fonts
+installpkg khmeros-base-fonts
 installpkg lohit-assamese-fonts
 installpkg lohit-bengali-fonts
 installpkg lohit-devanagari-fonts
-installpkg lohit-gu*-fonts
+installpkg lohit-gujarati-fonts
 installpkg lohit-kannada-fonts
+installpkg lohit-marathi-fonts
 installpkg lohit-odia-fonts
 installpkg lohit-tamil-fonts
 installpkg lohit-telugu-fonts
 installpkg madan-fonts
+installpkg paktype-naskh-basic-fonts
+installpkg sil-abyssinica-fonts
+installpkg sil-padauk-fonts
+installpkg sil-scheherazade-fonts
 installpkg smc-meera-fonts
 installpkg thai-scalable-waree-fonts
-installpkg sil-abyssinica-fonts
 installpkg xorg-x11-fonts-misc
-installpkg aajohan-comfortaa-fonts
-installpkg abattis-cantarell-fonts
-installpkg sil-scheherazade-fonts
-installpkg jomolhari-fonts
-installpkg khmeros-base-fonts
-installpkg sil-padauk-fonts
-installpkg google-noto-sans-cjk-ttc-fonts
 
 ## debugging/bug reporting tools
 installpkg gdb-gdbserver


### PR DESCRIPTION
Add lohit-marathi-fonts for Marathi.

Replace kacst-*-fonts with paktype-naskh-basic-fonts for Urdu,
for Arabic, we use dejavu-sans-fonts.

Replace lklug-fonts with google-noto-sans-sinhala-vf-fonts for Sinhala.

Replace lohit-gurmukhi-fonts with google-noto-sans-gurmukhi-fonts for Gurmukhi.