### PR TITLE
Also remove .opt-1.pyc and .opt-2.pyc, not just .pyo

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -353,6 +353,7 @@ removefrom ${product.name}-logos /usr/share/{firstboot,gnome-screensaver,kde4,pi
 
 ## cleanup_python_files()
 runcmd find ${root} -name "*.pyo" -type f -delete
+runcmd find ${root} -name "*.opt-?.pyc" -type f -delete
 runcmd find ${root} -name "*.pyc" -type f -exec ln -sf /dev/null {} \;
 
 ## cleanup /boot/ leaving vmlinuz, and .*hmac files


### PR DESCRIPTION
.pyo is for Python < 3.5 only.

cc @AdamWill could you include this in your testing?