### PR TITLE
Master osbuild composer backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ $(VM_IMAGE): srpm bots
 		--upload $(CURDIR)/test/vm.install:/var/tmp/vm.install \
 		--upload $(realpath tests):/ \
 		--run-command "chmod +x /var/tmp/vm.install" \
-		--run-command "cd /var/tmp; /var/tmp/vm.install $$srpm" \
+		--run-command "cd /var/tmp; BACKEND=$(BACKEND) /var/tmp/vm.install $$srpm" \
 		$(TEST_OS)
 	[ -f ~/.config/lorax-test-env ] && bots/image-customize \
 		--upload ~/.config/lorax-test-env:/var/tmp/lorax-test-env \

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ mandir ?= $(PREFIX)/share/man
 DOCKER ?= podman
 DOCS_VERSION ?= next
 RUN_TESTS ?= ci
+BACKEND ?= lorax-composer
 
 PKGNAME = lorax
 VERSION = $(shell awk '/Version:/ { print $$2 }' $(PKGNAME).spec)
@@ -173,10 +174,10 @@ vm-local-repos: vm
 		$(TEST_OS)
 	bots/image-customize -v \
 		--upload $(REPOS_DIR):/etc/yum.repos.d \
-		--run-command "yum -y remove composer-cli lorax-composer" \
+		--run-command "yum -y remove composer-cli $(BACKEND)" \
 		--run-command "yum -y update" \
-		--run-command "yum -y install composer-cli lorax-composer" \
-		--run-command "systemctl enable lorax-composer" \
+		--run-command "yum -y install composer-cli $(BACKEND)" \
+		--run-command "systemctl enable $(BACKEND).socket" \
 		$(TEST_OS)
 
 vm-reset:

--- a/test/composertest.py
+++ b/test/composertest.py
@@ -127,7 +127,7 @@ class ComposerTestCase(VirtMachineTestCase):
         # Upload the contents of the ./tests/ directory to the machine (it must have beakerlib already installed)
         self.machine.upload(["../tests"], "/")
 
-        print("Waiting for lorax-composer to become ready...")
+        print("Waiting for backend to become ready...")
         curl_command = ["curl", "--max-time", "360",
                                 "--silent",
                                 "--unix-socket", "/run/weldr/api.socket",
@@ -149,7 +149,7 @@ class ComposerTestCase(VirtMachineTestCase):
         return local_dir
 
     def runCliTest(self, script):
-        extra_env = []
+        extra_env = ["BACKEND=%s" % os.getenv('BACKEND', 'lorax-composer')]
         if self.sit:
             extra_env.append("COMPOSER_TEST_FAIL_FAST=1")
 

--- a/test/run
+++ b/test/run
@@ -4,12 +4,16 @@
 
 export BACKEND="${BACKEND:-lorax-composer}"
 
-make vm
-
-if [ -n "$TEST_SCENARIO" ]; then
-  if [ "$TEST_SCENARIO" == "lorax" ]; then
-    test/check-lorax TestLorax
-  fi
+if [ "$BACKEND" == "osbuild-composer" ] || [ "$TEST_SCENARIO" == "osbuild-composer" ]; then
+    rm -rf ./test/images/*
+    export BACKEND="osbuild-composer"
+    make BACKEND=osbuild-composer vm
 else
-  test/check-cli TestImages
+    make vm
+fi
+
+if [ "$TEST_SCENARIO" == "lorax" ]; then
+    test/check-lorax TestLorax
+else
+    test/check-cli TestImages
 fi

--- a/test/run
+++ b/test/run
@@ -2,6 +2,8 @@
 # This is the expected entry point for Cockpit CI; will be called without
 # arguments but with an appropriate $TEST_OS, and optionally $TEST_SCENARIO
 
+export BACKEND="${BACKEND:-lorax-composer}"
+
 make vm
 
 if [ -n "$TEST_SCENARIO" ]; then

--- a/test/vm.install
+++ b/test/vm.install
@@ -1,10 +1,11 @@
 #!/bin/sh -eux
 
+BACKEND="${BACKEND:-lorax-composer}"
 SRPM="$1"
 
 # always remove older versions of these RPMs if they exist
 # to ensure newly built packages have been installed
-yum -y remove lorax lorax-composer composer-cli
+yum -y remove lorax $BACKEND composer-cli
 
 if ! rpm -q beakerlib; then
     if [ $(. /etc/os-release && echo $ID) = "rhel" ]; then
@@ -41,9 +42,12 @@ rm -rf build-results
 su builder -c "/usr/bin/mock --verbose --no-clean --resultdir build-results --rebuild $SRPM"
 
 packages=$(find build-results -name '*.rpm' -not -name '*.src.rpm')
-yum install -y $packages
+if [ "$BACKEND" == "osbuild-composer" ]; then
+    packages=$(find build-results -name '*.rpm' -not -name '*.src.rpm' -not -name '*lorax-composer*')
+fi
+yum install -y $packages $BACKEND
 
-systemctl enable lorax-composer.socket
+systemctl enable $BACKEND.socket
 
 if [ -f /usr/bin/docker ]; then
     yum remove -y $(rpm -qf /usr/bin/docker)

--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -2,6 +2,9 @@
 
 . /usr/share/beakerlib/beakerlib.sh
 
+BACKEND="${BACKEND:-lorax-composer}"
+export BACKEND
+
 # Monkey-patch beakerlib to exit on first failure if COMPOSER_TEST_FAIL_FAST is
 # set. https://github.com/beakerlib/beakerlib/issues/42
 COMPOSER_TEST_FAIL_FAST=${COMPOSER_TEST_FAIL_FAST:-0}
@@ -97,8 +100,8 @@ composer_start() {
     else
         # socket stop/start seems to be necessary for a proper service restart
         # after a previous direct manual run for it to work properly
-        systemctl start lorax-composer.socket
-        systemctl start lorax-composer
+        systemctl start $BACKEND.socket
+        systemctl start $BACKEND
     fi
     rc=$?
 
@@ -106,7 +109,7 @@ composer_start() {
     if [ "$rc" -eq 0 ]; then
         wait_for_composer
     else
-        rlLogFail "Unable to start lorax-composer (exit code $rc)"
+        rlLogFail "Unable to start $BACKEND (exit code $rc)"
     fi
     return $rc
 }
@@ -115,15 +118,15 @@ composer_stop() {
     MANUAL=${MANUAL:-0}
     # socket stop/start seems to be necessary for a proper service restart
     # after a previous direct manual run for it to work properly
-    if systemctl list-units | grep -q lorax-composer.socket; then
-        systemctl stop lorax-composer.socket
+    if systemctl list-units | grep -q $BACKEND.socket; then
+        systemctl stop $BACKEND.socket
     fi
 
     if [[ -z "$CLI" || "$CLI" == "./src/bin/composer-cli" || "$MANUAL" == "1" ]]; then
         pkill -9 lorax-composer
         rm -f /run/weldr/api.socket
     else
-        systemctl stop lorax-composer
+        systemctl stop $BACKEND
     fi
 }
 

--- a/tests/cli/lib/lib.sh
+++ b/tests/cli/lib/lib.sh
@@ -93,9 +93,9 @@ composer_start() {
     local rc
     local params="$@"
 
-    if [[ -z "$CLI" || "$CLI" == "./src/bin/composer-cli" ]]; then
+    if [ "$BACKEND" == "lorax-composer" ] && [[ -z "$CLI" || "$CLI" == "./src/bin/composer-cli" ]]; then
         ./src/sbin/lorax-composer $params --sharedir $SHARE_DIR $BLUEPRINTS_DIR &
-    elif [ -n "$params" ]; then
+    elif [ "$BACKEND" == "lorax-composer" ] && [ -n "$params" ]; then
         /usr/sbin/lorax-composer $params /var/lib/lorax/composer/blueprints &
     else
         # socket stop/start seems to be necessary for a proper service restart

--- a/tests/cli/lib/test-http-server.toml
+++ b/tests/cli/lib/test-http-server.toml
@@ -1,0 +1,18 @@
+name = "test-http-server"
+description = "Http server with PHP and MySQL support used in tests."
+version = "0.0.1"
+
+[[modules]]
+name = "httpd"
+version = "2.4.*"
+
+[[modules]]
+name = "php"
+version = "7.*"
+
+[[packages]]
+name = "openssh-server"
+version = "*"
+
+[customizations.kernel]
+append = "custom_cmdline_arg console=ttyS0,115200n8"

--- a/tests/cli/lib/toml-compare
+++ b/tests/cli/lib/toml-compare
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import sys
+import toml
+
+if len(sys.argv) != 3:
+    print("USAGE: ", __file__, "<blueprint-one.toml> <blueprint-two.toml>")
+    sys.exit(1)
+
+blueprint_one = toml.loads(open(sys.argv[1]).read())
+blueprint_two = toml.loads(open(sys.argv[2]).read())
+
+assert blueprint_one == blueprint_two

--- a/tests/cli/test_blueprints_sanity.sh
+++ b/tests/cli/test_blueprints_sanity.sh
@@ -17,13 +17,15 @@ rlJournalStart
                     "`$CLI blueprints list | grep $bp`" "$bp"
             done
         fi
+
+        rlRun -t -c "$CLI blueprints push $(dirname $0)/lib/test-http-server.toml"
     rlPhaseEnd
 
     rlPhaseStartTest "blueprints save"
-        rlRun -t -c "$CLI blueprints save example-http-server"
-        rlAssertExists "example-http-server.toml"
-        rlAssertGrep "example-http-server" "example-http-server.toml"
-        rlAssertGrep "httpd" "example-http-server.toml"
+        rlRun -t -c "$CLI blueprints save test-http-server"
+        rlAssertExists "test-http-server.toml"
+        rlAssertGrep "test-http-server" "test-http-server.toml"
+        rlAssertGrep "httpd" "test-http-server.toml"
 
         # non-existing blueprint
         rlRun -t -c "$CLI blueprints save non-existing-bp" 1

--- a/tests/cli/test_blueprints_sanity.sh
+++ b/tests/cli/test_blueprints_sanity.sh
@@ -11,10 +11,12 @@ CLI="${CLI:-./src/bin/composer-cli}"
 
 rlJournalStart
     rlPhaseStartTest "blueprints list"
-        for bp in example-http-server example-development example-atlas; do
-            rlAssertEquals "blueprint list finds $bp" \
-                "`$CLI blueprints list | grep $bp`" "$bp"
-        done
+        if [ "$BACKEND" != "osbuild-composer" ]; then
+            for bp in example-http-server example-development example-atlas; do
+                rlAssertEquals "blueprint list finds $bp" \
+                    "`$CLI blueprints list | grep $bp`" "$bp"
+            done
+        fi
     rlPhaseEnd
 
     rlPhaseStartTest "blueprints save"

--- a/tests/cli/test_blueprints_sanity.sh
+++ b/tests/cli/test_blueprints_sanity.sh
@@ -51,7 +51,8 @@ __EOF__
     rlPhaseEnd
 
     rlPhaseStartTest "blueprints show"
-        rlAssertEquals "show displays blueprint in TOML" "`$CLI blueprints show $BLUEPRINT_NAME`" "`cat $BLUEPRINT_NAME.toml`"
+        $CLI blueprints show $BLUEPRINT_NAME > shown-$BLUEPRINT_NAME.toml
+        rlRun -t -c "$(dirname $0)/lib/toml-compare $BLUEPRINT_NAME.toml shown-$BLUEPRINT_NAME.toml"
     rlPhaseEnd
 
     rlPhaseStartTest "SemVer .patch version is incremented automatically"

--- a/tests/cli/test_blueprints_sanity.sh
+++ b/tests/cli/test_blueprints_sanity.sh
@@ -47,7 +47,6 @@ __EOF__
 
         rlRun -t -c "$CLI blueprints push beakerlib.toml"
         rlAssertEquals "pushed bp is found via list" "`$CLI blueprints list | grep beakerlib`" "beakerlib"
-        rlAssertExists "$BLUEPRINTS_DIR/git/workspace/master/beakerlib.toml"
     rlPhaseEnd
 
     rlPhaseStartTest "blueprints show"
@@ -76,7 +75,6 @@ __EOF__
     rlPhaseStartTest "blueprints delete"
         rlRun -t -c "$CLI blueprints delete beakerlib"
         rlAssertEquals "bp not found after delete" "`$CLI blueprints list | grep beakerlib`" ""
-        rlAssertNotExists "$BLUEPRINTS_DIR/git/workspace/master/beakerlib.toml"
     rlPhaseEnd
 
     rlPhaseStartTest "start a compose with deleted blueprint"

--- a/tests/cli/test_blueprints_sanity.sh
+++ b/tests/cli/test_blueprints_sanity.sh
@@ -34,47 +34,48 @@ rlJournalStart
 
     rlPhaseStartTest "blueprints push"
 
-        cat > beakerlib.toml << __EOF__
-name = "beakerlib"
-description = "Start building tests with beakerlib."
+        BLUEPRINT_NAME="openssh-server"
+        cat > $BLUEPRINT_NAME.toml << __EOF__
+name = "$BLUEPRINT_NAME"
+description = "Simple blueprint including only openssh"
 version = "0.0.1"
 modules = []
 groups = []
 [[packages]]
-name = "beakerlib"
+name = "openssh-server"
 version = "*"
 __EOF__
 
-        rlRun -t -c "$CLI blueprints push beakerlib.toml"
-        rlAssertEquals "pushed bp is found via list" "`$CLI blueprints list | grep beakerlib`" "beakerlib"
+        rlRun -t -c "$CLI blueprints push $BLUEPRINT_NAME.toml"
+        rlAssertEquals "pushed bp is found via list" "`$CLI blueprints list | grep $BLUEPRINT_NAME`" "$BLUEPRINT_NAME"
     rlPhaseEnd
 
     rlPhaseStartTest "blueprints show"
-        rlAssertEquals "show displays blueprint in TOML" "`$CLI blueprints show beakerlib`" "`cat beakerlib.toml`"
+        rlAssertEquals "show displays blueprint in TOML" "`$CLI blueprints show $BLUEPRINT_NAME`" "`cat $BLUEPRINT_NAME.toml`"
     rlPhaseEnd
 
     rlPhaseStartTest "SemVer .patch version is incremented automatically"
         # version is still 0.0.1
-        rlAssertEquals "version is 0.0.1" "`$CLI blueprints show beakerlib | grep 0.0.1`" 'version = "0.0.1"'
+        rlAssertEquals "version is 0.0.1" "`$CLI blueprints show $BLUEPRINT_NAME | grep 0.0.1`" 'version = "0.0.1"'
         # add a new package to the existing blueprint
-        cat >> beakerlib.toml << __EOF__
+        cat >> $BLUEPRINT_NAME.toml << __EOF__
 
 [[packages]]
 name = "php"
 version = "*"
 __EOF__
         # push again
-        rlRun -t -c "$CLI blueprints push beakerlib.toml"
+        rlRun -t -c "$CLI blueprints push $BLUEPRINT_NAME.toml"
         # official documentation says:
         # If a new blueprint is uploaded with the same version the server will
         # automatically bump the PATCH level of the version. If the version
         # doesn't match it will be used as is.
-        rlAssertEquals "version is 0.0.2" "`$CLI blueprints show beakerlib | grep 0.0.2`" 'version = "0.0.2"'
+        rlAssertEquals "version is 0.0.2" "`$CLI blueprints show $BLUEPRINT_NAME | grep 0.0.2`" 'version = "0.0.2"'
     rlPhaseEnd
 
     rlPhaseStartTest "blueprints delete"
-        rlRun -t -c "$CLI blueprints delete beakerlib"
-        rlAssertEquals "bp not found after delete" "`$CLI blueprints list | grep beakerlib`" ""
+        rlRun -t -c "$CLI blueprints delete $BLUEPRINT_NAME"
+        rlAssertEquals "bp not found after delete" "`$CLI blueprints list | grep $BLUEPRINT_NAME`" ""
     rlPhaseEnd
 
     rlPhaseStartTest "start a compose with deleted blueprint"
@@ -103,6 +104,10 @@ __EOF__
 
         rlRun -t -c "rm -f to-be-deleted.toml"
         unset compose_id
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun -t -c "rm *.toml"
     rlPhaseEnd
 
 rlJournalEnd

--- a/tests/cli/test_build_and_deploy_aws.sh
+++ b/tests/cli/test_build_and_deploy_aws.sh
@@ -77,7 +77,8 @@ __EOF__
 
     rlPhaseStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
-        UUID=`$CLI compose start example-http-server ami`
+        rlRun -t -c "$CLI blueprints push $(dirname $0)/lib/test-http-server.toml"
+        UUID=`$CLI compose start test-http-server ami`
         rlAssertEquals "exit code should be zero" $? 0
 
         UUID=`echo $UUID | cut -f 2 -d' '`

--- a/tests/cli/test_build_and_deploy_azure.sh
+++ b/tests/cli/test_build_and_deploy_azure.sh
@@ -62,7 +62,8 @@ rlJournalStart
 
     rlPhaseStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
-        UUID=`$CLI compose start example-http-server vhd`
+        rlRun -t -c "$CLI blueprints push $(dirname $0)/lib/test-http-server.toml"
+        UUID=`$CLI compose start test-http-server vhd`
         rlAssertEquals "exit code should be zero" $? 0
 
         UUID=`echo $UUID | cut -f 2 -d' '`

--- a/tests/cli/test_compose_ext4-filesystem.sh
+++ b/tests/cli/test_compose_ext4-filesystem.sh
@@ -20,7 +20,8 @@ CLI="${CLI:-./src/bin/composer-cli}"
 rlJournalStart
     rlPhaseStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
-        UUID=`$CLI compose start example-http-server ext4-filesystem`
+        rlRun -t -c "$CLI blueprints push $(dirname $0)/lib/test-http-server.toml"
+        UUID=`$CLI compose start test-http-server ext4-filesystem`
         rlAssertEquals "exit code should be zero" $? 0
 
         UUID=`echo $UUID | cut -f 2 -d' '`

--- a/tests/cli/test_compose_google.sh
+++ b/tests/cli/test_compose_google.sh
@@ -16,7 +16,8 @@ CLI="${CLI:-./src/bin/composer-cli}"
 rlJournalStart
     rlPhasStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
-        UUID=`$CLI compose start example-http-server google`
+        rlRun -t -c "$CLI blueprints push $(dirname $0)/lib/test-http-server.toml"
+        UUID=`$CLI compose start test-http-server google`
         rlAssertEquals "exit code should be zero" $? 0
 
         UUID=`echo $UUID | cut -f 2 -d ' '`

--- a/tests/cli/test_compose_partitioned-disk.sh
+++ b/tests/cli/test_compose_partitioned-disk.sh
@@ -20,7 +20,8 @@ CLI="${CLI:-./src/bin/composer-cli}"
 rlJournalStart
     rlPhaseStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
-        UUID=`$CLI compose start example-http-server partitioned-disk`
+        rlRun -t -c "$CLI blueprints push $(dirname $0)/lib/test-http-server.toml"
+        UUID=`$CLI compose start test-http-server partitioned-disk`
         rlAssertEquals "exit code should be zero" $? 0
 
         UUID=`echo $UUID | cut -f 2 -d' '`

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -103,7 +103,9 @@ rlJournalStart
 
             rlRun -t -c "$CLI compose image $UUID"
             rlAssertExists "$UUID-disk.qcow2"
+        fi
 
+        if [ "$BACKEND" != "osbuild-composer" ]; then
             # because this path is listed in the documentation
             rlAssertExists    "/var/lib/lorax/composer/results/$UUID/"
             rlAssertExists    "/var/lib/lorax/composer/results/$UUID/disk.qcow2"

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -67,18 +67,11 @@ rlJournalStart
         else
             rlFail "Compose UUID is empty!"
         fi
-
-        # check if anaconda is really running
-        until ps -axo comm,pid | grep '^anaconda'; do
-            sleep 10
-            rlLogInfo "Waiting for anaconda to start running..."
-        done;
     rlPhaseEnd
 
     rlPhaseStartTest "cancel compose"
         rlRun -t -c "$CLI compose cancel $UUID"
         rlRun -t -c "$CLI compose info $UUID" 1 "compose is canceled"
-        rlAssertNotExists "/var/run/anaconda.pid"
     rlPhaseEnd
 
     rlPhaseStartTest "compose start again"

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -50,7 +50,8 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose start"
-        UUID=`$CLI compose start example-http-server ami`
+        rlRun -t -c "$CLI blueprints push $(dirname $0)/lib/test-http-server.toml"
+        UUID=`$CLI compose start test-http-server qcow2`
         rlAssertEquals "exit code should be zero" $? 0
         UUID=`echo $UUID | cut -f 2 -d' '`
 
@@ -81,7 +82,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose start again"
-        UUID=`$CLI compose start example-http-server ami`
+        UUID=`$CLI compose start test-http-server qcow2`
         rlAssertEquals "exit code should be zero" $? 0
 
         UUID=`echo $UUID | cut -f 2 -d' '`
@@ -101,12 +102,12 @@ rlJournalStart
             check_compose_status "$UUID"
 
             rlRun -t -c "$CLI compose image $UUID"
-            rlAssertExists "$UUID-root.tar.xz"
+            rlAssertExists "$UUID-disk.qcow2"
 
             # because this path is listed in the documentation
             rlAssertExists    "/var/lib/lorax/composer/results/$UUID/"
-            rlAssertExists    "/var/lib/lorax/composer/results/$UUID/root.tar.xz"
-            rlAssertNotDiffer "/var/lib/lorax/composer/results/$UUID/root.tar.xz" "$UUID-root.tar.xz"
+            rlAssertExists    "/var/lib/lorax/composer/results/$UUID/disk.qcow2"
+            rlAssertNotDiffer "/var/lib/lorax/composer/results/$UUID/disk.qcow2" "$UUID-disk.qcow2"
         fi
     rlPhaseEnd
 

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -71,7 +71,9 @@ rlJournalStart
 
     rlPhaseStartTest "cancel compose"
         rlRun -t -c "$CLI compose cancel $UUID"
-        rlRun -t -c "$CLI compose info $UUID" 1 "compose is canceled"
+        if [ "$BACKEND" == "lorax-composer" ]; then
+            rlRun -t -c "$CLI compose info $UUID" 1 "compose is canceled"
+        fi
     rlPhaseEnd
 
     rlPhaseStartTest "compose start again"

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -113,5 +113,9 @@ rlJournalStart
         fi
     rlPhaseEnd
 
+    rlPhaseStartCleanup
+        rlRun -t -c "$CLI compose delete $UUID"
+    rlPhaseEnd
+
 rlJournalEnd
 rlJournalPrintText

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -11,18 +11,42 @@ CLI="${CLI:-./src/bin/composer-cli}"
 
 rlJournalStart
     rlPhaseStartTest "compose types"
+        TYPE_LIVE_ISO="live-iso"
+        TYPE_ALIBABA="alibaba"
+        TYPE_GOOGLE="google"
+        TYPE_HYPER_V="hyper-v"
+        TYPE_LIVEIMG="liveimg-tar"
+        TYPE_EXT4="ext4-filesystem"
+        TYPE_PARTITIONED_DISK="partitioned-disk"
+        TYPE_TAR="tar"
+        TYPE_IOT=""
+
+        # backend specific compose type overrides
+        if [ "$BACKEND" == "osbuild-composer" ]; then
+            TYPE_LIVE_ISO=""
+            TYPE_ALIBABA=""
+            TYPE_GOOGLE=""
+            TYPE_HYPER_V=""
+            TYPE_LIVEIMG=""
+            TYPE_EXT4=""
+            TYPE_PARTITIONED_DISK=""
+            TYPE_TAR=""
+            TYPE_IOT="fedora-iot-commit"
+        fi
+
+        # arch specific compose type selections
         if [ "$(uname -m)" == "x86_64" ]; then
-            rlAssertEquals "lists all supported types" \
-                    "`$CLI compose types | xargs`" "alibaba ami ext4-filesystem google hyper-v live-iso liveimg-tar openstack partitioned-disk qcow2 tar vhd vmdk"
+            SUPPORTED_TYPES="$TYPE_ALIBABA ami $TYPE_IOT $TYPE_EXT4 $TYPE_GOOGLE $TYPE_HYPER_V $TYPE_LIVE_ISO $TYPE_LIVEIMG openstack $TYPE_PARTITIONED_DISK qcow2 $TYPE_TAR vhd vmdk"
         elif [ "$(uname -m)" == "aarch64" ]; then
             # ami is supported on aarch64
-            rlAssertEquals "lists all supported types" \
-                    "`$CLI compose types | xargs`" "ami ext4-filesystem live-iso liveimg-tar openstack partitioned-disk qcow2 tar"
+            SUPPORTED_TYPES="ami $TYPE_EXT4 $TYPE_LIVE_ISO $TYPE_LIVEIMG openstack $TYPE_PARTITIONED_DISK qcow2 $TYPE_TAR"
         else
-            # non-x86 architectures disable alibaba
-            rlAssertEquals "lists all supported types" \
-                    "`$CLI compose types | xargs`" "ext4-filesystem live-iso liveimg-tar openstack partitioned-disk qcow2 tar"
+            SUPPORTED_TYPES="$TYPE_EXT4 $TYPE_LIVE_ISO $TYPE_LIVEIMG openstack $TYPE_PARTITIONED_DISK qcow2 $TYPE_TAR"
         fi
+
+        # truncate white space in case some types are not available
+        SUPPORTED_TYPES=$(echo "$SUPPORTED_TYPES" | tr -s ' ' | sed 's/^[[:space:]]*//')
+        rlAssertEquals "lists all supported types" "`$CLI compose types | xargs`" "$SUPPORTED_TYPES"
     rlPhaseEnd
 
     rlPhaseStartTest "compose start"
@@ -57,7 +81,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "compose start again"
-        UUID=`$CLI compose start example-http-server tar`
+        UUID=`$CLI compose start example-http-server ami`
         rlAssertEquals "exit code should be zero" $? 0
 
         UUID=`echo $UUID | cut -f 2 -d' '`

--- a/tests/cli/test_compose_tar.sh
+++ b/tests/cli/test_compose_tar.sh
@@ -22,7 +22,8 @@ rlJournalStart
 
     rlPhaseStartTest "compose start"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
-        UUID=`$CLI compose start example-http-server tar`
+        rlRun -t -c "$CLI blueprints push $(dirname $0)/lib/test-http-server.toml"
+        UUID=`$CLI compose start test-http-server tar`
         rlAssertEquals "exit code should be zero" $? 0
 
         UUID=`echo $UUID | cut -f 2 -d' '`

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -10,6 +10,8 @@ set -eu
 CLI="${CLI:-}"
 
 function setup_tests {
+    [ "$BACKEND" == "osbuild-composer" ] && return 0
+
     local share_dir=$1
     local blueprints_dir=$2
 
@@ -56,6 +58,8 @@ __EOF__
 }
 
 function teardown_tests {
+    [ "$BACKEND" == "osbuild-composer" ] && return 0
+
     local share_dir=$1
     local blueprints_dir=$2
 
@@ -91,7 +95,7 @@ if [ -z "$CLI" ]; then
     chmod a+rx -R $SHARE_DIR
 
     setup_tests $SHARE_DIR $BLUEPRINTS_DIR
-    # start the lorax-composer daemon
+    # start the backend daemon
     composer_start
 else
     export PACKAGE="composer-cli"
@@ -111,14 +115,14 @@ setup_beakerlib_env
 run_beakerlib_tests "$@"
 
 if [ -z "$CLI" ]; then
-    # stop lorax-composer and remove /run/weldr/api.socket
+    # stop backend and remove /run/weldr/api.socket
     # only if running against source
     composer_stop
     teardown_tests $SHARE_DIR $BLUEPRINTS_DIR
 else
     composer_stop
     teardown_tests /usr/share/lorax /var/lib/lorax/composer/blueprints
-    # start lorax-composer again so we can continue with manual or other kinds
+    # start backend again so we can continue with manual or other kinds
     # of testing on the same system
     composer_start
 fi


### PR DESCRIPTION
This is the same as #917 but rebased on top of master branch.

My intention was to make sure composer-cli is using the osbuild-composer backend so we can have coverage for the scenarios where compose types are compared against a hard-coded list, see discussion here:
https://github.com/osbuild/osbuild-composer/pull/503#discussion_r408913577

Arguably most of the tests that we have here should be disabled b/c they are already covered in osbuild-composer. Only the cli specific ones should remain here. I'll update this PR with a few more commits.


