### PR TITLE
[RHEL7] Fix 'local variable 'rc' referenced before assignment'

### DIFF
--- a/src/pylorax/installer.py
+++ b/src/pylorax/installer.py
@@ -404,6 +404,7 @@ def virt_install(opts, install_log, disk_img, disk_size, cancel_func=None):
         for arg in opts.compress_args:
             compress_args += arg.split(" ", 1)
 
+        rc = 1  # assume failure if PartitionMount fails to mount anything
         with PartitionMount(diskimg_path) as img_mount:
             if img_mount and img_mount.mount_dir:
                 rc = mktar(img_mount.mount_dir, disk_img, opts.compression, compress_args)


### PR DESCRIPTION
This happens when --make-tar is selected and the virtual install
fails in such a way that the disk image contains no acceptable
partitions.

I've submitted this fix against the RHEL7 branch because that's the version I was using when I hit this, but it might affect other branches too. Shall I open PRs for all affected branches, or do you have a better procedure for this?