### PR TITLE
rsyslog: Disable journal ratelimits during install

### DIFF
--- a/share/templates.d/99-generic/config_files/common/rsyslog.conf
+++ b/share/templates.d/99-generic/config_files/common/rsyslog.conf
@@ -5,12 +5,15 @@
 
 #### MODULES ####
 
-# The imjournal module bellow is now used as a message source instead of imuxsock.
+# The imjournal module below is now used as a message source instead of imuxsock.
 $ModLoad imuxsock # provides support for local system logging (e.g. via logger command)
 $SystemLogRateLimitInterval 0 # disables message dropping, we need all of them
 $ModLoad imjournal # provides access to the systemd journal
 #$ModLoad imklog # reads kernel messages (the same are read from journald)
 #$ModLoad immark  # provides --MARK-- message capability
+# Disable rate limiting to the journal, we need all the messages for debugging
+$imjournalRatelimitInterval 0
+$imjournalRatelimitBurst 0
 
 # Provides UDP syslog reception
 #$ModLoad imudp


### PR DESCRIPTION
Every log entry is sacred

Resolves: rhbz#1752754