### PR TITLE
Ensure /proc exists before trying to touch /proc/modules

### DIFF
--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -256,6 +256,7 @@ def rebuild_initrds_for_live(opts, sys_root_dir, results_dir):
         raise Exception("No initrds found, cannot rebuild_initrds")
 
     # Hush some dracut warnings. TODO: bind-mount proc in place?
+    os.makedirs(joinpaths(sys_root_dir, "/proc"), exist_ok=True)
     open(joinpaths(sys_root_dir,"/proc/modules"),"w")
 
     if opts.ostree:

--- a/src/pylorax/treebuilder.py
+++ b/src/pylorax/treebuilder.py
@@ -309,6 +309,7 @@ class TreeBuilder(object):
             raise Exception("No kernels found, cannot rebuild_initrds")
 
         # Hush some dracut warnings. TODO: bind-mount proc in place?
+        os.makedirs(joinpaths(self.vars.inroot, "/proc"), exist_ok=True)
         open(joinpaths(self.vars.inroot,"/proc/modules"),"w")
         for kernel in self.kernels:
             if prefix:


### PR DESCRIPTION
The last few Rawhide composes failed because, when we try to
touch /proc/modules here (in treebuilder.py), /proc does not
exist in the inroot. I tried and failed all afternoon to figure
out *why* it suddenly doesn't exist; I'd still like to know, but
this at least should make it not an issue. `exist_ok=True` means
that if the dir already exists we'll do nothing and carry on.

Signed-off-by: Adam Williamson <awilliam@redhat.com>