### PR TITLE
lorax: Write package lists in run_transaction

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -133,14 +133,14 @@ removefrom audit /sbin/ausearch /sbin/autrace /usr/bin/*
 removefrom audit-libs /etc/* /${libdir}/libauparse*
 removefrom authconfig /usr/sbin/* /usr/share/*
 removefrom bash /etc/* /usr/bin/bashbug* /usr/share/*
-removefrom bind-utils /usr/bin/dig /usr/bin/host /usr/bin/nsupdate
+removefrom bind-utils /usr/bin/host /usr/bin/nsupdate
 removefrom bitmap-fangsongti-fonts /usr/share/fonts/*
 removefrom ca-certificates /etc/pki/java/*
 removefrom ca-certificates /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/*
 removefrom cairo /usr/${libdir}/libcairo-script* /usr/bin/cairo-sphinx
 removefrom coreutils /etc/* /usr/bin/link /usr/bin/nice /usr/bin/stty /usr/bin/su /usr/bin/unlink
 removefrom coreutils /usr/sbin/runuser /usr/bin/[ /usr/bin/base64 /usr/bin/chcon
-removefrom coreutils /usr/bin/cksum /usr/bin/comm /usr/bin/csplit
+removefrom coreutils /usr/bin/cksum /usr/bin/csplit
 removefrom coreutils /usr/bin/dir /usr/bin/dircolors
 removefrom coreutils /usr/bin/expand /usr/bin/factor
 removefrom coreutils /usr/bin/fold /usr/bin/groups /usr/bin/hostid

--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -119,12 +119,6 @@ remove etc/lvm/cache
 remove etc/lvm/lvm.conf
 append etc/lvm/lvm.conf "global {\n\tuse_lvmetad = 1\n}\n"
 
-## Record the package versions used to create the image
-## rpm initializes nss, which requires /dev/urandom to be present, hence the mknod
-runcmd chroot ${root} /usr/bin/mknod -m 666 /dev/random c 1 8
-runcmd chroot ${root} /usr/bin/mknod -m 666 /dev/urandom c 1 9
-runcmd chroot ${root} /usr/bin/rpm -qa --pipe "sort | tee /root/lorax-packages.log"
-
 ## TODO: we could run prelink here if we wanted?
 
 ## fix fonconfig cache containing timestamps


### PR DESCRIPTION
A change in glibc now requires /proc be mounted in order to run mknod
which is needed in order to run rpm from runtime-postinstall.

This drops that code from the template and moves writing the package
list into run_transaction, which already has all of the needed
information to generate the list.

Resolves: rhbz#1812895