### PR TITLE
runtime-cleanup: don't wipe /usr/bin/report-cli (#1937550)

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -283,7 +283,6 @@ removefrom psmisc /usr/share/locale/*
 removefrom python3-kickstart /usr/lib/python*/site-packages/pykickstart/locale/*
 removefrom readline /usr/${libdir}/libhistory*
 removefrom libreport /usr/share/locale/*
-removefrom libreport-cli /usr/bin/*
 removefrom rdma-core /etc/rdma/mlx4.conf
 removefrom rpm /usr/bin/* /usr/share/locale/*
 removefrom rsync /etc/*


### PR DESCRIPTION
We need it for reporting things!

Signed-off-by: Adam Williamson <awilliam@redhat.com>