### PR TITLE
lorax-composer: Add 'weldr' to indicate it supports the weldr API

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -160,6 +160,9 @@ Requires: python3-boto3
 %{?systemd_requires}
 BuildRequires: systemd
 
+# Implements the weldr API
+Provides: weldr
+
 %description composer
 lorax-composer provides a REST API for building images using lorax.
 


### PR DESCRIPTION
osbuild-composer also supports the weldr API, and front-ends like
cockpit-composer can use either one of them, so to make it easier to
switch between them we are adding 'weldr' to each of the API servers.