### PR TITLE
templates: Copy missing files into ISO filesystem

### DIFF
--- a/share/templates.d/99-generic/aarch64.tmpl
+++ b/share/templates.d/99-generic/aarch64.tmpl
@@ -68,7 +68,7 @@ mkdir ${KERNELDIR}
 %>
 
 # Add the license files
-%for f in glob("/usr/share/licenses/*-release/*"):
+%for f in glob("usr/share/licenses/*-release-common/*"):
     install ${f} ${f|basename}
     <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor

--- a/share/templates.d/99-generic/arm.tmpl
+++ b/share/templates.d/99-generic/arm.tmpl
@@ -85,7 +85,7 @@ treeinfo ${basearch} platforms ${platforms}
 %>
 
 # Add the license files
-%for f in glob("/usr/share/licenses/*-release/*"):
+%for f in glob("usr/share/licenses/*-release-common/*"):
     install ${f} ${f|basename}
     <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor

--- a/share/templates.d/99-generic/live/aarch64.tmpl
+++ b/share/templates.d/99-generic/live/aarch64.tmpl
@@ -67,7 +67,7 @@ mkdir ${KERNELDIR}
 %endfor
 
 # Add the license files
-%for f in glob("/usr/share/licenses/*-release/*"):
+%for f in glob("usr/share/licenses/*-release-common/*"):
     install ${f} ${f|basename}
     <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor

--- a/share/templates.d/99-generic/live/arm.tmpl
+++ b/share/templates.d/99-generic/live/arm.tmpl
@@ -44,7 +44,7 @@ mkdir ${KERNELDIR}
 %endfor
 
 # Add the license files
-%for f in glob("/usr/share/licenses/*-release/*"):
+%for f in glob("usr/share/licenses/*-release-common/*"):
     install ${f} ${f|basename}
 %endfor
 

--- a/share/templates.d/99-generic/live/ppc64le.tmpl
+++ b/share/templates.d/99-generic/live/ppc64le.tmpl
@@ -74,7 +74,7 @@ replace @EXTRA@ '${extra_boot_args}' ${GRUBDIR}/grub.cfg
 %endfor
 
 # Add the license files
-%for f in glob("/usr/share/licenses/*-release/*"):
+%for f in glob("usr/share/licenses/*-release-common/*"):
     install ${f} ${f|basename}
     <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor

--- a/share/templates.d/99-generic/live/s390.tmpl
+++ b/share/templates.d/99-generic/live/s390.tmpl
@@ -69,7 +69,7 @@ treeinfo images-${basearch} cdboot.prm ${BOOTDIR}/cdboot.prm
 %endfor
 
 # Add the license files
-%for f in glob("/usr/share/licenses/*-release/*"):
+%for f in glob("usr/share/licenses/*-release-common/*"):
     install ${f} ${f|basename}
     <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor

--- a/share/templates.d/99-generic/live/x86.tmpl
+++ b/share/templates.d/99-generic/live/x86.tmpl
@@ -107,7 +107,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %endfor
 
 # Add the license files
-%for f in glob("/usr/share/licenses/*-release/*"):
+%for f in glob("usr/share/licenses/*-release-common/*"):
     install ${f} ${f|basename}
     <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor

--- a/share/templates.d/99-generic/live/x86.tmpl
+++ b/share/templates.d/99-generic/live/x86.tmpl
@@ -112,6 +112,12 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
     <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor
 
+# Add the livecd-iso-to-disk script if installed
+<% f = "usr/bin/livecd-iso-to-disk" %>
+%if exists(f):
+    install ${f} ${LIVEDIR}/${f|basename}
+%endif
+
 ## make boot.iso
 runcmd xorrisofs ${isoargs} -o ${outroot}/images/boot.iso \
        -isohybrid-mbr /usr/share/syslinux/isohdpfx.bin \

--- a/share/templates.d/99-generic/ppc64le.tmpl
+++ b/share/templates.d/99-generic/ppc64le.tmpl
@@ -80,7 +80,7 @@ replace @ROOT@ 'inst.stage2=hd:LABEL=${isolabel|udev}' ${GRUBDIR}/grub.cfg
 %>
 
 # Add the license files
-%for f in glob("/usr/share/licenses/*-release/*"):
+%for f in glob("usr/share/licenses/*-release-common/*"):
     install ${f} ${f|basename}
     <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor

--- a/share/templates.d/99-generic/s390.tmpl
+++ b/share/templates.d/99-generic/s390.tmpl
@@ -66,7 +66,7 @@ treeinfo images-${basearch} redhat.exec ${BOOTDIR}/redhat.exec
 %>
 
 # Add the license files
-%for f in glob("/usr/share/licenses/*-release/*"):
+%for f in glob("usr/share/licenses/*-release-common/*"):
     install ${f} ${f|basename}
     <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor

--- a/share/templates.d/99-generic/x86.tmpl
+++ b/share/templates.d/99-generic/x86.tmpl
@@ -115,7 +115,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %>
 
 # Add the license files
-%for f in glob("/usr/share/licenses/*-release/*"):
+%for f in glob("usr/share/licenses/*-release-common/*"):
     install ${f} ${f|basename}
     <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor


### PR DESCRIPTION
Restore the Fedora (or generic) license files, which have been missing from image builds since Fedora 30.

Copy the `livecd-iso-to-disk` script (if it is present) into the LiveOS/ directory. Currently, a post-install script in fedora-live-base.ks [modifies a Lorax template](https://pagure.io/fedora-kickstarts/blob/97dd0f7e4d9f5b7005ede9369df6784a0fc01a46/f/fedora-live-base.ks#_338-346) to do this; move that directly into Lorax.

Please backport to stable Fedora branches (applies cleanly).