### PR TITLE
Drop firmware for Mellanox Spectrum

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -266,6 +266,7 @@ removefrom linux-firmware /usr/lib/firmware/intel/dsp*
 removefrom linux-firmware /usr/lib/firmware/as102*
 removefrom linux-firmware /usr/lib/firmware/qcom/venus*/*
 removefrom linux-firmware /usr/lib/firmware/meson/vdec/*
+removefrom linux-firmware /usr/lib/firmware/mellanox/mlxsw_spectrum*
 removefrom lldpad /etc/*
 removefrom lua /usr/bin/*
 removefrom madan-fonts /usr/share/fonts/madan/*


### PR DESCRIPTION
Mellanox Spectrum devices are switches intended for data centers.
It is I guess feasible that someone might want to install Fedora
on one, but from the product pages and data sheets, I believe
they all have management interfaces that do not require this
firmware to work, and that's what you'd use if you needed a
network connection during OS deployment. The firmware is only
needed for the actual switched interfaces, and we don't need to
make those work during installation.

Signed-off-by: Adam Williamson <awilliam@redhat.com>