### PR TITLE
Use inst.rescue to trigger rescue mode

### DIFF
--- a/share/templates.d/99-generic/config_files/aarch64/grub2-efi.cfg
+++ b/share/templates.d/99-generic/config_files/aarch64/grub2-efi.cfg
@@ -40,7 +40,7 @@ submenu 'Troubleshooting -->' {
 		initrd @INITRDPATH@
 	}
 	menuentry 'Rescue a @PRODUCT@ system' --class red --class gnu-linux --class gnu --class os {
-		linux @KERNELPATH@ @ROOT@ rescue
+		linux @KERNELPATH@ @ROOT@ inst.rescue
 		initrd @INITRDPATH@
 	}
 }

--- a/share/templates.d/99-generic/config_files/ppc/grub.cfg.in
+++ b/share/templates.d/99-generic/config_files/ppc/grub.cfg.in
@@ -14,7 +14,7 @@ menuentry "Test this media & install @PRODUCT@ @VERSION@  (64-bit kernel)" --cla
 }
 
 menuentry "Rescue a @PRODUCT@ system (64-bit kernel)" --class fedora --class gnu-linux --class gnu --class os {
-      linux /ppc/ppc64/vmlinuz @ROOT@ rescue ro
+      linux /ppc/ppc64/vmlinuz @ROOT@ inst.rescue ro
       initrd /ppc/ppc64/initrd.img
 }
 

--- a/share/templates.d/99-generic/config_files/sparc/boot.msg
+++ b/share/templates.d/99-generic/config_files/sparc/boot.msg
@@ -5,5 +5,5 @@
 
  -  To install in text mode, type: [7mlinux text <ENTER>[m.
 
- -  To enter rescue mode type: [7mlinux rescue <ENTER>[m.
+ -  To enter rescue mode type: [7mlinux inst.rescue <ENTER>[m.
 

--- a/share/templates.d/99-generic/config_files/x86/grub2-efi.cfg
+++ b/share/templates.d/99-generic/config_files/x86/grub2-efi.cfg
@@ -34,7 +34,7 @@ submenu 'Troubleshooting -->' {
 		initrdefi @INITRDPATH@
 	}
 	menuentry 'Rescue a @PRODUCT@ system' --class fedora --class gnu-linux --class gnu --class os {
-		linuxefi @KERNELPATH@ @ROOT@ rescue quiet
+		linuxefi @KERNELPATH@ @ROOT@ inst.rescue quiet
 		initrdefi @INITRDPATH@
 	}
 }

--- a/share/templates.d/99-generic/config_files/x86/isolinux.cfg
+++ b/share/templates.d/99-generic/config_files/x86/isolinux.cfg
@@ -93,7 +93,7 @@ label rescue
 	and edit config files to try to get it booting again.
   endtext
   kernel vmlinuz
-  append initrd=initrd.img @ROOT@ rescue quiet
+  append initrd=initrd.img @ROOT@ inst.rescue quiet
 
 label memtest
   menu label Run a ^memory test


### PR DESCRIPTION
anaconda in F34 and Rawhide recently stopped accepting params
without the inst. prefix, so 'rescue' does nothing except print
a warning now. We need to use `inst.rescue`. This has worked for
quite a long time so will be OK at least on all Fedoras and RHEL
8, not sure about RHEL 7.

Signed-off-by: Adam Williamson <awilliam@redhat.com>