### PR TITLE
[backport] test: Fix vm.install for non-LVM cloud images

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -35,12 +35,15 @@ if ! rpm -q qemu-kvm; then
     yum install -y qemu-kvm
 fi
 
-# Grow root partition to make room for images. This only works on Fedora right now.
-parted --script /dev/vda resizepart 2 100%
-partprobe
-pvs --noheadings -opv_name | xargs pvresize
-rootlv=$(findmnt --noheadings -oSOURCE /)
-lvresize $rootlv -l+100%FREE -r
+# Grow root partition on LVM test images to make room for built images
+PVS=$(pvs --noheadings -opv_name)
+if [ -n "$PVS" ]; then
+    echo ", +" | sfdisk -N 2 -f /dev/vda
+    partprobe
+    echo "$PVS" | xargs pvresize
+    rootlv=$(findmnt --noheadings -oSOURCE /)
+    lvresize $rootlv -l+100%FREE -r
+fi
 
 rm -rf build-results
 su builder -c "/usr/bin/mock --no-clean --resultdir build-results --rebuild $SRPM"


### PR DESCRIPTION
Some of our images, like centos-8-stream, are already built from the
official cloud images instead of virt-install with LVM. More images are
going to do that soon [1][2], so fix vm.install to only do the LVM grow
steps if the image actually uses LVM.

Also adjust the comment, as commit 6ddaa5e0dd0b0ce9db fixed this for
RHEL images.

[1] https://github.com/cockpit-project/bots/pull/1518
[2] https://github.com/cockpit-project/bots/pull/1527

(cherry-picked from commit 04ce221a6523cef)

 - [x] Land this fix in master first: PR #1105, then adjust commit message