### PR TITLE
Master size ostree

### DIFF
--- a/docs/lorax-composer.rst
+++ b/docs/lorax-composer.rst
@@ -4,7 +4,7 @@ lorax-composer
 :Authors:
     Brian C. Lane <bcl@redhat.com>
 
-``lorax-composer`` is an API server that allows you to build disk images using
+``lorax-composer`` is a WELDR API server that allows you to build disk images using
 `Blueprints`_ to describe the package versions to be installed into the image.
 It is compatible with the Weldr project's bdcs-api REST protocol. More
 information on Weldr can be found `on the Weldr blog <http://www.weldr.io>`_.
@@ -12,6 +12,15 @@ information on Weldr can be found `on the Weldr blog <http://www.weldr.io>`_.
 Behind the scenes it uses `livemedia-creator <livemedia-creator.html>`_ and
 `Anaconda <https://anaconda-installer.readthedocs.io/en/latest/>`_ to handle the
 installation and configuration of the images.
+
+.. note::
+
+    ``lorax-composer`` is now deprecated. It is being replaced by the
+    ``osbuild-composer`` WELDR API server which implements more features (eg.
+    ostree, image uploads, etc.) You can still use ``composer-cli`` and
+    ``cockpit-composer`` with ``osbuild-composer``. See the documentation or
+    the `osbuild website <https://www.osbuild.org/>`_ for more information.
+
 
 Important Things To Note
 ------------------------

--- a/etc/bash_completion.d/composer-cli
+++ b/etc/bash_completion.d/composer-cli
@@ -3,7 +3,7 @@
 __composer_cli_flags="-h --help -j --json -s --socket --log -a --api --test -V"
 
 declare -A __composer_cli_cmds=(
-  [compose]="list start types status log cancel delete info metadata logs results image"
+  [compose]="list start start-ostree types status log cancel delete info metadata logs results image"
   [blueprints]="list show changes diff save delete depsolve push freeze tag undo workspace"
   [modules]="list"
   [projects]="list info"
@@ -112,7 +112,7 @@ _composer_cli() {
             blueprints:freeze)
                 COMPREPLY=($(compgen -W "$(__composer_blueprints) show save" -- "${cur}"))
             ;;
-            compose:start|blueprints:*)
+            compose:start|compose:start-ostree|blueprints:*)
                 COMPREPLY=($(compgen -W "$(__composer_blueprints)" -- "${cur}"))
             ;;
             compose:cancel)
@@ -143,10 +143,11 @@ _composer_cli() {
             compose:delete)
                 COMPREPLY=($(compgen -W "$(__composer_composes finished failed)" -- "${cur}"))
             ;;
-            compose:start)
+            compose:start|compose:start-ostree)
+                subpos="$subcmd:$cmd_cword"
                 if [ "$cmd_cword" == 3 ]; then
                     COMPREPLY=($(compgen -W "$(__composer_compose_types)" -- "${cur}"))
-                elif [ "$cmd_cword" == 5 ]; then
+                elif [ "$subpos" == "start:5" ] || [ "$subpos" == "start-ostree:7" ]; then
                     # If they have typed something looking like a path, use file completion
                     # otherwise suggest providers.
                     case "${cur}" in
@@ -158,7 +159,7 @@ _composer_cli() {
                             COMPREPLY=($(compgen -W "$(__composer_provider_list)" -- "${cur}"))
                         ;;
                     esac
-                elif [ "$cmd_cword" == 6 ]; then
+                elif [ "$subpos" == "start:6" ] || [ "$subpos" == "start-ostree:8" ]; then
                     COMPREPLY=($(compgen -W "$(__composer_profile_list ${prev})" -- "${cur}"))
                 fi
             ;;

--- a/src/composer/cli/compose.py
+++ b/src/composer/cli/compose.py
@@ -95,7 +95,7 @@ def get_size(args):
         return (args, 0)
 
     if len(args) < 2:
-        return (args, 0)
+        raise RuntimeError("--size is missing the value, in MiB")
 
     # Let this raise an error for non-digit input
     size = int(args[1])

--- a/src/composer/cli/help.py
+++ b/src/composer/cli/help.py
@@ -16,8 +16,9 @@
 
 # Documentation for the commands
 compose_help = """
-compose start <BLUEPRINT> <TYPE> [<IMAGE-NAME> <PROVIDER> <PROFILE> | <IMAGE-NAME> <PROFILE.TOML>]
+compose start [--size XXXX] <BLUEPRINT> <TYPE> [<IMAGE-NAME> <PROVIDER> <PROFILE> | <IMAGE-NAME> <PROFILE.TOML>]
     Start a compose using the selected blueprint and output type. Optionally start an upload.
+    --size is supported by osbuild-composer, and is in MiB.
 
 compose types
     List the supported output types.

--- a/src/composer/cli/help.py
+++ b/src/composer/cli/help.py
@@ -20,6 +20,10 @@ compose start [--size XXXX] <BLUEPRINT> <TYPE> [<IMAGE-NAME> <PROVIDER> <PROFILE
     Start a compose using the selected blueprint and output type. Optionally start an upload.
     --size is supported by osbuild-composer, and is in MiB.
 
+compose start-ostree [--size XXXX] <BLUEPRINT> <TYPE> <REF> <PARENT> [<IMAGE-NAME> <PROVIDER> <PROFILE> | <IMAGE-NAME> <PROFILE.TOML>]
+    Start an ostree compose using the selected blueprint and output type. Optionally start an upload. This command
+    is only supported by osbuild-composer, and requires the ostree REF and PARENT. --size is in MiB.
+
 compose types
     List the supported output types.
 

--- a/tests/composer/test_compose.py
+++ b/tests/composer/test_compose.py
@@ -1,0 +1,369 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler
+import json
+import shutil
+from socketserver import UnixStreamServer
+import threading
+
+import tempfile
+import unittest
+
+from composer import http_client as client
+import composer.cli as cli
+from composer.cli.cmdline import composer_cli_parser
+
+# Use a GLOBAL record the request data for use in the test
+# because there is no way to access the request handler class from the test methods
+LAST_REQUEST = {}
+
+# Test data for upload profile
+PROFILE_TOML = """
+provider = "aws"
+
+[settings]
+aws_access_key = "AWS Access Key"
+aws_bucket = "AWS Bucket"
+aws_region = "AWS Region"
+aws_secret_key = "AWS Secret Key"
+"""
+
+class MyUnixServer(UnixStreamServer):
+    def get_request(self):
+        """There is no client address for Unix Domain Sockets, so return the server address"""
+        req, _ = self.socket.accept()
+        return (req, self.server_address)
+
+
+class APIHTTPHandler(BaseHTTPRequestHandler):
+    STATUS = {}
+
+    def send_json_response(self, status, d):
+        """Send a 200 with a JSON body"""
+        body = json.dumps(d).encode("UTF-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def send_api_status_dict(self):
+        self.send_json_response(HTTPStatus.OK, self.STATUS)
+
+    def send_api_status(self, status=True, errors=None):
+        if status:
+            self.send_json_response(HTTPStatus.OK, {"status": True})
+        else:
+            self.send_json_response(HTTPStatus.BAD_REQUEST,
+                    {"status": False, "errors": [{"id": "0", "msg": "Test Framework"}]})
+
+    def save_request(self):
+        global LAST_REQUEST
+        LAST_REQUEST = {
+                "command": self.command,
+                "path": self.path,
+                "headers": self.headers,
+                "body": "",
+        }
+        try:
+            length = int(self.headers.get('content-length'))
+            LAST_REQUEST["body"] = self.rfile.read(length)
+        except (ValueError, TypeError):
+            pass
+        print("%s" % LAST_REQUEST)
+
+    def do_GET(self):
+        self.save_request()
+        if self.path == "/api/status":
+            self.send_api_status_dict()
+
+    def do_POST(self):
+        # Need to check for /api/status and send the correct response
+        self.save_request()
+        self.send_api_status(True)
+
+
+class LoraxAPIv0HTTPHandler(APIHTTPHandler):
+    STATUS = {
+        "api": "0",
+        "backend": "lorax-composer",
+        "build": "devel",
+        "db_supported": True,
+        "db_version": "0",
+        "msgs": [],
+        "schema_version": "0"
+    }
+
+
+class LoraxAPIv1HTTPHandler(APIHTTPHandler):
+    STATUS = {
+        "api": "1",
+        "backend": "lorax-composer",
+        "build": "devel",
+        "db_supported": True,
+        "db_version": "0",
+        "msgs": [],
+        "schema_version": "0"
+    }
+
+
+class OsBuildAPIv0HTTPHandler(APIHTTPHandler):
+    STATUS = {
+        "api": "0",
+        "backend": "osbuild-composer",
+        "build": "devel",
+        "db_supported": True,
+        "db_version": "0",
+        "msgs": [],
+        "schema_version": "0"
+    }
+
+
+class OsBuildAPIv1HTTPHandler(APIHTTPHandler):
+    STATUS = {
+        "api": "1",
+        "backend": "osbuild-composer",
+        "build": "devel",
+        "db_supported": True,
+        "db_version": "0",
+        "msgs": [],
+        "schema_version": "0"
+    }
+
+
+class ComposeTestCase(unittest.TestCase):
+    def run_test(self, args):
+        global LAST_REQUEST
+        LAST_REQUEST = {}
+        p = composer_cli_parser()
+        opts = p.parse_args(args)
+        cli.main(opts)
+        return LAST_REQUEST
+
+
+class ComposeLoraxV0TestCase(ComposeTestCase):
+    @classmethod
+    def setUpClass(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="composer-cli.test.")
+        self.socket = self.tmpdir + "/api.socket"
+        self.server = MyUnixServer(self.socket, LoraxAPIv0HTTPHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever)
+        self.thread.daemon = True
+        self.thread.start()
+
+    @classmethod
+    def tearDownClass(self):
+        self.server.shutdown()
+        self.thread.join(10)
+        shutil.rmtree(self.tmpdir)
+
+    def test_status(self):
+        """Make sure the mock status response is working"""
+        global LAST_REQUEST
+        LAST_REQUEST = {}
+        result = client.get_url_json(self.socket, "/api/status")
+        self.assertTrue("path" in LAST_REQUEST)
+        self.assertEqual(LAST_REQUEST["path"], "/api/status")
+        self.assertEqual(result, LoraxAPIv0HTTPHandler.STATUS)
+
+    def test_compose_start_plain(self):
+        result = self.run_test(["--socket", self.socket, "--api", "0", "compose", "start", "http-server", "qcow2"])
+        self.assertTrue(result is not None)
+        self.assertTrue("body" in result)
+        self.assertGreater(len(result["body"]), 0)
+        jd = json.loads(result["body"])
+        self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "qcow2", "branch": "master"})
+
+
+class ComposeLoraxV1TestCase(ComposeTestCase):
+    @classmethod
+    def setUpClass(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="composer-cli.test.")
+        self.socket = self.tmpdir + "api.socket"
+        self.server = MyUnixServer(self.socket, LoraxAPIv1HTTPHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever)
+        self.thread.daemon = True
+        self.thread.start()
+
+    @classmethod
+    def tearDownClass(self):
+        self.server.shutdown()
+        self.thread.join(10)
+        shutil.rmtree(self.tmpdir)
+
+    def test_status(self):
+        """Make sure the mock status response is working"""
+        global LAST_REQUEST
+        LAST_REQUEST = {}
+        result = client.get_url_json(self.socket, "/api/status")
+        self.assertTrue("path" in LAST_REQUEST)
+        self.assertEqual(LAST_REQUEST["path"], "/api/status")
+        self.assertEqual(result, LoraxAPIv1HTTPHandler.STATUS)
+
+    def test_compose_start_plain(self):
+        result = self.run_test(["--socket", self.socket, "--api", "1", "compose", "start", "http-server", "qcow2"])
+        self.assertTrue(result is not None)
+        self.assertTrue("body" in result)
+        self.assertGreater(len(result["body"]), 0)
+        jd = json.loads(result["body"])
+        self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "qcow2", "branch": "master"})
+
+    def test_compose_start_upload(self):
+        with tempfile.NamedTemporaryFile(prefix="composer-cli.test.") as f:
+            f.write(PROFILE_TOML.encode("UTF-8"))
+            f.seek(0)
+            result = self.run_test(["--socket", self.socket, "--api", "1", "compose", "start", "http-server", "qcow2", "httpimage", f.name])
+            self.assertTrue(result is not None)
+            self.assertTrue("body" in result)
+            self.assertGreater(len(result["body"]), 0)
+            jd = json.loads(result["body"])
+            self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "qcow2", "branch": "master",
+                "upload": {"image_name": "httpimage", "provider": "aws",
+                "settings": {"aws_access_key": "AWS Access Key", "aws_bucket": "AWS Bucket", "aws_region": "AWS Region", "aws_secret_key": "AWS Secret Key"}}})
+
+    def test_compose_start_provider(self):
+        result = self.run_test(["--socket", self.socket, "--api", "1", "compose", "start", "http-server", "qcow2", "httpimage", "aws", "production"])
+        self.assertTrue(result is not None)
+        self.assertTrue("body" in result)
+        self.assertGreater(len(result["body"]), 0)
+        jd = json.loads(result["body"])
+        self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "qcow2", "branch": "master",
+            "upload": {"image_name": "httpimage", "profile": "production", "provider": "aws"}})
+
+class ComposeOsBuildV0TestCase(ComposeTestCase):
+    @classmethod
+    def setUpClass(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="composer-cli.test.")
+        self.socket = self.tmpdir + "api.socket"
+        self.server = MyUnixServer(self.socket, OsBuildAPIv0HTTPHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever)
+        self.thread.daemon = True
+        self.thread.start()
+
+    @classmethod
+    def tearDownClass(self):
+        self.server.shutdown()
+        self.thread.join(10)
+        shutil.rmtree(self.tmpdir)
+
+    def test_status(self):
+        """Make sure the mock status response is working"""
+        global LAST_REQUEST
+        LAST_REQUEST = {}
+        result = client.get_url_json(self.socket, "/api/status")
+        self.assertTrue("path" in LAST_REQUEST)
+        self.assertEqual(LAST_REQUEST["path"], "/api/status")
+        self.assertEqual(result, OsBuildAPIv0HTTPHandler.STATUS)
+
+    def test_compose_start_plain(self):
+        result = self.run_test(["--socket", self.socket, "--api", "0", "compose", "start", "http-server", "qcow2"])
+        self.assertTrue(result is not None)
+        self.assertTrue("body" in result)
+        self.assertGreater(len(result["body"]), 0)
+        jd = json.loads(result["body"])
+        self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "qcow2", "branch": "master"})
+
+class ComposeOsBuildV1TestCase(ComposeTestCase):
+    @classmethod
+    def setUpClass(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="composer-cli.test.")
+        self.socket = self.tmpdir + "api.socket"
+        self.server = MyUnixServer(self.socket, OsBuildAPIv1HTTPHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever)
+        self.thread.daemon = True
+        self.thread.start()
+
+    @classmethod
+    def tearDownClass(self):
+        self.server.shutdown()
+        self.thread.join(10)
+        shutil.rmtree(self.tmpdir)
+
+    def test_status(self):
+        """Make sure the mock status response is working"""
+        global LAST_REQUEST
+        LAST_REQUEST = {}
+        result = client.get_url_json(self.socket, "/api/status")
+        self.assertTrue("path" in LAST_REQUEST)
+        self.assertEqual(LAST_REQUEST["path"], "/api/status")
+        self.assertEqual(result, OsBuildAPIv1HTTPHandler.STATUS)
+
+    def test_compose_start_plain(self):
+        result = self.run_test(["--socket", self.socket, "--api", "1", "compose", "start", "http-server", "qcow2"])
+        self.assertTrue(result is not None)
+        self.assertTrue("body" in result)
+        self.assertGreater(len(result["body"]), 0)
+        jd = json.loads(result["body"])
+        self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "qcow2", "branch": "master"})
+
+    def test_compose_start_upload(self):
+        with tempfile.NamedTemporaryFile(prefix="composer-cli.test.") as f:
+            f.write(PROFILE_TOML.encode("UTF-8"))
+            f.seek(0)
+            result = self.run_test(["--socket", self.socket, "--api", "1", "compose", "start", "http-server", "qcow2", "httpimage", f.name])
+            self.assertTrue(result is not None)
+            self.assertTrue("body" in result)
+            self.assertGreater(len(result["body"]), 0)
+            jd = json.loads(result["body"])
+            self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "qcow2", "branch": "master",
+                "upload": {"image_name": "httpimage", "provider": "aws",
+                "settings": {"aws_access_key": "AWS Access Key", "aws_bucket": "AWS Bucket", "aws_region": "AWS Region", "aws_secret_key": "AWS Secret Key"}}})
+
+    def test_compose_start_plain_size(self):
+        result = self.run_test(["--socket", self.socket, "--api", "1", "compose", "start", "--size", "1776", "http-server", "qcow2"])
+        self.assertTrue(result is not None)
+        self.assertTrue("body" in result)
+        self.assertGreater(len(result["body"]), 0)
+        jd = json.loads(result["body"])
+        self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "qcow2", "branch": "master", "size": 1862270976})
+
+    def test_compose_start_size_upload(self):
+        with tempfile.NamedTemporaryFile(prefix="composer-cli.test.") as f:
+            f.write(PROFILE_TOML.encode("UTF-8"))
+            f.seek(0)
+            result = self.run_test(["--socket", self.socket, "--api", "1", "compose", "start", "--size", "1791", "http-server", "qcow2", "httpimage", f.name])
+            self.assertTrue(result is not None)
+            self.assertTrue("body" in result)
+            self.assertGreater(len(result["body"]), 0)
+            jd = json.loads(result["body"])
+            self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "qcow2", "branch": "master", "size": 1877999616,
+                "upload": {"image_name": "httpimage", "provider": "aws",
+                "settings": {"aws_access_key": "AWS Access Key", "aws_bucket": "AWS Bucket", "aws_region": "AWS Region", "aws_secret_key": "AWS Secret Key"}}})
+
+    def test_compose_start_ostree(self):
+        result = self.run_test(["--socket", self.socket, "--api", "1", "compose", "start-ostree", "http-server", "fedora-iot-commit", "referenceid", "parenturl"])
+        self.assertTrue(result is not None)
+        self.assertTrue("body" in result)
+        self.assertGreater(len(result["body"]), 0)
+        jd = json.loads(result["body"])
+        self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "fedora-iot-commit", "branch": "master",
+            "ostree": {"ref": "referenceid", "parent": "parenturl"}})
+
+    def test_compose_start_ostree_upload(self):
+        with tempfile.NamedTemporaryFile(prefix="composer-cli.test.") as f:
+            f.write(PROFILE_TOML.encode("UTF-8"))
+            f.seek(0)
+            result = self.run_test(["--socket", self.socket, "--api", "1", "compose", "start-ostree", "http-server", "fedora-iot-commit", "referenceid", "parenturl", "httpimage", f.name])
+            self.assertTrue(result is not None)
+            self.assertTrue("body" in result)
+            self.assertGreater(len(result["body"]), 0)
+            jd = json.loads(result["body"])
+            self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "fedora-iot-commit", "branch": "master",
+                "ostree": {"ref": "referenceid", "parent": "parenturl"},
+                "upload": {"image_name": "httpimage", "provider": "aws",
+                "settings": {"aws_access_key": "AWS Access Key", "aws_bucket": "AWS Bucket", "aws_region": "AWS Region", "aws_secret_key": "AWS Secret Key"}}})

--- a/tests/composer/test_compose.py
+++ b/tests/composer/test_compose.py
@@ -27,6 +27,7 @@ import unittest
 from composer import http_client as client
 import composer.cli as cli
 from composer.cli.cmdline import composer_cli_parser
+from composer.cli.compose import get_size
 
 # Use a GLOBAL record the request data for use in the test
 # because there is no way to access the request handler class from the test methods
@@ -367,3 +368,27 @@ class ComposeOsBuildV1TestCase(ComposeTestCase):
                 "ostree": {"ref": "referenceid", "parent": "parenturl"},
                 "upload": {"image_name": "httpimage", "provider": "aws",
                 "settings": {"aws_access_key": "AWS Access Key", "aws_bucket": "AWS Bucket", "aws_region": "AWS Region", "aws_secret_key": "AWS Secret Key"}}})
+
+class SizeTest(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(get_size([]), ([], 0))
+
+    def test_no_size(self):
+        self.assertEqual(get_size(["blueprint", "type", "imagename", "profile"]),
+                         (["blueprint", "type", "imagename", "profile"], 0))
+
+    def test_size_later(self):
+        with self.assertRaises(RuntimeError):
+            get_size(["blueprint", "--size", "100", "type"])
+
+    def test_size_no_value(self):
+        with self.assertRaises(RuntimeError):
+            get_size(["--size"])
+
+    def test_size_nonint(self):
+        with self.assertRaises(ValueError):
+            get_size(["--size", "abc"])
+
+    def test_get_size(self):
+        self.assertEqual(get_size(["--size", "1912", "blueprint", "type"]),
+                         (["blueprint", "type"], 2004877312))


### PR DESCRIPTION
This currently doesn't have any tests for the new features. But I think this is working, I can pass --size and observe it using that size in the results json. And if I do a start-ostree fedora-iot-commit I can see the ref and parent in the json.
