### PR TITLE
composer-cli: Change timeout to 5 minutes

### DIFF
--- a/src/composer/http_client.py
+++ b/src/composer/http_client.py
@@ -126,7 +126,7 @@ def get_url_json_unlimited(socket_path, url, total_fn=None):
     r_unlimited = http.request("GET", unlimited_url)
     return json.loads(r_unlimited.data.decode('utf-8'))
 
-def delete_url_json(socket_path, url, timeout=120):
+def delete_url_json(socket_path, url):
     """Send a DELETE request to the url and return JSON response
 
     :param socket_path: Path to the Unix socket to use for API communication
@@ -136,7 +136,7 @@ def delete_url_json(socket_path, url, timeout=120):
     :returns: The json response from the server
     :rtype: dict
     """
-    http = UnixHTTPConnectionPool(socket_path, timeout=timeout)
+    http = UnixHTTPConnectionPool(socket_path)
     r = http.request("DELETE", url)
     return json.loads(r.data.decode("utf-8"))
 

--- a/src/composer/unix_socket.py
+++ b/src/composer/unix_socket.py
@@ -53,8 +53,10 @@ class UnixHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
 
         :param socket_path: The path to the Unix domain socket
         :param timeout: Number of seconds to timeout the connection
+
+        NOTE: retries are disabled for these connections, they are never useful
         """
-        super(UnixHTTPConnectionPool, self).__init__('localhost', timeout=timeout)
+        super(UnixHTTPConnectionPool, self).__init__('localhost', timeout=timeout, retries=False)
         self.socket_path = socket_path
 
     def _new_conn(self):

--- a/src/composer/unix_socket.py
+++ b/src/composer/unix_socket.py
@@ -26,7 +26,7 @@ import urllib3
 # https://github.com/docker/docker-py/blob/master/docker/transport/unixconn.py
 class UnixHTTPConnection(http.client.HTTPConnection, object):
 
-    def __init__(self, socket_path, timeout=60):
+    def __init__(self, socket_path, timeout=60*5):
         """Create an HTTP connection to a unix domain socket
 
         :param socket_path: The path to the Unix domain socket
@@ -48,7 +48,7 @@ class UnixHTTPConnection(http.client.HTTPConnection, object):
 
 class UnixHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
 
-    def __init__(self, socket_path, timeout=60):
+    def __init__(self, socket_path, timeout=60*5):
         """Create a connection pool using a Unix domain socket
 
         :param socket_path: The path to the Unix domain socket


### PR DESCRIPTION
Related: rhbz#1844649

In some cases osbuild-composer with an empty cache can take longer than
a minute to depsolve and start a compose.