### PR TITLE
include generic.ins for s390 boot iso

### DIFF
--- a/share/templates.d/99-generic/s390.tmpl
+++ b/share/templates.d/99-generic/s390.tmpl
@@ -81,6 +81,7 @@ runcmd xorrisofs ${isoargs} -o ${outroot}/images/boot.iso \
        -boot-load-size 4 -no-emul-boot \
        -R -J -V '${isolabel}' -graft-points \
        .discinfo=${outroot}/.discinfo \
+       generic.ins=${outroot}/generic.ins \
        ${BOOTDIR}=${outroot}/${BOOTDIR} \
        ${filegraft}
 treeinfo images-${basearch} boot.iso images/boot.iso


### PR DESCRIPTION
Include the generic.ins file on the s390 boot iso, so it's directly bootable
on an LPAR. The full iso already had generic.ins included.