### PR TITLE
lorax: Add eject back into the boot.iso

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -19,7 +19,7 @@ removefrom ${product.name}-logos /usr/share/plymouth/*
 ## We also need dracut-shutdown.service and dracut-initramfs-restore to reboot
 removefrom dracut --allbut /usr/lib/dracut/modules.d/30convertfs/convertfs.sh \
                   /usr/lib/dracut/modules.d/99base/dracut-lib.sh \
-                  /usr/lib/systemd/* /usr/lib/dracut/modules.d/98systemd/*.service \
+                  /usr/lib/systemd/* /usr/lib/dracut/modules.d/98dracut-systemd/*.service \
                   /usr/lib/dracut/dracut-initramfs-restore
 ## we don't run SELinux (not in enforcing, anyway)
 removepkg checkpolicy selinux-policy libselinux-utils

--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -311,7 +311,7 @@ removefrom sysvinit-tools /usr/bin/*
 removefrom tar /usr/share/locale/*
 removefrom usbutils /usr/bin/*
 removefrom util-linux --allbut \
-    /usr/bin/{dmesg,getopt,kill,login,lsblk,more,mount,umount,mountpoint,findmnt} \
+    /usr/bin/{dmesg,eject,getopt,kill,login,lsblk,more,mount,umount,mountpoint,findmnt} \
     /etc/mtab /etc/pam.d/login /etc/pam.d/remote \
     /usr/sbin/{agetty,blkid,blockdev,clock,fdisk,fsck,fstrim,hwclock,losetup} \
     /usr/sbin/{mkswap,swaplabel,nologin,sfdisk,swapoff,swapon,wipefs,partx,fsfreeze} \

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -174,7 +174,7 @@ installpkg libreport-plugin-bugzilla libreport-plugin-reportuploader
 installpkg fpaste
 
 ## extra tools not required by anaconda
-installpkg vim-minimal strace lsof dump xz less eject
+installpkg vim-minimal strace lsof dump xz less
 installpkg wget rsync bind-utils ftp mtr vconfig
 installpkg icfg spice-vdagent
 installpkg gdisk hexedit sg3_utils


### PR DESCRIPTION
The eject utility moved into util-linux and the package was dropped, but
since the runtime-cleanup template is using `removefrom util-linux
--allbut` it was never added to the boot.iso after the move.

This removes the package request for eject and adds it to the list of
binaries to keep from util-linux.

Related: rhbz#1805405