### PR TITLE
[rhel8] test: Put VM image overlay into /var/tmp

### DIFF
--- a/test/composertest.py
+++ b/test/composertest.py
@@ -31,10 +31,11 @@ class VirtMachineTestCase(unittest.TestCase):
 
     def setUpTestMachine(self, image, identity_file=None):
         self.network = testvm.VirtNetwork(0)
-        if identity_file:
-            self.machine = testvm.VirtMachine(image, networking=self.network.host(), cpus=2, memory_mb=2048, identity_file=identity_file)
-        else:
-            self.machine = testvm.VirtMachine(image, networking=self.network.host(), cpus=2, memory_mb=2048)
+        # default overlay directory is not big enough to hold the large composed trees; thus put overlay into /var/tmp/
+        self.machine = testvm.VirtMachine(image, networking=self.network.host(),
+                                          cpus=2, memory_mb=2048,
+                                          overlay_dir="/var/tmp",
+                                          identity_file=identity_file)
 
         print("Starting virtual machine '{}'".format(image))
         self.machine.start()


### PR DESCRIPTION
At least in our CI, the default place to store VM runtime overlays
(testvm.get_temp_dir()) points to a tmpfs file, so that tests can put VM
overlays into RAM and are not affected by slow I/O. But that doesn't
work for composer, as it tends to produce huge overlays due to real-life
OS composed trees.

Use /var/tmp/ instead, which is meant for large files.

Also simplify the VirtMachine invocation -- if `identity_file` is None,
that's fine -- it's the default value of that argument anyway.

Cherry-picked from master commit 9b8e0e2335c5