### PR TITLE
tests: Disable non-cli test scenarios b/c osbuild-composer

### DIFF
--- a/test/check-api
+++ b/test/check-api
@@ -1,9 +1,13 @@
 #!/usr/bin/python3
 
+import unittest
+
 import composertest
 import requests
 import subprocess
 
+
+@unittest.skip("API is now tested by osbuild-composer test suite")
 class TestApi(composertest.ComposerTestCase):
     """Test Composer HTTP API"""
 

--- a/test/check-cli
+++ b/test/check-cli
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+import unittest
+
 import tempfile
 import composertest
 
@@ -20,13 +22,16 @@ class TestImages(composertest.ComposerTestCase):
     def test_compose_sanity(self):
         self.runCliTest("/tests/cli/test_compose_sanity.sh")
 
+    @unittest.skip("Image building is now tested by osbuild-composer test suite")
     def test_ext4_filesystem(self):
         self.runCliTest("/tests/cli/test_compose_ext4-filesystem.sh")
 
+    @unittest.skip("Image building is now tested by osbuild-composer test suite")
     def test_partitioned_disk(self):
         self.runCliTest("/tests/cli/test_compose_partitioned-disk.sh")
 
 
+@unittest.skip("Image building is now tested by osbuild-composer test suite")
 class TestQcow2(composertest.ComposerTestCase):
     def tearDown(self):
         super().tearDownTestMachine()
@@ -52,6 +57,7 @@ class TestQcow2(composertest.ComposerTestCase):
             self.runImageTest("/tests/cli/test_boot_qcow2.sh")
 
 
+@unittest.skip("Image building is now tested by osbuild-composer test suite")
 class TestLiveIso(composertest.ComposerTestCase):
     def tearDown(self):
         super().tearDownTestMachine()
@@ -73,11 +79,13 @@ class TestLiveIso(composertest.ComposerTestCase):
             self.runImageTest("/tests/cli/test_boot_live-iso.sh")
 
 
+@unittest.skip("Image building is now tested by osbuild-composer test suite")
 class TestRepos(composertest.ComposerTestCase):
     def test_repos_sanity(self):
         self.runCliTest("/tests/cli/test_repos_sanity.sh")
 
 
+@unittest.skip("Image building is now tested by osbuild-composer test suite")
 class TestTar(composertest.ComposerTestCase):
     def test_tar(self):
         self.runCliTest("/tests/cli/test_compose_tar.sh")

--- a/test/check-cloud
+++ b/test/check-cloud
@@ -1,8 +1,11 @@
 #!/usr/bin/python3
 
+import unittest
+
 import composertest
 
 
+@unittest.skip("Image building is now tested by osbuild-composer test suite")
 class TestCloud(composertest.ComposerTestCase):
     def test_alibaba(self):
         self.runCliTest("/tests/cli/test_compose_alibaba.sh")

--- a/test/run
+++ b/test/run
@@ -5,19 +5,9 @@
 make vm
 
 if [ -n "$TEST_SCENARIO" ]; then
-  if [ "$TEST_SCENARIO" == "live-iso" ]; then
-    test/check-cli TestLiveIso
-  elif [ "$TEST_SCENARIO" == "qcow2" ]; then
-    test/check-cli TestQcow2
-  elif [ "$TEST_SCENARIO" == "tar" ]; then
-    test/check-cli TestTar
-  elif [ "$TEST_SCENARIO" == "lorax" ]; then
+  if [ "$TEST_SCENARIO" == "lorax" ]; then
     test/check-lorax TestLorax
-  else
-    test/check-cloud TestCloud.test_$TEST_SCENARIO
   fi
 else
   test/check-cli TestImages
-  test/check-api
-  test/check-cli TestRepos
 fi


### PR DESCRIPTION
the image building functionality is now tested by the
osbuild-composer test suite. We weren't successfull at making this
test suite work with the 2 backends so decided to disabled these
scenarios instead. In the future they will likely be deleted.


Proposing this PR instead of #1007 and #1049 after talking yesterday with Brian. The idea here is to disable as much as possible (I am still leaving the cli scenarios) and then work downstream to rely on reverse dependency gating tests to cover composer-cli. 

@bcl maybe we'd like to split composer-cli into a separate repo/package at some point. 

@larskarlitski should I go ahead and remove all of the disabled scenarios from `testmap.py` as well ?