### PR TITLE
composer-cli: Bump the default API version to 1

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:rawhide
+FROM registry.fedoraproject.org/fedora:31
 RUN  dnf -y install \
   anaconda-tui \
   libgit2-glib \

--- a/src/composer/cli/cmdline.py
+++ b/src/composer/cli/cmdline.py
@@ -37,7 +37,7 @@ def composer_cli_parser():
                         help="Path to the socket file to listen on")
     parser.add_argument("--log", dest="logfile", default=None, metavar="LOG",
                         help="Path to logfile (./composer-cli.log)")
-    parser.add_argument("-a", "--api", dest="api_version", default="0", metavar="APIVER",
+    parser.add_argument("-a", "--api", dest="api_version", default="1", metavar="APIVER",
                         help="API Version to use")
     parser.add_argument("--test", dest="testmode", default=0, type=int, metavar="TESTMODE",
                         help="Pass test mode to compose. 1=Mock compose with fail. 2=Mock compose with finished.")

--- a/test/composertest.py
+++ b/test/composertest.py
@@ -11,6 +11,7 @@ import unittest
 sys.path.append(os.path.join(os.path.dirname(__file__), "../bots/machine"))
 import testvm # pylint: disable=import-error
 
+#pylint: disable=subprocess-run-check
 
 def print_exception(etype, value, tb):
     # only include relevant lines

--- a/tests/pylorax/blueprints/example-glusterfs.toml
+++ b/tests/pylorax/blueprints/example-glusterfs.toml
@@ -3,11 +3,11 @@ description = "An example GlusterFS server with samba"
 
 [[modules]]
 name = "glusterfs"
-version = "6.*"
+version = "7.*"
 
 [[modules]]
 name = "glusterfs-cli"
-version = "6.*"
+version = "7.*"
 
 [[packages]]
 name = "samba"

--- a/tests/pylorax/test_projects.py
+++ b/tests/pylorax/test_projects.py
@@ -326,7 +326,7 @@ def singlerepo_v0():
         "check_gpg": True,
         "check_ssl": True,
         "gpgkey_urls": [
-            "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-32-x86_64"
+            "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-31-x86_64"
         ],
         "name": "single-repo",
         "system": False,

--- a/tests/pylorax/test_server.py
+++ b/tests/pylorax/test_server.py
@@ -52,8 +52,8 @@ OPENSSH_GLOB = {"name":"openssh-server", "version": "8.*"}
 RSYNC_GLOB = {"name": "rsync", "version": "3.1.*"}
 SAMBA_GLOB = {"name": "samba", "version": "4.*.*"}
 TMUX_GLOB = {"name": "tmux", "version": "2.9a"}
-GLUSTERFS_GLOB = {"name": "glusterfs", "version": "6.*"}
-GLUSTERFSCLI_GLOB = {"name": "glusterfs-cli", "version": "6.*"}
+GLUSTERFS_GLOB = {"name": "glusterfs", "version": "7.*"}
+GLUSTERFSCLI_GLOB = {"name": "glusterfs-cli", "version": "7.*"}
 
 
 def get_system_repo():


### PR DESCRIPTION
This was lost when backporting the sources command from master (on
master it is included as part of the upload command which is not
available on F31).