### PR TITLE
runtime-cleanup: big refresh of stale things

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -10,7 +10,7 @@ remove usr/share/i18n
 ## perl is needed by /usr/bin/rxe_cfg from libibverbs
 
 ## no sound support, thanks
-removepkg flac gstreamer-tools libsndfile pulseaudio* sound-theme-freedesktop
+removepkg flac-libs libsndfile pulseaudio* sound-theme-freedesktop
 ## we don't create new initramfs/bootloader conf inside anaconda
 ## (that happens inside the target system after we install dracut/grubby)
 removepkg dracut-network grubby anaconda-dracut
@@ -22,7 +22,7 @@ removefrom dracut --allbut /usr/lib/dracut/modules.d/30convertfs/convertfs.sh \
                   /usr/lib/systemd/* /usr/lib/dracut/modules.d/98dracut-systemd/*.service \
                   /usr/lib/dracut/dracut-initramfs-restore
 ## we don't run SELinux (not in enforcing, anyway)
-removepkg checkpolicy selinux-policy libselinux-utils
+removepkg selinux-policy libselinux-utils
 
 ## selinux checks for the /etc/selinux/config file's existance
 ## The removepkg above removes it, create an empty one. See rhbz#1243168
@@ -34,18 +34,11 @@ removepkg fedora-release-rawhide
 removefrom shadow-utils --allbut /usr/bin/chage /usr/sbin/chpasswd \
                         /usr/sbin/groupadd /usr/sbin/useradd
 
-## remove other account management tools
-removepkg usermode usermode-gtk passwd
 ## no services to turn on/off (keep the /etc/init.d link though)
-removepkg chkconfig
 removefrom initscripts /usr/sbin/* /usr/share/locale/* /usr/share/doc/* /usr/share/man/*
 
-## Miscellanous unnecessary gpg program
-removepkg pinentry
 ## no storage device monitoring
 removepkg device-mapper-event dmraid-events sgpio
-## no notifications in anaconda
-removepkg notification-daemon
 ## logrotate isn't useful in anaconda
 removepkg logrotate
 remove /etc/logrotate.d
@@ -54,19 +47,19 @@ removefrom isomd5sum --allbut /usr/bin/checkisomd5
 
 ## systemd-nspawn isn't very useful and doesn't link anyway without iptables,
 ## and there's no need for a bunch of zsh files without zsh
-removefrom systemd /usr/bin/systemd-nspawn /usr/share/zsh
+removefrom systemd /usr/share/zsh/site-functions/*
 
 ## various other things we remove to save space
-removepkg avahi-autoipd coreutils-libs dash db4-utils diffutils file
-removepkg genisoimage info iptables
-removepkg jasper-libs libXxf86misc
-removepkg libasyncns libhbaapi libhbalinux
-removepkg libmcpp libtiff linux-atm-libs
-removepkg lvm2-libs m4 mailx makebootfat mcpp
-removepkg mingetty mobile-broadband-provider-info pkgconfig ppp pth
+removepkg diffutils file
+removepkg jasper-libs
+removepkg libasyncns
+removepkg libmcpp libtiff
+removepkg lvm2-libs mcpp
+removepkg mobile-broadband-provider-info
+removepkg pkgconf pkgconf-m4 pkgconf-pkg-config ppp pth
 removepkg rmt rpcbind squashfs-tools system-config-firewall-base
-removepkg tigervnc-license ttmkfdir xml-common xorg-x11-font-utils
-removepkg xorg-x11-server-common yum-utils firewalld
+removepkg tigervnc-license xml-common xorg-x11-font-utils
+removepkg xorg-x11-server-common
 
 ## other removals
 remove /home /media /opt /srv /tmp/*
@@ -96,10 +89,13 @@ removekmod sound drivers/media drivers/hwmon \
            arch/x86/kvm
 ## Need to keep virtio_console.ko and ipmi stuff in drivers/char
 ## Also keep virtio-rng so that the installer can get sufficient randomness for
-## LUKS setup.
+## LUKS setup. As of 2020-09 this is not built as a module, but keep it in here
+## in case that changes again
 removekmod drivers/char --allbut virtio_console hw_random \
                                   virtio-rng ipmi hmcdrv
 removekmod drivers/hid --allbut hid-logitech-dj hid-logitech-hidpp
+
+## As of 2020-09 most of this are built-in too, but again, keep them listed
 removekmod drivers/video --allbut hyperv_fb syscopyarea sysfillrect sysimgblt fb_sys_fops
 remove lib/modules/*/{build,source,*.map}
 ## NOTE: depmod gets re-run after cleanup finishes
@@ -117,29 +113,21 @@ removefrom xfsprogs /usr/share/locale/* /usr/share/doc/* /usr/share/man/*
 removefrom xfsdump --allbut /usr/sbin/*
 
 ## other package specific removals
-removefrom GConf2 /etc/rpm/* /etc/xdg/* /usr/bin/*
-removefrom GConf2 /usr/${libdir}/GConf/2/libgconfbackend-{evoldap,oldxml}*
-removefrom GConf2 /usr/${libdir}/gio/modules/*
-removefrom GConf2 /usr/libexec/gconf-defaults-mechanism /usr/share/GConf/*
-removefrom GConf2 /usr/share/locale/* /usr/share/sgml/*
-removefrom NetworkManager /usr/share/NetworkManager/*
-removefrom NetworkManager /usr/share/locale/*/NetworkManager.mo
-removefrom nm-connection-editor /usr/${libdir}/*
+removefrom gsettings-desktop-schemas /usr/share/locale/*
+removefrom NetworkManager-libnm /usr/share/locale/*/NetworkManager.mo
 removefrom nm-connection-editor /usr/share/applications/*
-removefrom anaconda /etc/* /usr/share/applications/* /usr/share/icons/*
 removefrom atk /usr/share/locale/*
-removefrom audit /etc/* /sbin/audispd /sbin/auditctl /sbin/aureport
+removefrom audit /etc/* /sbin/auditctl /sbin/aureport
 removefrom audit /sbin/ausearch /sbin/autrace /usr/bin/*
 removefrom audit-libs /etc/* /${libdir}/libauparse*
-removefrom authconfig /usr/sbin/* /usr/share/*
 removefrom bash /etc/* /usr/bin/bashbug* /usr/share/*
 removefrom bind-utils /usr/bin/host /usr/bin/nsupdate
 removefrom bitmap-fangsongti-fonts /usr/share/fonts/*
 removefrom ca-certificates /etc/pki/java/*
-removefrom ca-certificates /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/*
+removefrom ca-certificates /etc/pki/tls/certs/ca-bundle.trust.crt
 removefrom cairo /usr/${libdir}/libcairo-script* /usr/bin/cairo-sphinx
-removefrom coreutils /etc/* /usr/bin/link /usr/bin/nice /usr/bin/stty /usr/bin/su /usr/bin/unlink
-removefrom coreutils /usr/sbin/runuser /usr/bin/[ /usr/bin/base64 /usr/bin/chcon
+removefrom coreutils /usr/bin/link /usr/bin/nice /usr/bin/stty /usr/bin/unlink
+removefrom coreutils /usr/bin/[ /usr/bin/base64 /usr/bin/chcon
 removefrom coreutils /usr/bin/cksum /usr/bin/csplit
 removefrom coreutils /usr/bin/dir /usr/bin/dircolors
 removefrom coreutils /usr/bin/expand /usr/bin/factor
@@ -154,92 +142,71 @@ removefrom coreutils /usr/bin/sha512sum /usr/bin/shuf /usr/bin/stat
 removefrom coreutils /usr/bin/stdbuf /usr/bin/sum /usr/bin/test
 removefrom coreutils /usr/bin/timeout /usr/bin/truncate /usr/bin/tsort
 removefrom coreutils /usr/bin/unexpand /usr/bin/users /usr/bin/vdir
-removefrom coreutils /usr/bin/who /usr/bin/whoami /usr/bin/yes /usr/share/*
+removefrom coreutils /usr/bin/who /usr/bin/whoami /usr/bin/yes
+removefrom coreutils-common /etc/* /usr/share/*
 removefrom cpio /usr/share/*
 removefrom cracklib /usr/sbin/*
 removefrom cracklib-dicts /usr/${libdir}/* /usr/sbin/*
-removefrom cryptsetup-luks /usr/share/*
+removefrom cryptsetup /usr/share/*
+removefrom cryptsetup-libs /usr/share/locale/*
 removefrom cyrus-sasl-lib /usr/sbin/*
-removefrom db4 /usr/*
-removefrom dbus-glib /usr/bin/*
 removefrom dbus-x11 /etc/X11/*
 removefrom dejavu-sans-fonts --allbut *.conf */DejaVuSans{,-Bold}.ttf
 removefrom dejavu-sans-mono-fonts --allbut *.conf */DejaVuSansMono.ttf
-removefrom dhclient /usr/lib/* /usr/share/*
-removefrom dnsmasq /etc/rc.d/* /usr/sbin/*
+removefrom dnf /usr/share/locale/*
 removefrom dump /etc/*
 removefrom elfutils-libelf /usr/share/locale/*
 removefrom expat /usr/bin/*
-removefrom fcoe-utils /etc/rc.d/* /usr/libexec/fcoe/dcbcheck.sh
+removefrom fcoe-utils /usr/libexec/fcoe/dcbcheck.sh
 removefrom fcoe-utils /usr/libexec/fcoe/fcc.sh /usr/libexec/fcoe/fcoe-setup.sh
 removefrom fcoe-utils /usr/libexec/fcoe/fcoedump.sh /usr/sbin/fcnsq
 removefrom fcoe-utils /usr/sbin/fcoeadm /usr/sbin/fcping /usr/sbin/fcrls
 removefrom file-libs /usr/share/*
-removefrom findutils /usr/bin/oldfind /usr/share/*
+removefrom findutils /usr/share/*
 removefrom fontconfig /usr/bin/*
-removefrom gawk /usr/bin/{igawk,pgawk} /usr/libexec/* /usr/share/*
-removefrom gdb /usr/share/* /usr/include/* /etc/gdbinit*
+removefrom gawk /usr/libexec/* /usr/share/*
+removefrom gdb /usr/share/* /usr/include/*
+removefrom gdb-headless /usr/share/* /etc/gdbinit*
 removefrom gdisk /usr/share/*
 removefrom gdk-pixbuf2 /usr/share/locale*
 removefrom gfs2-utils /usr/sbin/*
-removefrom glib2 /etc/* /usr/bin/* /usr/share/locale/*
-removefrom glibc /etc/gai.conf /etc/localtime /etc/rpc
-removefrom glibc /lib/*/nosegneg/* /${libdir}/libBrokenLocale*
+removefrom glib2 /usr/bin/* /usr/share/locale/*
+removefrom glibc /etc/gai.conf /etc/rpc
+removefrom glibc /${libdir}/libBrokenLocale*
 removefrom glibc /${libdir}/libSegFault* /${libdir}/libanl*
-removefrom glibc /${libdir}/libcidn* /${libdir}/libnss_compat*
-removefrom glibc /${libdir}/libnss_hesiod* /${libdir}/libnss_nis*
+removefrom glibc /${libdir}/libnss_compat*
 # python-pyudev uses ctypes.util.find_library, which uses /sbin/ldconfig
-removefrom glibc /${libdir}/rtkaio* /sbin/sln
 removefrom glibc /usr/libexec/* /usr/sbin/*
-removefrom glibc-common /etc/* /usr/bin/catchsegv /usr/bin/gencat
+removefrom glibc-common /usr/bin/catchsegv /usr/bin/gencat
 removefrom glibc-common /usr/bin/getent
-removefrom glibc-common /usr/bin/locale /usr/bin/rpcgen /usr/bin/sprof
+removefrom glibc-common /usr/bin/locale /usr/bin/sprof
 # NB: we keep /usr/bin/localedef so anaconda can inspect payload locale info
 removefrom glibc-common /usr/bin/tzselect
-removefrom glibc-common /usr/libexec/* /usr/sbin/*
-removefrom gmp /usr/${libdir}/libgmpxx.* /usr/${libdir}/libmp.*
-removefrom gnome-bluetooth-libs /usr/${libdir}/libgnome-bluetooth*
-removefrom gnome-bluetooth-libs /usr/share/*
+removefrom glibc-common /usr/sbin/*
 removefrom gnutls /usr/share/locale/*
 removefrom google-noto-sans-cjk-ttc-fonts /usr/share/fonts/google-noto-cjk/NotoSansCJK-{Black,Bold,*Light,Medium,Thin}.ttc
 removefrom grep /etc/* /usr/share/locale/*
-removefrom gstreamer /usr/bin/* /usr/${libdir}/gstreamer-0.10/*
-removefrom gstreamer /usr/${libdir}/libgst* /usr/libexec/* /usr/share/locale/*
 removefrom gtk2 /usr/bin/update-gtk-immodules
 removefrom gtk3 /usr/${libdir}/gtk-3.0/*
 removefrom gzip /usr/bin/{gzexe,zcmp,zdiff,zegrep,zfgrep,zforce,zgrep,zless,zmore,znew}
-removefrom hwdata /etc/* /usr/share/hwdata/oui.txt /usr/share/hwdata/pnp.ids
-removefrom hwdata /usr/share/hwdata/upgradelist
+removefrom hwdata /usr/share/hwdata/oui.txt /usr/share/hwdata/pnp.ids
 removefrom iproute --allbut /usr/sbin/{ip,routef,routel,rtpr}
-removefrom iscsi-initiator-utils /etc/rc.d/*
 removefrom kbd --allbut */bin/{dumpkeys,kbd_mode,loadkeys,setfont,unicode_*,chvt}
+removefrom kmod /usr/sbin/weak-modules
 removefrom less /etc/*
 removefrom libX11-common /usr/share/X11/XErrorDB
-removefrom libbonobo /etc/* /usr/bin/* /usr/sbin/* /usr/share/locale/*
-removefrom libbonobo /usr/${libdir}/bonobo/monikers/*
-removefrom libbonobo /usr/${libdir}/orbit-2.0/Bonobo_module.so
 removefrom libcanberra /usr/${libdir}/libcanberra-*
-removefrom libcanberra-gtk2 /usr/${libdir}/gtk-2.0/*
 removefrom libcanberra-gtk3 /usr/bin/*
 removefrom libcap /usr/sbin/*
 removefrom libconfig /usr/${libdir}/libconfig++*
-removefrom libcroco /usr/bin/*
-removefrom libgnome-keyring /usr/share/locale/*
-removefrom libgnomecanvas /usr/share/locale/*
 removefrom libgpg-error /usr/bin/* /usr/share/locale/*
-removefrom libgssglue /etc/*
-removefrom libidn /usr/bin/* /usr/share/locale/*
-removefrom libmlx4 /etc/rdma/* /usr/${libdir}/*
+removefrom libibverbs /usr/${libdir}/libmlx4*
+removefrom libidn2 /usr/share/locale/*
 removefrom libnotify /usr/bin/*
-removefrom librsvg2 /usr/bin/*
-removefrom libselinux /usr/sbin/*
 removefrom libsemanage /etc/selinux/*
 removefrom libstdc++ /usr/share/*
-removefrom libuser /usr/bin/* /usr/sbin/* /usr/share/locale/*
 removefrom libvorbis /usr/${libdir}/libvorbisenc.*
 removefrom libxml2 /usr/bin/*
-removefrom libxml2-python /usr/${libdir}/python?.?/site-packages/libxml2mod.a
-removefrom libxml2-python /usr/${libdir}/python?.?/site-packages/libxml2mod.la
 removefrom linux-firmware /usr/lib/firmware/dvb*
 removefrom linux-firmware /usr/lib/firmware/*_12mhz*
 removefrom linux-firmware /usr/lib/firmware/v4l*
@@ -267,16 +234,10 @@ removefrom linux-firmware /usr/lib/firmware/as102*
 removefrom linux-firmware /usr/lib/firmware/qcom/venus*/*
 removefrom linux-firmware /usr/lib/firmware/meson/vdec/*
 removefrom lldpad /etc/*
-removefrom lua /usr/bin/*
-removefrom madan-fonts /usr/share/fonts/madan/*
 removefrom mdadm /etc/*
 removefrom mesa-dri-drivers /usr/${libdir}/dri/*_video.so
-removefrom module-init-tools /etc/* /usr/sbin/insmod.static /usr/sbin/weak-modules
-removefrom mt-st /etc/* /usr/sbin/*
+removefrom mt-st /usr/sbin/*
 removefrom mtools /etc/*
-removefrom ncurses /usr/bin/captoinfo /usr/bin/infocmp /usr/bin/infotocap
-removefrom ncurses /usr/bin/reset /usr/bin/tabs /usr/bin/tic /usr/bin/toe
-removefrom ncurses /usr/bin/tput /usr/bin/tset
 removefrom ncurses-libs /usr/${libdir}/libform*
 ## libmenu.so is needed by lp_diag binary from ppc64-diag which is a PowerPC specific package
 %if basearch not in ("ppc64le"):
@@ -287,49 +248,43 @@ removefrom net-tools */bin/netstat */sbin/ether-wake */sbin/ipmaddr
 removefrom net-tools */sbin/iptunnel */sbin/mii-diag */sbin/mii-tool
 removefrom net-tools */sbin/nameif */sbin/plipconfig */sbin/slattach
 removefrom net-tools /usr/share/locale/*
-removefrom newt /usr/share/locale/*
 removefrom nfs-utils /etc/nfsmount.conf
-removefrom nfs-utils /etc/rc.d/init.d/* /lib/systemd/system/*
-removefrom nfs-utils /etc/sysconfig/nfs /sbin/rpc.statd /usr/sbin/exportfs
-removefrom nfs-utils /usr/sbin/gss_clnt_send_err /usr/sbin/gss_destroy_creds
+removefrom nfs-utils /usr/lib/systemd/system/*
+removefrom nfs-utils /sbin/rpc.statd /usr/sbin/exportfs
 removefrom nfs-utils /usr/sbin/mountstats /usr/sbin/nfsiostat
 removefrom nfs-utils /usr/sbin/nfsstat /usr/sbin/rpc.gssd /usr/sbin/rpc.idmapd
 removefrom nfs-utils /usr/sbin/rpc.mountd /usr/sbin/rpc.nfsd
-removefrom nfs-utils /usr/sbin/rpc.svcgssd /usr/sbin/rpcdebug
+removefrom nfs-utils /usr/sbin/rpcdebug
 removefrom nfs-utils /usr/sbin/showmount /usr/sbin/sm-notify
 removefrom nfs-utils /usr/sbin/start-statd /var/lib/nfs/etab
-removefrom nfs-utils /var/lib/nfs/rmtab /var/lib/nfs/state /var/lib/nfs/xtab
+removefrom nfs-utils /var/lib/nfs/rmtab /var/lib/nfs/statd/state
 removefrom nss-softokn /usr/${libdir}/nss/*
 removefrom openldap /etc/openldap/* /usr/${libdir}/libldap_r-*
 removefrom openssh /usr/libexec/*
 removefrom openssh-clients /etc/ssh/* /usr/bin/ssh-*
 removefrom openssh-clients /usr/libexec/*
 removefrom openssh-server /etc/ssh/* /usr/libexec/openssh/sftp-server
-removefrom openssl /etc/pki/* /usr/bin/* /usr/${libdir}/openssl/*
+removefrom openssl /usr/bin/*
 removefrom pam /usr/sbin/* /usr/share/locale/*
 removefrom policycoreutils /etc/* /usr/bin/* /usr/share/locale/*
 removefrom polkit /usr/bin/*
-removefrom polkit-desktop-policy /var/lib/*
 removefrom popt /usr/share/locale/*
-removefrom procps /usr/bin/free /usr/bin/pgrep /usr/bin/pkill
-removefrom procps /usr/bin/pmap /usr/bin/pwdx /usr/bin/skill /usr/bin/slabtop
-removefrom procps /usr/bin/snice /usr/bin/tload /usr/bin/uptime
-removefrom procps /usr/bin/vmstat /usr/bin/w /usr/bin/watch
+removefrom procps-ng /usr/bin/free /usr/bin/pgrep /usr/bin/pkill
+removefrom procps-ng /usr/bin/pmap /usr/bin/pwdx /usr/bin/skill /usr/bin/slabtop
+removefrom procps-ng /usr/bin/snice /usr/bin/tload /usr/bin/uptime
+removefrom procps-ng /usr/bin/vmstat /usr/bin/w /usr/bin/watch
 removefrom psmisc /usr/share/locale/*
-removefrom pygtk2 /usr/bin/* /usr/${libdir}/pygtk/*
-removefrom pykickstart /usr/bin/* /usr/share/locale/*
+removefrom python3-kickstart /usr/lib/python*/site-packages/pykickstart/locale/*
 removefrom readline /usr/${libdir}/libhistory*
-removefrom libreport /usr/bin/* /usr/share/locale/*
+removefrom libreport /usr/share/locale/*
+removefrom libreport-cli /usr/bin/*
+removefrom rdma-core /etc/rdma/mlx4.conf
 removefrom rpm /usr/bin/* /usr/share/locale/*
 removefrom rsync /etc/*
 removefrom sed /usr/share/locale/*
 removefrom smartmontools /etc/* /usr/sbin/smartd
 removefrom smartmontools /usr/sbin/update-smart-drivedb
 removefrom smartmontools /usr/share/smartmontools/*
-removefrom sqlite /usr/bin/*
-removefrom system-config-date /etc/* /usr/bin/* /usr/share/icons/*
-removefrom system-config-keyboard /etc/* /usr/bin/* /usr/share/icons/*
-removefrom sysvinit-tools /usr/bin/*
 removefrom tar /usr/share/locale/*
 removefrom usbutils /usr/bin/*
 removefrom util-linux --allbut \
@@ -342,14 +297,12 @@ removefrom volume_key-libs /usr/share/locale/*
 removefrom wget /etc/* /usr/share/locale/*
 removefrom xorg-x11-drv-intel /usr/${libdir}/libI*
 removefrom xorg-x11-drv-openchrome /usr/${libdir}/libchrome*
-removefrom xorg-x11-drv-synaptics /usr/bin/*
 removefrom xorg-x11-drv-wacom /usr/bin/*
 removefrom xorg-x11-fonts-misc --allbut /usr/share/X11/fonts/misc/{6x13,encodings,fonts,*cursor}*
 removefrom xorg-x11-server-utils --allbut /usr/bin/xrandr /usr/bin/xrdb
-removefrom yum /etc/* /usr/share/locale/* /usr/share/yum-cli/*
 removefrom ${product.name}-logos /etc/*
 removefrom ${product.name}-logos /usr/share/icons/{Bluecurve,oxygen}/*
-removefrom ${product.name}-logos /usr/share/{firstboot,gnome-screensaver,kde4,pixmaps}/*
+removefrom ${product.name}-logos /usr/share/{firstboot,kde4,pixmaps}/*
 
 ## cleanup_python_files()
 runcmd find ${root} -name "*.pyo" -type f -delete

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -169,7 +169,6 @@ installpkg lohit-marathi-fonts
 installpkg lohit-odia-fonts
 installpkg lohit-tamil-fonts
 installpkg lohit-telugu-fonts
-installpkg madan-fonts
 installpkg paktype-naskh-basic-fonts
 installpkg sil-abyssinica-fonts
 installpkg sil-padauk-fonts


### PR DESCRIPTION
I based this on the output of a recent installer image build:
https://kojipkgs.fedoraproject.org/compose/branched/Fedora-33-20200904.n.0/logs/x86_64/buildinstall-Everything-logs/pylorax.log
I looked at every runtime-cleanup related error there and tried
to make appropriate changes. In many cases this means just
removing a line that isn't needed any more because the package
in question just went away or is no longer pulled into the
installer environment. In other cases packages changed name or
files moved around, and I tried to make appropriate updates. In
a few cases files moved to another package but I wasn't sure
enough it would still be safe to remove them so I just left them
in place. Most of the changes here I'm pretty sure should be
safe, though there *could* be unforeseen fallout from e.g. fixing
the removals from procps to be removals from procps-ng - it's
been years since that package was renamed, so something *could*
have started using those binaries in the meantime. I did at least
check that anaconda itself does not.

Signed-off-by: Adam Williamson <awilliam@redhat.com>