### PR TITLE
xorg-x11-font-utils is now four packages, remove all of them

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -58,7 +58,8 @@ removepkg lvm2-libs mcpp
 removepkg mobile-broadband-provider-info
 removepkg pkgconf pkgconf-m4 pkgconf-pkg-config ppp pth
 removepkg rmt rpcbind squashfs-tools system-config-firewall-base
-removepkg tigervnc-license xml-common xorg-x11-font-utils
+removepkg tigervnc-license xml-common
+removepkg xorg-x11-font-utils bdftopcf mkfontscale fonttosfnt
 removepkg xorg-x11-server-common
 removepkg ncurses
 


### PR DESCRIPTION
Fedora has split xorg-x11-font-utils, with bdftopcf, mkfontscale and
fonttosfnt being split out into separate packages. Remove all of those too.


Somewhat related to #1117