### PR TITLE
Add --no-system-repos to lorax-composer

### DIFF
--- a/src/sbin/lorax-composer
+++ b/src/sbin/lorax-composer
@@ -79,6 +79,8 @@ def get_parser():
                         help="Top level temporary directory")
     parser.add_argument("--proxy", default=None, metavar="PROXY",
                         help="Set proxy for DNF, overrides configuration file setting.")
+    parser.add_argument("--no-system-repos", action="store_true", default=False,
+                        help="Do not copy over system repos from /etc/yum.repos.d/ at startup")
     parser.add_argument("BLUEPRINTS", metavar="BLUEPRINTS",
                         help="Path to the blueprints")
 
@@ -242,6 +244,10 @@ if __name__ == '__main__':
     # Override the config file's DNF proxy setting
     if opts.proxy:
         server.config["COMPOSER_CFG"].set("yum", "proxy", opts.proxy)
+
+    # Override using system repos
+    if opts.no_system_repos:
+        server.config["COMPOSER_CFG"].set("repos", "use_system_repos", "0")
 
     # Make sure the queue paths are setup correctly, exit on errors
     errors = make_queue_dirs(server.config["COMPOSER_CFG"], gid)


### PR DESCRIPTION
Running lorax-composer --no-system-repos will prevent it from copying
the yum repositories from /etc/yum.repos.d/ into the lorax-composer repo
directory. It will *only* use repositories setup using the sources api
or written to /var/lib/lorax/composer/repos.d/

If lorax-composer has previously been run without this switch the system
repos will need to be removed from the composer/repos.d/ directory. It
would also be a good idea to remove the cached metadata in
/var/tmp/composer/

Resolves: rhbz#1785388