### PR TITLE
Change --make-pxe-live --no-virt to use a fsimage

### DIFF
--- a/src/pylorax/installer.py
+++ b/src/pylorax/installer.py
@@ -254,7 +254,7 @@ def novirt_install(opts, disk_img, disk_size, repo_url, cancel_func=None):
     if opts.armplatform:
         args += ["--armplatform", opts.armplatform]
 
-    if opts.make_iso or opts.make_fsimage:
+    if opts.make_iso or opts.make_fsimage or opts.make_pxe_live:
         # Make a blank fs image
         args += ["--dirinstall"]
 


### PR DESCRIPTION
Instead of a partitioned disk image. This will allow a single pass
of lmc to be used to create an ostree live PXE image.

Resolves: rhbz#1802591