### PR TITLE
[tests] don't add only rel-eng optional repo for live-iso

### DIFF
--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -16,17 +16,23 @@ CLI="${CLI:-./src/bin/composer-cli}"
 
 rlJournalStart
     rlPhaseStartSetup
-        OPTIONAL_REPO="/etc/yum.repos.d/rhel7-rel-eng-optional.repo"
+        if grep -qE "https?://.*/nightly/" /etc/yum.repos.d/*; then
+            RELEASE_TYPE="nightly"
+        else
+            RELEASE_TYPE="rel-eng"
+        fi
+        
+        OPTIONAL_REPO="/etc/yum.repos.d/rhel7-${RELEASE_TYPE}-optional.repo"
 
         if [ ! -f "$OPTIONAL_REPO" ]; then
             composer_stop
             cat > $OPTIONAL_REPO << __EOF__
-[rhel7-rel-eng-optional]
+[rhel7-${RELEASE_TYPE}-optional]
 gpgcheck=0
 enabled=1
 skip_if_unavailable=0
-name=rhel7-rel-eng-optional
-baseurl=http://download-node-02.eng.bos.redhat.com/rhel-7/rel-eng/latest-RHEL-7/compose/Server-optional/\$basearch/os/
+name=rhel7-${RELEASE_TYPE}-optional
+baseurl=http://download-node-02.eng.bos.redhat.com/rhel-7/$RELEASE_TYPE/latest-RHEL-7/compose/Server-optional/\$basearch/os/
 __EOF__
             composer_start
         fi


### PR DESCRIPTION
This PR fixes issues with dependency discrepancies caused by a combination of nightly base and rel-eng optional repos, which causes live-iso tests to fail (see #990).

This PR modifies the live iso test to add an optional repo (rel-eng or nightly) depending on the already present base repos. Adding a nightly optional repo shouldn't break anything if the nightly base repo is present (which it is by default in the images used by bots framework, and this fix should be also fine when used with a rel-eng image (this is related to #976).