### PR TITLE
tests: pip install future

### DIFF
--- a/tests/cli/test_build_and_deploy_openstack.sh
+++ b/tests/cli/test_build_and_deploy_openstack.sh
@@ -49,7 +49,7 @@ rlJournalStart
         source $VENV/bin/activate
 
         rlRun -t -c "pip install --upgrade pip setuptools"
-        rlRun -t -c "pip install ansible openstacksdk"
+        rlRun -t -c "pip install ansible openstacksdk future"
     rlPhaseEnd
 
     rlPhaseStartTest "compose start"


### PR DESCRIPTION
Resolves:
https://github.com/ansible/ansible/issues/68616
https://github.com/cockpit-project/bots/pull/636

Another posibility would be to `yum install python2-future` from EPEL in vm.install instead.

@bcl - do I need to create a RHBZ for this ? If yes I could probably reuse some of my other bugzillas.