### PR TITLE
Remove display-related packages

### DIFF
--- a/share/templates.d/99-generic/config_files/common/sshd_config.anaconda
+++ b/share/templates.d/99-generic/config_files/common/sshd_config.anaconda
@@ -1,6 +1,4 @@
 PermitRootLogin yes
-X11Forwarding yes
-X11DisplayOffset 10
 PrintMotd yes
 SyslogFacility AUTHPRIV
 PasswordAuthentication yes

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -88,13 +88,6 @@ installpkg tar xz curl bzip2
 installpkg systemd-sysv systemd-units
 installpkg rsyslog
 
-## xorg/GUI packages
-installpkg xorg-x11-drivers xorg-x11-server-Xorg
-installpkg xrandr xrdb xorg-x11-xauth
-installpkg dbus-x11 metacity gsettings-desktop-schemas
-installpkg nm-connection-editor
-installpkg librsvg2
-
 ## filesystem tools
 installpkg btrfs-progs jfsutils xfsprogs reiserfs-utils gfs2-utils ntfs-3g ntfsprogs
 installpkg system-storage-manager


### PR DESCRIPTION
They are now dependencies of various Anaconda subpackages.

Depends on: https://github.com/rhinstaller/anaconda/pull/3235