### PR TITLE
Skip creating empty /proc/modules for dracut

### DIFF
--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -255,9 +255,6 @@ def rebuild_initrds_for_live(opts, sys_root_dir, results_dir):
     if not kernels:
         raise Exception("No initrds found, cannot rebuild_initrds")
 
-    # Hush some dracut warnings. TODO: bind-mount proc in place?
-    open(joinpaths(sys_root_dir,"/proc/modules"),"w")
-
     if opts.ostree:
         # Dracut assumes to have some dirs in disk image
         # /var/tmp for temp files
@@ -294,7 +291,6 @@ def rebuild_initrds_for_live(opts, sys_root_dir, results_dir):
         shutil.copy2(joinpaths(sys_root_dir, kernel.path), results_dir)
     umount(joinpaths(sys_root_dir, "var/tmp"), delete=False)
     umount(joinpaths(sys_root_dir, "results"), delete=False)
-    os.unlink(joinpaths(sys_root_dir,"/proc/modules"))
 
 def create_pxe_config(template, images_dir, live_image_name, add_args = None):
     """

--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -282,9 +282,9 @@ def rebuild_initrds_for_live(opts, sys_root_dir, results_dir):
             # Construct an initrd from the kernel name
             outfile = os.path.basename(kernel.path.replace("vmlinuz-", "initrd-") + ".img")
         log.info("rebuilding %s", outfile)
+        log.info("dracut warnings about /proc are safe to ignore")
 
         kver = kernel.version
-
         cmd = dracut + ["/results/"+outfile, kver]
         runcmd(cmd, root=sys_root_dir)
 

--- a/src/pylorax/treebuilder.py
+++ b/src/pylorax/treebuilder.py
@@ -308,8 +308,6 @@ class TreeBuilder(object):
         if not self.kernels:
             raise Exception("No kernels found, cannot rebuild_initrds")
 
-        # Hush some dracut warnings. TODO: bind-mount proc in place?
-        open(joinpaths(self.vars.inroot,"/proc/modules"),"w")
         for kernel in self.kernels:
             if prefix:
                 idir = os.path.dirname(kernel.path)
@@ -327,8 +325,6 @@ class TreeBuilder(object):
                     os.rename(initrd, initrd + backup)
             cmd = dracut + [outfile, kernel.version]
             runcmd(cmd, root=self.vars.inroot)
-
-        os.unlink(joinpaths(self.vars.inroot,"/proc/modules"))
 
     def build(self):
         templatefile = templatemap[self.vars.arch.basearch]

--- a/src/pylorax/treebuilder.py
+++ b/src/pylorax/treebuilder.py
@@ -319,6 +319,8 @@ class TreeBuilder(object):
                 # Construct an initrd from the kernel name
                 outfile = kernel.path.replace("vmlinuz-", "initrd-") + ".img"
             logger.info("rebuilding %s", outfile)
+            logger.info("dracut warnings about /proc are safe to ignore")
+
             if backup:
                 initrd = joinpaths(self.vars.inroot, outfile)
                 if os.path.exists(initrd):


### PR DESCRIPTION
Creating /proc/modules just quiets one dracut warning, it doesn't
actually effect the initrd that is created.

Now that mock is being run with netsharedpath set to exclude /proc is
causes problems for running lorax inside a mock, so just remove this to
prevent a crash when it doesn't exist.

Related: rhbz#1848201