### PR TITLE
composer-cli: Add support for start-ostree --url URL

### DIFF
--- a/src/composer/cli/compose.py
+++ b/src/composer/cli/compose.py
@@ -133,6 +133,18 @@ def get_ref(args):
     value = value if value is not None else ""
     return (args, value)
 
+def get_url(args):
+    """Return optional --url argument, and remaining args
+
+    :param args: list of arguments
+    :type args: list of strings
+    :returns: (args, parent)
+    :rtype: tuple
+    """
+    args, value = get_arg(args, "--url")
+    value = value if value is not None else ""
+    return (args, value)
+
 def compose_list(socket_path, api_version, args, show_json=False, testmode=0):
     """Return a simple list of compose identifiers"""
 
@@ -405,13 +417,14 @@ def compose_ostree(socket_path, api_version, args, show_json=False, testmode=0):
     :param api: Details about the API server, "version" and "backend"
     :type api: dict
 
-    compose start-ostree [--size XXXX] [--parent PARENT] [--ref REF] <BLUEPRINT> <TYPE> [<IMAGE-NAME> <PROFILE.TOML>]
+    compose start-ostree [--size XXXX] [--parent PARENT] [--ref REF] [--url URL] <BLUEPRINT> <TYPE> [<IMAGE-NAME> <PROFILE.TOML>]
     """
-    # Get the optional size before checking other parameters
+    # Get the optional arguments before checking other parameters
     try:
         args, size = get_size(args)
         args, parent = get_parent(args)
         args, ref = get_ref(args)
+        args, url = get_url(args)
     except (RuntimeError, ValueError) as e:
         log.error(str(e))
         return 1
@@ -434,6 +447,8 @@ def compose_ostree(socket_path, api_version, args, show_json=False, testmode=0):
         }
     if size > 0:
         config["size"] = size
+    if len(url) > 0:
+        config["ostree"]["url"] = url
 
     if len(args) == 4:
         config["upload"] = {"image_name": args[2]}

--- a/src/composer/cli/help.py
+++ b/src/composer/cli/help.py
@@ -20,7 +20,7 @@ compose start [--size XXXX] <BLUEPRINT> <TYPE> [<IMAGE-NAME> <PROVIDER> <PROFILE
     Start a compose using the selected blueprint and output type. --size is in MiB.
     NOTE: uploading and --size are only supported by osbuild-composer.
 
-compose start-ostree [--size XXXX] [--parent PARENT] [--ref REF] <BLUEPRINT> <TYPE> [<IMAGE-NAME> <PROFILE.TOML>]
+compose start-ostree [--size XXXX] [--parent PARENT] [--ref REF] [--url url] <BLUEPRINT> <TYPE> [<IMAGE-NAME> <PROFILE.TOML>]
     Start an ostree compose using the selected blueprint and output type. Optionally start an upload. This command
     is only supported by osbuild-composer. --size is in MiB.
 

--- a/tests/composer/test_compose.py
+++ b/tests/composer/test_compose.py
@@ -391,6 +391,16 @@ class ComposeOsBuildV1TestCase(ComposeTestCase):
         self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "fedora-iot-commit", "branch": "master",
             "ostree": {"ref": "refid", "parent": "parenturl"}})
 
+    def test_compose_start_ostree_url(self):
+        """Test start-ostree with --ref, --parent, and --url"""
+        result = self.run_args(["--socket", self.socket, "--api", "1", "compose", "start-ostree", "--ref", "refid", "--parent", "parenturl", "--url", "http://some/path/", "http-server", "fedora-iot-commit"])
+        self.assertTrue(result is not None)
+        self.assertTrue("body" in result)
+        self.assertGreater(len(result["body"]), 0)
+        jd = json.loads(result["body"])
+        self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "fedora-iot-commit", "branch": "master",
+            "ostree": {"ref": "refid", "parent": "parenturl", "url": "http://some/path/"}})
+
     def test_compose_start_ostree_size(self):
         """Test start-ostree with --size, --ref and --parent"""
         result = self.run_args(["--socket", self.socket, "--api", "1", "compose", "start-ostree", "--size", "2048", "--ref", "refid", "--parent", "parenturl", "http-server", "fedora-iot-commit"])


### PR DESCRIPTION
Some ostree builds, like edge, require passing a url to it along with
the ref and parent arguments. This adds an optional --url argument to
the 'composer-cli compose start-ostree' command.

Related: rhbz#1929381