### PR TITLE
[tests] Enable handling of rel-eng images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,20 @@ vm-local-repos: vm
 		--run-command "systemctl enable lorax-composer" \
 		$(TEST_OS)
 
+vm-releng:
+	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
+	bots/image-customize -v \
+		--resize 20G \
+		--upload $(CURDIR)/test/vm.install:/var/tmp/vm.install \
+		--upload $(realpath tests):/ \
+		--run-command "chmod +x /var/tmp/vm.install" \
+		--run-command "cd /var/tmp; BUILD_SRPM=0 /var/tmp/vm.install" \
+		$(TEST_OS)
+	[ -f ~/.config/lorax-test-env ] && bots/image-customize \
+		--upload ~/.config/lorax-test-env:/var/tmp/lorax-test-env \
+		$(TEST_OS) || echo
+
+
 vm-reset:
 	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
 

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,6 @@ endif
 export TEST_OS
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 
-ifeq ($(REPOS_DIR),)
-REPOS_DIR = /etc/yum.repos.d
-endif
-
 default: all
 
 src/composer/version.py:
@@ -133,21 +129,6 @@ $(VM_IMAGE): srpm bots
 # convenience target for the above
 vm: $(VM_IMAGE)
 	echo $(VM_IMAGE)
-
-# grab all repositories from the host system, overwriting what's inside the VM
-# and update the image. Mostly used when testing downstream snapshots to make
-# sure VM_IMAGE is as close as possible to the host!
-vm-local-repos: vm
-	bots/image-customize -v \
-		--run-command "rm -rf /etc/yum.repos.d" \
-		$(TEST_OS)
-	bots/image-customize -v \
-		--upload $(REPOS_DIR):/etc/yum.repos.d \
-		--run-command "yum -y remove composer-cli lorax-composer" \
-		--run-command "yum -y update" \
-		--run-command "yum -y install composer-cli lorax-composer" \
-		--run-command "systemctl enable lorax-composer" \
-		$(TEST_OS)
 
 vm-releng:
 	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2

--- a/test/README.md
+++ b/test/README.md
@@ -49,6 +49,24 @@ You may also define `REPOS_DIR` variable to point to another directory
 containing yum .repo files. By default the value is `/etc/yum.repos.d`!
 This is mostly useful when running tests by hand on a downstream snapshot!
 
+If you need to run the tests on a particular rel-eng RHEL compose, you can
+create the image by using [image-create-rhel-compose](https://github.com/cockpit-project/bots/blob/master/image-create-rhel-compose)
+script from bots repo. By default it uses the `-latest` extras rel-eng repo,
+however it’s advisable to build the image using explicitly specified repos
+using `COMPOSE` and `EXTRAS_COMPOSE` environment variables, for example:
+
+    $ export COMPOSE=”RHEL-7.x-yyyymmdd.b”
+    $ export EXTRAS_COMPOSE=”EXTRAS-7.x-RHEL-7-yyyymmdd.b”
+    $ bots/image-create-rhel-compose
+
+This will provide you with a RHEL-7.x-yyyymmdd.b image with preconfigured
+rel-eng repos. To perform the composer-specific setup as you would do by `make vm`
+for a stock bots image, use
+
+    $ export TEST_OS=”rhel-7-x-yyyymmdd-b”
+    $ make vm-releng
+
+
 ## Running tests
 
 After building a test image, run

--- a/test/README.md
+++ b/test/README.md
@@ -41,14 +41,6 @@ To delete the generated image, run
 Base images are stored in `bots/images`. Set `TEST_DATA` to override this
 directory.
 
-To configure the image with all repositories found on the host system use
-
-    $ make vm-local-repos
-
-You may also define `REPOS_DIR` variable to point to another directory
-containing yum .repo files. By default the value is `/etc/yum.repos.d`!
-This is mostly useful when running tests by hand on a downstream snapshot!
-
 If you need to run the tests on a particular rel-eng RHEL compose, you can
 create the image by using [image-create-rhel-compose](https://github.com/cockpit-project/bots/blob/master/image-create-rhel-compose)
 script from bots repo. By default it uses the `-latest` extras rel-eng repo,

--- a/test/vm.install
+++ b/test/vm.install
@@ -1,6 +1,11 @@
 #!/bin/sh -eux
 
-SRPM="$1"
+# BUILD_SRPM serves as a flag whether we should build and install the composer packages
+BUILD_SRPM=${BUILD_SRPM:-1}
+
+if [ "$BUILD_SRPM" -eq 1 ]; then
+    SRPM="$1"
+fi
 
 # always remove older versions of these RPMs if they exist
 # to ensure newly built packages have been installed
@@ -86,11 +91,17 @@ rootlv=$(findmnt --noheadings -oSOURCE /)
 lvresize $rootlv -l+100%FREE -r
 
 rm -rf build-results
-su builder -c "/usr/bin/mock --no-clean --resultdir build-results --rebuild $SRPM"
 
-packages=$(find build-results -name '*.rpm' -not -name '*.src.rpm')
-yum install -y $packages
 
+if [ "$BUILD_SRPM" -eq 1 ]; then
+    SRPM="$1"
+    su builder -c "/usr/bin/mock --no-clean --resultdir build-results --rebuild $SRPM"
+
+    packages=$(find build-results -name '*.rpm' -not -name '*.src.rpm')
+    yum install -y $packages
+else
+    yum -y install lorax-composer composer-cli
+fi
 systemctl enable lorax-composer.socket
 
 if [ -f /usr/bin/docker ]; then


### PR DESCRIPTION
In order to enable testing with rel-eng images, we need some slight changes in `Makefile` and `vm.install`. This could actually be done by using the already existing `vm-local-repos` target, however this involves some unnecessary steps (building and installing lorax-composer RPMs that are in turn removed and reinstalled by RPMs from additionally defined custom repos - which itself is another unnecessary step). This approach however can't be used on a host system other than RHEL-7, as one of the steps involved is building a RHEL-7 lorax-composer SRPM.

Thus I think the best way is to define a new Makefile target and introduce a `BUILD_SRPM` environment variable in `vm.install` script that bypasses RPM building and installation in case of a rel-eng image.