### PR TITLE
Use only BOS repo for Beaker repos in vm.install

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -20,7 +20,7 @@ fi
 
 if ! rpm -q beakerlib; then
     if [ $(. /etc/os-release && echo $ID) = "rhel" ]; then
-        (cd /etc/yum.repos.d; curl -O -L http://download.devel.redhat.com/beakerrepos/beaker-client-RedHatEnterpriseLinux.repo)
+        (cd /etc/yum.repos.d; curl -O -L http://download.eng.bos.redhat.com/beakerrepos/beaker-client-RedHatEnterpriseLinux.repo)
         # disable sslverify b/c yum will fail to sync metadata otherwise
         sed -i "s/\(gpgcheck=0\)/\1\nsslverify=0/" /etc/yum.repos.d/beaker-client-RedHatEnterpriseLinux.repo
         # do not remove the repo file. We now have tests which use beakerlib

--- a/tests/cli/test_compose_live-iso.sh
+++ b/tests/cli/test_compose_live-iso.sh
@@ -16,17 +16,23 @@ CLI="${CLI:-./src/bin/composer-cli}"
 
 rlJournalStart
     rlPhaseStartSetup
-        OPTIONAL_REPO="/etc/yum.repos.d/rhel7-rel-eng-optional.repo"
+        if grep -q "http://.*/nightly/" /etc/yum.repos.d/*; then
+            RELEASE_TYPE="nightly"
+        else
+            RELEASE_TYPE="rel-eng"
+        fi
+        
+        OPTIONAL_REPO="/etc/yum.repos.d/rhel7-${RELEASE_TYPE}-optional.repo"
 
         if [ ! -f "$OPTIONAL_REPO" ]; then
             composer_stop
             cat > $OPTIONAL_REPO << __EOF__
-[rhel7-rel-eng-optional]
+[rhel7-${RELEASE_TYPE}-optional]
 gpgcheck=0
 enabled=1
 skip_if_unavailable=0
-name=rhel7-rel-eng-optional
-baseurl=http://download-node-02.eng.bos.redhat.com/rhel-7/rel-eng/latest-RHEL-7/compose/Server-optional/\$basearch/os/
+name=rhel7-${RELEASE_TYPE}-optional
+baseurl=http://download-node-02.eng.bos.redhat.com/rhel-7/$RELEASE_TYPE/latest-RHEL-7/compose/Server-optional/\$basearch/os/
 __EOF__
             composer_start
         fi


### PR DESCRIPTION
The redirection from download.devel for Beaker repos doesn't work properly if run from a BRQ location. We can just directly use BOS repos in this case, as it shouldn't break anything and the amount of data transferred from this repo shouldn't cause any significant delay even from a BRQ site.

@atodorov if you think this is OK, I'll create a BZ to reference.