### PR TITLE
Remove mdmonitor service from boot.iso

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -239,7 +239,7 @@ removefrom linux-firmware /usr/lib/firmware/mellanox/mlxsw_spectrum*
     removefrom linux-firmware /usr/lib/firmware/dpaa2/*
 %endif
 removefrom lldpad /etc/*
-removefrom mdadm /etc/*
+removefrom mdadm /etc/* /usr/lib/systemd/system/mdmonitor*
 removefrom mesa-dri-drivers /usr/${libdir}/dri/*_video.so
 removefrom mt-st /usr/sbin/*
 removefrom mtools /etc/*

--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -37,8 +37,6 @@ symlink /lib/systemd/system/rngd.service etc/systemd/system/basic.target.wants/r
 ## Disable unwanted systemd services
 systemctl disable systemd-readahead-collect.service \
                   systemd-readahead-replay.service \
-                  mdmonitor.service \
-                  mdmonitor-takeover.service \
                   lvm2-monitor.service \
                   dnf-makecache.timer
 ## These services can't be disabled normally (they're linked into place in


### PR DESCRIPTION
There's no reason for it to run, it can't notify anyone. But disabling
the service, or masking it, doesn't work so remove the service files
from the rootfs.

Resolves: rhbz#1888730