### PR TITLE
drop 32-bit support from ppc live image grub.cfg

### DIFF
--- a/share/templates.d/99-generic/live/config_files/ppc/grub.cfg.in
+++ b/share/templates.d/99-generic/live/config_files/ppc/grub.cfg.in
@@ -3,19 +3,15 @@ set timeout=5
 
 echo -e "\nWelcome to the @PRODUCT@ @VERSION@ installer!\n\n"
 
-for BITS in 32 64; do
-  if [ -d "/ppc/ppc${BITS}" ]; then
-    menuentry "Start @PRODUCT@ @VERSION@ (${BITS}-bit kernel)"  $BITS --class fedora --class gnu-linux --class gnu --class os {
-      linux /ppc/ppc${2}/vmlinuz @ROOT@ @EXTRA@ ro rd.live.image quiet
-      initrd /ppc/ppc${2}/initrd.img
-    }
+menuentry "Start @PRODUCT@ @VERSION@ (64-bit kernel)" --class fedora --class gnu-linux --class gnu --class os {
+  linux /ppc/ppc64/vmlinuz @ROOT@ @EXTRA@ ro rd.live.image quiet
+  initrd /ppc/ppc64/initrd.img
+}
 
-    menuentry "Test this media & start @PRODUCT@ @VERSION@  (${BITS}-bit kernel)" $BITS --class fedora --class gnu-linux --class  gnu --class os {
-      linux /ppc/ppc${2}/vmlinuz @ROOT@ @EXTRA@ rd.live.image rd.live.check ro quiet
-      initrd /ppc/ppc${2}/initrd.img
-      }
-  fi
-done
+menuentry "Test this media & start @PRODUCT@ @VERSION@ (64-bit kernel)" --class fedora --class gnu-linux --class  gnu --class os {
+  linux /ppc/ppc64/vmlinuz @ROOT@ @EXTRA@ rd.live.image rd.live.check ro quiet
+  initrd /ppc/ppc64/initrd.img
+}
 
 submenu 'Other options...' {
   menuentry 'Reboot' {
@@ -26,4 +22,3 @@ submenu 'Other options...' {
     exit
   }
 }
-


### PR DESCRIPTION
Seems petitboot can't properly parse the live image grub config on ppc, thus
booting fails on bare-metal. Fix the problem by removing the obsolete 32-bit
entries.