### PR TITLE
Fix EFI booting for ISOs generated by `mkksiso`

### DIFF
--- a/src/sbin/mkksiso
+++ b/src/sbin/mkksiso
@@ -279,7 +279,7 @@ class Xorrisofs_aarch64(MakeISOTool):
                "-R", "-J", "-V", volume_name]
         if log.root.level < log.INFO:
             cmd.append("--verbose")
-        if efimode == EFIBOOT:
+        if efimode >= EFIBOOT:
             cmd.extend(["-eltorito-alt-boot", "-e", "images/efiboot.img", "-no-emul-boot"])
         if efimode == MACBOOT:
             cmd.extend(["-eltorito-alt-boot", "-e", "images/macboot.img", "-no-emul-boot"])
@@ -348,7 +348,7 @@ class Xorrisofs_x86_64(MakeISOTool):
                "-boot-load-size", "4", "-boot-info-table", "-no-emul-boot"]
         if log.root.level < log.INFO:
             cmd.append("--verbose")
-        if efimode == EFIBOOT:
+        if efimode >= EFIBOOT:
             cmd.extend(["-eltorito-alt-boot", "-e", "images/efiboot.img", "-no-emul-boot", "-isohybrid-gpt-basdat"])
         if efimode == MACBOOT:
             cmd.extend(["-eltorito-alt-boot", "-e", "images/macboot.img", "-no-emul-boot", "-isohybrid-gpt-hfsplus"])


### PR DESCRIPTION
If the original ISO contains both `efiboot.img` and `macboot.img`,
the current `xorrisofs` invocation does not configure `efiboot.img`
to be bootable, only `macboot.img`.

This fix uses `>=` to compare `efimode` against `EFIBOOT`, since
`MACBOOT` implies `EFIBOOT` as well.

This is similar to the logic for `mkisofs`.

Fixes #1046.

Generated image confirmed to work, when comparing the reports:

  `xorriso -indev $PATH_TO_ISO -report_el_torito cmd`

```
❯ diff -u ~/xorriso-report-{orig,new}.log
--- /home/michel/xorriso-report-orig.log        2020-07-15 20:01:01.405289018 -0700
+++ /home/michel/xorriso-report-new.log 2020-07-15 20:01:19.183555423 -0700
@@ -1,6 +1,6 @@
--volid 'Fedora-S-dvd-x86_64-32'
--volume_date uuid '2020042219432600'
--boot_image isolinux system_area=--interval:imported_iso:0s-15s:zero_mbrpt,zero_gpt:'/home/michel/Downloads/Fedora-Server-netinst-x86_64-32-1.6.iso'
+-volid 'Fedora-32-btrfs'
+-volume_date uuid '2020071602410900'
+-boot_image isolinux system_area=--interval:imported_iso:0s-15s:zero_mbrpt,zero_gpt:'/home/michel/src/github/michel-slm/luks-kickstarts/iso/Fedora-32-WS-20200715-3.iso'
 -boot_image any partition_cyl_align=on
 -boot_image any partition_offset=0
 -boot_image any partition_hd_cyl=64
@@ -14,12 +14,6 @@
 -boot_image any load_size=2048
 -boot_image any boot_info_table=on
 -boot_image any next
--boot_image any efi_path='/images/efiboot.img'
--boot_image any platform_id=0xef
--boot_image any emul_type=no_emulation
--boot_image any load_size=11462656
--boot_image isolinux partition_entry=gpt_basdat
--boot_image any next
 -boot_image any efi_path='/images/macboot.img'
 -boot_image any platform_id=0xef
 -boot_image any emul_type=no_emulation
```

```
❯ diff -u ~/xorriso-report-{orig,new5}.log
--- /home/michel/xorriso-report-orig.log        2020-07-15 20:01:01.405289018 -0700
+++ /home/michel/xorriso-report-new5.log        2020-07-15 20:30:27.571644770 -0700
@@ -1,6 +1,6 @@
--volid 'Fedora-S-dvd-x86_64-32'
--volume_date uuid '2020042219432600'
--boot_image isolinux system_area=--interval:imported_iso:0s-15s:zero_mbrpt,zero_gpt:'/home/michel/Downloads/Fedora-Server-netinst-x86_64-32-1.6.iso'
+-volid 'Fedora-32-btrfs'
+-volume_date uuid '2020071603283100'
+-boot_image isolinux system_area=--interval:imported_iso:0s-15s:zero_mbrpt,zero_gpt:'./iso/Fedora-32-WS-20200715-5.iso'
 -boot_image any partition_cyl_align=on
 -boot_image any partition_offset=0
 -boot_image any partition_hd_cyl=64
@@ -17,7 +17,7 @@
 -boot_image any efi_path='/images/efiboot.img'
 -boot_image any platform_id=0xef
 -boot_image any emul_type=no_emulation
--boot_image any load_size=11462656
+-boot_image any load_size=11460608
 -boot_image isolinux partition_entry=gpt_basdat
 -boot_image any next
 -boot_image any efi_path='/images/macboot.img'
```

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weldr/lorax/1047)
<!-- Reviewable:end -->
