### PR TITLE
Drop dpaa2 firmware on non-aarch64 arches

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -234,6 +234,9 @@ removefrom linux-firmware /usr/lib/firmware/as102*
 removefrom linux-firmware /usr/lib/firmware/qcom/venus*/*
 removefrom linux-firmware /usr/lib/firmware/meson/vdec/*
 removefrom linux-firmware /usr/lib/firmware/mellanox/mlxsw_spectrum*
+%if basearch != "aarch64":
+    removefrom linux-firmware /usr/lib/firmware/dpaa2/*
+%endif
 removefrom lldpad /etc/*
 removefrom mdadm /etc/*
 removefrom mesa-dri-drivers /usr/${libdir}/dri/*_video.so


### PR DESCRIPTION
AFAICS, the devices that need these firmwares - various boards
built by NXP, https://www.nxp.com - are all aarch64. So we don't
need to carry these firmware files in the installer env for other
arches.

Signed-off-by: Adam Williamson <awilliam@redhat.com>