### PR TITLE
test: Don't upgrade pip packages

### DIFF
--- a/tests/cli/test_build_and_deploy_aws.sh
+++ b/tests/cli/test_build_and_deploy_aws.sh
@@ -45,7 +45,7 @@ rlJournalStart
         rlRun -t -c "virtualenv $VENV"
         source $VENV/bin/activate
 
-        rlRun -t -c "pip install --upgrade pip setuptools"
+        rlRun -t -c "pip install pip setuptools"
         rlRun -t -c "pip install awscli"
 
         # aws configure

--- a/tests/cli/test_build_and_deploy_azure.sh
+++ b/tests/cli/test_build_and_deploy_azure.sh
@@ -62,7 +62,7 @@ rlJournalStart
         rlRun -t -c "virtualenv $VENV"
         source $VENV/bin/activate
 
-        rlRun -t -c "pip install --upgrade pip setuptools"
+        rlRun -t -c "pip install pip setuptools"
         rlRun -t -c "pip install ansible[azure] futures"
     rlPhaseEnd
 

--- a/tests/cli/test_build_and_deploy_openstack.sh
+++ b/tests/cli/test_build_and_deploy_openstack.sh
@@ -48,7 +48,7 @@ rlJournalStart
         rlRun -t -c "virtualenv $VENV"
         source $VENV/bin/activate
 
-        rlRun -t -c "pip install --upgrade pip setuptools"
+        rlRun -t -c "pip install pip setuptools"
         rlRun -t -c "pip install ansible openstacksdk future"
     rlPhaseEnd
 

--- a/tests/cli/test_build_and_deploy_vmware.sh
+++ b/tests/cli/test_build_and_deploy_vmware.sh
@@ -60,7 +60,7 @@ rlJournalStart
         rlRun -t -c "virtualenv $VENV"
         source $VENV/bin/activate
 
-        rlRun -t -c "pip install --upgrade pip setuptools"
+        rlRun -t -c "pip install pip setuptools"
         rlRun -t -c "pip install pyvmomi"
 
         TMP_DIR=`mktemp -d /tmp/composer-vmware.XXXXX`


### PR DESCRIPTION
See https://github.com/cockpit-project/bots/pull/1115

As per comment `...but since py2.7 is dead it's probably not a good idea to upgrade it`.

Lets see if this was the problem or not really.