### PR TITLE
Do not use '--loglevel' option when running Anaconda

### DIFF
--- a/src/pylorax/installer.py
+++ b/src/pylorax/installer.py
@@ -355,7 +355,7 @@ def novirt_install(opts, disk_img, disk_size, cancel_func=None, tar_img=None):
         if os.path.isdir(path):
             shutil.rmtree(path)
 
-    args = ["--kickstart", opts.ks[0], "--cmdline", "--loglevel", "debug"]
+    args = ["--kickstart", opts.ks[0], "--cmdline"]
     if opts.anaconda_args:
         for arg in opts.anaconda_args:
             args += arg.split(" ", 1)


### PR DESCRIPTION
This option has been removed, see https://github.com/rhinstaller/anaconda/pull/2864