### PR TITLE
isolinux.cfg: Rename the 'vesa' menu entry to 'basic'

### DIFF
--- a/share/templates.d/99-generic/config_files/x86/isolinux.cfg
+++ b/share/templates.d/99-generic/config_files/x86/isolinux.cfg
@@ -73,11 +73,11 @@ menu separator # insert an empty line
 
 # utilities submenu
 menu begin ^Troubleshooting
-  menu title Troubleshooting
+  menu title Troubleshooting @PRODUCT@ @VERSION@
 
-label vesa
+label basic
   menu indent count 5
-  menu label Install @PRODUCT@ @VERSION@ in ^basic graphics mode
+  menu label Install using ^basic graphics mode
   text help
 	Try this option out if you're having trouble installing
 	@PRODUCT@ @VERSION@.

--- a/share/templates.d/99-generic/live/config_files/x86/isolinux.cfg
+++ b/share/templates.d/99-generic/live/config_files/x86/isolinux.cfg
@@ -73,11 +73,11 @@ menu separator # insert an empty line
 
 # utilities submenu
 menu begin ^Troubleshooting
-  menu title Troubleshooting
+  menu title Troubleshooting @PRODUCT@ @VERSION@
 
-label vesa
+label basic
   menu indent count 5
-  menu label Start @PRODUCT@ @VERSION@ in ^basic graphics mode
+  menu label Start using ^basic graphics mode
   text help
 	Try this option out if you're having trouble starting
 	@PRODUCT@ @VERSION@.

--- a/src/composer/cli/compose.py
+++ b/src/composer/cli/compose.py
@@ -114,6 +114,18 @@ def get_ref(args):
     value = value if value is not None else ""
     return (args, value)
 
+def get_url(args):
+    """Return optional --url argument, and remaining args
+
+    :param args: list of arguments
+    :type args: list of strings
+    :returns: (args, parent)
+    :rtype: tuple
+    """
+    args, value = get_arg(args, "--url")
+    value = value if value is not None else ""
+    return (args, value)
+
 def compose_list(socket_path, api_version, args, show_json=False, testmode=0, api=None):
     """Return a simple list of compose identifiers"""
 
@@ -352,7 +364,7 @@ def compose_ostree(socket_path, api_version, args, show_json=False, testmode=0, 
     :param api: Details about the API server, "version" and "backend"
     :type api: dict
 
-    compose start-ostree [--size XXXX] [--parent PARENT] [--ref REF] <BLUEPRINT> <TYPE> [<IMAGE-NAME> <PROFILE.TOML>]
+    compose start-ostree [--size XXXX] [--parent PARENT] [--ref REF] [--url URL] <BLUEPRINT> <TYPE> [<IMAGE-NAME> <PROFILE.TOML>]
     """
     if api == None:
         log.error("Missing api version/backend")
@@ -362,11 +374,12 @@ def compose_ostree(socket_path, api_version, args, show_json=False, testmode=0, 
         log.warning("lorax-composer doesn not support start-ostree.")
         return 1
 
-    # Get the optional size before checking other parameters
+    # Get the optional arguments before checking other parameters
     try:
         args, size = get_size(args)
         args, parent = get_parent(args)
         args, ref = get_ref(args)
+        args, url = get_url(args)
     except (RuntimeError, ValueError) as e:
         log.error(str(e))
         return 1
@@ -389,6 +402,8 @@ def compose_ostree(socket_path, api_version, args, show_json=False, testmode=0, 
         }
     if size > 0:
         config["size"] = size
+    if len(url) > 0:
+        config["ostree"]["url"] = url
 
     if len(args) == 4:
         config["upload"] = {"image_name": args[2]}

--- a/src/composer/cli/help.py
+++ b/src/composer/cli/help.py
@@ -20,7 +20,7 @@ compose start [--size XXXX] <BLUEPRINT> <TYPE> [<IMAGE-NAME> <PROVIDER> <PROFILE
     Start a compose using the selected blueprint and output type. Optionally start an upload.
     --size is supported by osbuild-composer, and is in MiB.
 
-compose start-ostree [--size XXXX] [--parent PARENT] [--ref REF] <BLUEPRINT> <TYPE> [<IMAGE-NAME> <PROFILE.TOML>]
+compose start-ostree [--size XXXX] [--parent PARENT] [--ref REF] [--url url] <BLUEPRINT> <TYPE> [<IMAGE-NAME> <PROFILE.TOML>]
     Start an ostree compose using the selected blueprint and output type. Optionally start an upload. This command
     is only supported by osbuild-composer. --size is in MiB.
 

--- a/tests/composer/test_compose.py
+++ b/tests/composer/test_compose.py
@@ -387,6 +387,16 @@ class ComposeOsBuildV1TestCase(ComposeTestCase):
         self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "fedora-iot-commit", "branch": "master",
             "ostree": {"ref": "refid", "parent": "parenturl"}})
 
+    def test_compose_start_ostree_url(self):
+        """Test start-ostree with --ref, --parent, and --url"""
+        result = self.run_test(["--socket", self.socket, "--api", "1", "compose", "start-ostree", "--ref", "refid", "--parent", "parenturl", "--url", "http://some/path/", "http-server", "fedora-iot-commit"])
+        self.assertTrue(result is not None)
+        self.assertTrue("body" in result)
+        self.assertGreater(len(result["body"]), 0)
+        jd = json.loads(result["body"])
+        self.assertEqual(jd, {"blueprint_name": "http-server", "compose_type": "fedora-iot-commit", "branch": "master",
+            "ostree": {"ref": "refid", "parent": "parenturl", "url": "http://some/path/"}})
+
     def test_compose_start_ostree_size(self):
         """Test start-ostree with --size, --ref and --parent"""
         result = self.run_test(["--socket", self.socket, "--api", "1", "compose", "start-ostree", "--size", "2048", "--ref", "refid", "--parent", "parenturl", "http-server", "fedora-iot-commit"])


### PR DESCRIPTION
It never used vesa directly, it passes nomodeset, so make it less
confusing. Also simplify the menu text so that it fits on the screen
for distributions with long names.