### PR TITLE
test: Work around invalid fedora baseurls

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -26,6 +26,10 @@ sed -i "s/metalink.*//" /etc/yum.repos.d/*.repo
 sed -i "s/#\(baseurl=.*\)/\1/" /etc/yum.repos.d/*.repo
 sed -i "s/download.fedoraproject/dl.fedoraproject/" /etc/yum.repos.d/*.repo
 
+# HACK: Fedora ships baseurl with `example.com` as domain
+# Example: `#baseurl=http://download.example/pub/fedora/linux/updates/$releasever/Everything/$basearch/`
+sed -i "s/download.example/dl.fedoraproject.org/" /etc/yum.repos.d/*.repo
+
 # Grow root partition to make room for images. This only works on Fedora right now.
 echo ", +" | sfdisk -N 2 -f /dev/vda
 partprobe


### PR DESCRIPTION
In the newest Fedora 31 refresh (and in Fedora 32) `baseurl` in repos
contains `download.example`. That is of course not a valid domain.

Fixes https://github.com/cockpit-project/bots/pull/771