### PR TITLE
Switch to using mutter as the window manager

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -171,7 +171,7 @@ removefrom gdb-headless /usr/share/* /etc/gdbinit*
 removefrom gdisk /usr/share/*
 removefrom gdk-pixbuf2 /usr/share/locale*
 removefrom gfs2-utils /usr/sbin/*
-removefrom glib2 /usr/bin/* /usr/share/locale/*
+removefrom glib2 /usr/share/locale/*
 removefrom glibc /etc/gai.conf /etc/rpc
 removefrom glibc /${libdir}/libBrokenLocale*
 removefrom glibc /${libdir}/libSegFault* /${libdir}/libanl*

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -91,9 +91,13 @@ installpkg rsyslog
 ## xorg/GUI packages
 installpkg xorg-x11-drivers xorg-x11-server-Xorg
 installpkg xorg-x11-server-utils xorg-x11-xauth
-installpkg dbus-x11 metacity gsettings-desktop-schemas
+installpkg dbus-x11 gsettings-desktop-schemas
 installpkg nm-connection-editor
 installpkg librsvg2
+
+## mutter and dependencies
+installpkg mutter
+installpkg gnome-settings-daemon
 
 ## filesystem tools
 installpkg btrfs-progs jfsutils xfsprogs reiserfs-utils gfs2-utils ntfs-3g ntfsprogs


### PR DESCRIPTION
mutter is the modern replacement for metacity, this installs the
required packages to use it for running Anaconda.

NOTE: This also requires a change to Anaconda to start mutter instead of
metacity.