### PR TITLE
Keep /etc/default/useradd in install.img

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -35,7 +35,8 @@ removepkg fedora-release-rawhide
 
 ## keep enough of shadow-utils to create accounts
 removefrom shadow-utils --allbut /usr/bin/chage /usr/sbin/chpasswd \
-                        /usr/sbin/groupadd /usr/sbin/useradd
+                        /usr/sbin/groupadd /usr/sbin/useradd \
+                        /etc/default/useradd
 
 ## remove other account management tools
 removepkg usermode usermode-gtk passwd


### PR DESCRIPTION
Anaconda creates a user for connecting via ssh during the installation when the sshpw kickstart command is used. The user is created with "/sbin/nologin" shell when /etc/default/useradd is missing, which prevents the user from log into the running installation.

Resolves: rhbz#1838677