### PR TITLE
templates: Ensure nano is installed for the runtime environment

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -180,6 +180,7 @@ installpkg fpaste
 installpkg python3-pyatspi
 
 ## extra tools not required by anaconda
+installpkg nano nano-default-editor
 installpkg vim-minimal strace lsof dump xz less
 installpkg wget rsync bind-utils ftp mtr vconfig
 installpkg icfg spice-vdagent


### PR DESCRIPTION
The expectation is that all environments where an editor might be
used should ship GNU nano by default and tools should activate it
when an "editor" is requested. This change should ensure that for
the install media runtime environment.

Reference: https://fedoraproject.org/wiki/Changes/UseNanoByDefault

Resolves: [rhbz#1874094](https://bugzilla.redhat.com/show_bug.cgi?id=1874094)