### PR TITLE
lmc-no-virt: Add requirement on anaconda-install-env-deps

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -114,6 +114,7 @@ Summary:  livemedia-creator no-virt dependencies
 Requires: lorax = %{version}-%{release}
 Requires: anaconda-core
 Requires: anaconda-tui
+Requires: anaconda-install-env-deps
 Requires: system-logos
 
 %description lmc-novirt


### PR DESCRIPTION
This makes sure that anaconda has all the expected modules available,
eg. libblockdev-plugins-all