### PR TITLE
Install weak dependencies of anaconda-install-env-deps

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -103,6 +103,9 @@ installpkg xfsdump
 ## extra storage packages
 # hostname is needed for iscsi to work, see RHBZ#1593917
 installpkg udisks2 udisks2-iscsi hostname
+%if basearch in ("i386", "x86_64"):
+    installpkg fcoe-utils
+%endif
 
 ## extra libblockdev plugins
 installpkg libblockdev-lvm-dbus

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -111,6 +111,9 @@ installpkg libblockdev-lvm-dbus
 installpkg volume_key
 installpkg nss-tools
 
+## enable swap on zram
+installpkg zram-generator-defaults
+
 ## SELinux support
 installpkg selinux-policy-targeted audit
 


### PR DESCRIPTION
It looks like lorax doesn't install weak dependencies of anaconda-install-env-deps
on the boot.iso, so let's install these packages explicitly.

Related changes:
https://fedoraproject.org/wiki/Changes/SwapOnZRAM
https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD