### PR TITLE
[WIP, don't merge] Fix tests which break on secondary arches

### DIFF
--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -26,7 +26,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose start"
-        UUID=`$CLI compose start example-http-server ami`
+        UUID=`$CLI compose start example-http-server ext4-filesystem`
         rlAssertEquals "exit code should be zero" $? 0
         UUID=`echo $UUID | cut -f 2 -d' '`
 


### PR DESCRIPTION
cc @jrusz

opening here so I anyone wanting to test secondary arch support while lorax-composer is still the default backend can do so.

@bcl no need to merge b/c this test suite will be soon obsolete.