### PR TITLE
xorg-x11-server-utils was split up in Fedora 34, so adjust templates

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -304,7 +304,6 @@ removefrom xorg-x11-drv-intel /usr/${libdir}/libI*
 removefrom xorg-x11-drv-openchrome /usr/${libdir}/libchrome*
 removefrom xorg-x11-drv-wacom /usr/bin/*
 removefrom xorg-x11-fonts-misc --allbut /usr/share/X11/fonts/misc/{6x13,encodings,fonts,*cursor}*
-removefrom xorg-x11-server-utils --allbut /usr/bin/xrandr /usr/bin/xrdb
 removefrom ${product.name}-logos /etc/*
 removefrom ${product.name}-logos /usr/share/icons/{Bluecurve,oxygen}/*
 removefrom ${product.name}-logos /usr/share/{firstboot,kde4,pixmaps}/*

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -90,7 +90,7 @@ installpkg rsyslog
 
 ## xorg/GUI packages
 installpkg xorg-x11-drivers xorg-x11-server-Xorg
-installpkg xorg-x11-server-utils xorg-x11-xauth
+installpkg xrandr xrdb xorg-x11-xauth
 installpkg dbus-x11 metacity gsettings-desktop-schemas
 installpkg nm-connection-editor
 installpkg librsvg2


### PR DESCRIPTION
In f34 and beyond, the old xorg-x11-server-utils package was split up
into seperate packages for each util. This was to allow them to rev at
their own pace instead of requiring all of them to rebuild at once.
See https://bugzilla.redhat.com/show_bug.cgi?id=1932754
and
https://fedoraproject.org/wiki/Changes/XorgUtilityDeaggregation

We need to adjust lorax (in f34+) to not try and remove the
xorg-x11-server-utils package (as it no longer exists) and also to
install the 2 utils that we need from it for installs.

Fixes issue #1117 

Signed-off-by: Kevin Fenzi <kevin@scrye.com>