### PR TITLE
Change khmeros-base-fonts to khmer-os-system-fonts

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -153,7 +153,7 @@ installpkg google-noto-sans-cjk-ttc-fonts
 installpkg google-noto-sans-gurmukhi-fonts
 installpkg google-noto-sans-sinhala-vf-fonts
 installpkg jomolhari-fonts
-installpkg khmeros-base-fonts
+installpkg khmer-os-system-fonts
 installpkg lohit-assamese-fonts
 installpkg lohit-bengali-fonts
 installpkg lohit-devanagari-fonts


### PR DESCRIPTION
This font got renamed last year.

Signed-off-by: Parag Nemade <pnemade@fedoraproject.org>