### PR TITLE
mksquashfs: Catch errors with mksquashfs and report them

### DIFF
--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -319,14 +319,18 @@ class Lorax(BaseLoraxClass):
                 logger.info("no BCJ filter for arch %s", self.arch.basearch)
         if squashfs_only:
             # Create an ext4 rootfs.img and compress it with squashfs
-            rb.create_squashfs_runtime(joinpaths(installroot,runtime),
-                compression=compression, compressargs=compressargs,
-                size=size)
+            rc = rb.create_squashfs_runtime(joinpaths(installroot,runtime),
+                    compression=compression, compressargs=compressargs,
+                    size=size)
         else:
             # Create an ext4 rootfs.img and compress it with squashfs
-            rb.create_ext4_runtime(joinpaths(installroot,runtime),
-                compression=compression, compressargs=compressargs,
-                size=size)
+            rc = rb.create_ext4_runtime(joinpaths(installroot,runtime),
+                    compression=compression, compressargs=compressargs,
+                    size=size)
+        if rc != 0:
+            logger.error("rootfs.img creation failed. See program.log")
+            sys.exit(1)
+
         rb.finished()
 
         logger.info("preparing to build output tree and boot images")

--- a/src/pylorax/treebuilder.py
+++ b/src/pylorax/treebuilder.py
@@ -234,7 +234,7 @@ class RuntimeBuilder(object):
         os.makedirs(os.path.dirname(outfile))
 
         # squash the rootfs
-        imgutils.mksquashfs(self.vars.root, outfile, compression, compressargs)
+        return imgutils.mksquashfs(self.vars.root, outfile, compression, compressargs)
 
     def create_ext4_runtime(self, outfile="/var/tmp/squashfs.img", compression="xz", compressargs=None, size=2):
         """Create a squashfs compressed ext4 runtime"""
@@ -253,8 +253,9 @@ class RuntimeBuilder(object):
             raise
 
         # squash the live rootfs and clean up workdir
-        imgutils.mksquashfs(workdir, outfile, compression, compressargs)
+        rc = imgutils.mksquashfs(workdir, outfile, compression, compressargs)
         remove(workdir)
+        return rc
 
     def finished(self):
         """ Done using RuntimeBuilder


### PR DESCRIPTION
The host system can run out of space while running mksquashfs, and while
this is logged to program.log it isn't detected by lorax or
livemedia-creator so it will continue running, possibly reporting
unrelated errors and causing confusion.

This adds checks for the return status when calling mksquashfs, logs it
to the log, and either exits or raises an error immediately.