### PR TITLE
test: Fix vm.install for non-LVM cloud images

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -31,12 +31,15 @@ sed -i "s/download.fedoraproject/dl.fedoraproject/" /etc/yum.repos.d/*.repo
 # Example: `#baseurl=http://download.example/pub/fedora/linux/updates/$releasever/Everything/$basearch/`
 sed -i "s/download.example/dl.fedoraproject.org/" /etc/yum.repos.d/*.repo
 
-# Grow root partition to make room for images. This only works on Fedora right now.
-echo ", +" | sfdisk -N 2 -f /dev/vda
-partprobe
-pvs --noheadings -opv_name | xargs pvresize
-rootlv=$(findmnt --noheadings -oSOURCE /)
-lvresize $rootlv -l+100%FREE -r
+# Grow root partition on LVM test images to make room for built images
+PVS=$(pvs --noheadings -opv_name)
+if [ -n "$PVS" ]; then
+    echo ", +" | sfdisk -N 2 -f /dev/vda
+    partprobe
+    echo "$PVS" | xargs pvresize
+    rootlv=$(findmnt --noheadings -oSOURCE /)
+    lvresize $rootlv -l+100%FREE -r
+fi
 
 rm -rf build-results
 su builder -c "/usr/bin/mock --verbose --no-clean --resultdir build-results --rebuild $SRPM"


### PR DESCRIPTION
Some of our images, like centos-8-stream, are already built from the
official cloud images instead of virt-install with LVM. More images are
going to do that soon [1][2], so fix vm.install to only do the LVM grow
steps if the image actually uses LVM.

Also adjust the comment, as commit 6ddaa5e0dd0b0ce9db fixed this for
RHEL images.

[1] https://github.com/cockpit-project/bots/pull/1518
[2] https://github.com/cockpit-project/bots/pull/1527