### PR TITLE
Add dig and comm to the boot.iso

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -133,14 +133,14 @@ removefrom audit /sbin/ausearch /sbin/autrace /usr/bin/*
 removefrom audit-libs /etc/* /${libdir}/libauparse*
 removefrom authconfig /usr/sbin/* /usr/share/*
 removefrom bash /etc/* /usr/bin/bashbug* /usr/share/*
-removefrom bind-utils /usr/bin/dig /usr/bin/host /usr/bin/nsupdate
+removefrom bind-utils /usr/bin/host /usr/bin/nsupdate
 removefrom bitmap-fangsongti-fonts /usr/share/fonts/*
 removefrom ca-certificates /etc/pki/java/*
 removefrom ca-certificates /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/*
 removefrom cairo /usr/${libdir}/libcairo-script* /usr/bin/cairo-sphinx
 removefrom coreutils /etc/* /usr/bin/link /usr/bin/nice /usr/bin/stty /usr/bin/su /usr/bin/unlink
 removefrom coreutils /usr/sbin/runuser /usr/bin/[ /usr/bin/base64 /usr/bin/chcon
-removefrom coreutils /usr/bin/cksum /usr/bin/comm /usr/bin/csplit
+removefrom coreutils /usr/bin/cksum /usr/bin/csplit
 removefrom coreutils /usr/bin/dir /usr/bin/dircolors
 removefrom coreutils /usr/bin/expand /usr/bin/factor
 removefrom coreutils /usr/bin/fold /usr/bin/groups /usr/bin/hostid


### PR DESCRIPTION
The /usr/libexec/chrony-helper script requires them.

Resolves: rhbz#1812127