### PR TITLE
Fix broken single-item tuples in a few places

### DIFF
--- a/share/templates.d/99-generic/live/live-install.tmpl
+++ b/share/templates.d/99-generic/live/live-install.tmpl
@@ -21,7 +21,7 @@
     installpkg biosdevname memtest86+ syslinux
     installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
 %endif
-%if basearch in ("ppc64le"):
+%if basearch == "ppc64le":
     installpkg powerpc-utils
     installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
     installpkg grub2-${basearch}

--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -280,7 +280,7 @@ removefrom ncurses /usr/bin/reset /usr/bin/tabs /usr/bin/tic /usr/bin/toe
 removefrom ncurses /usr/bin/tput /usr/bin/tset
 removefrom ncurses-libs /usr/${libdir}/libform*
 ## libmenu.so is needed by lp_diag binary from ppc64-diag which is a PowerPC specific package
-%if basearch not in ("ppc64le"):
+%if basearch != "ppc64le":
     removefrom ncurses-libs /usr/${libdir}/libmenu*
 %endif
 removefrom ncurses-libs /usr/${libdir}/libpanel.* /usr/${libdir}/libtic*

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -55,7 +55,7 @@ installpkg glibc-all-langpacks
     installpkg biosdevname memtest86+ syslinux
     installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
 %endif
-%if basearch in ("ppc64le"):
+%if basearch == "ppc64le":
     installpkg powerpc-utils lsvpd ppc64-diag
     installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
     installpkg grub2-${basearch}


### PR DESCRIPTION
When we stopped caring about ppc and ppc64, we changed several
instances of three-item tuples:

("ppc", "ppc64", "ppc64le")

into...this:

("ppc64le")

which is not a single item tuple, but just the string "ppc64le"
in some extraneous braces. It so happens that the right thing
still happened in all relevant cases , we think, but it's wrong.
There's no need to be using an iterator at all for a single
item, so just change them all to == "ppc64le" or != "ppc64le" as
appropriate.

Signed-off-by: Adam Williamson <awilliam@redhat.com>