### PR TITLE
docs: Remove anaconda from rhel-livemedia.ks example

### DIFF
--- a/docs/rhel-livemedia.ks
+++ b/docs/rhel-livemedia.ks
@@ -1,6 +1,7 @@
 # Live ISO Image
 # NOTE: This example is for creating a live-iso, eg.
-# livemedia-creator --project RHEL --releasever 8 --make-iso --ks=rhel-livemedia.ks --no-virt
+#       livemedia-creator --project RHEL --releasever 8 --make-iso --ks=rhel-livemedia.ks --no-virt
+# NOTE: This example does not include Anaconda and cannot be installed to a harddrive.
 
 # X Window System configuration information
 xconfig  --startxonboot
@@ -393,8 +394,6 @@ EOF
 firefox
 gnome-terminal
 aajohan-comfortaa-fonts
-anaconda
-anaconda-live
 dracut-config-generic
 dracut-live
 glibc-all-langpacks


### PR DESCRIPTION
Anaconda no longer includes the liveinst script in the core package.
This means the live iso will just be a live desktop, not a live
installer.

Resolves: rhbz#1876563