### PR TITLE
sshd_config: Apply suggested changes

### DIFF
--- a/share/templates.d/99-generic/config_files/common/sshd_config.anaconda
+++ b/share/templates.d/99-generic/config_files/common/sshd_config.anaconda
@@ -1,14 +1,8 @@
-Port 22
 PermitRootLogin yes
-IgnoreRhosts yes
-StrictModes yes
 X11Forwarding yes
 X11DisplayOffset 10
 PrintMotd yes
-XAuthLocation /bin/xauth
-KeepAlive yes
 SyslogFacility AUTHPRIV
-RSAAuthentication yes
 PasswordAuthentication yes
 PermitEmptyPasswords yes
 PermitUserEnvironment yes


### PR DESCRIPTION
Some of the options have been removed, others are now the default.
 MOTD still needs to be printed, the boot environment doesn't include the pam motd module.

Resolves: rhbz#1872892