### PR TITLE
[rhel8] test: Fix URL to bots testmap, fix osbuild-composer tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -8,7 +8,7 @@ images and tools to manipulate and start virtual machines from them.
 
 Each test is run on a new instance of a virtual machine.
 Branch/test scenario matrix is configured in
-[testmap.py](https://github.com/cockpit-project/bots/blob/master/task/testmap.py).
+[testmap.py](https://github.com/cockpit-project/bots/blob/master/lib/testmap.py).
 
 ## Dependencies
 

--- a/tests/cli/test_compose_sanity.sh
+++ b/tests/cli/test_compose_sanity.sh
@@ -31,7 +31,7 @@ rlJournalStart
             TYPE_EXT4=""
             TYPE_PARTITIONED_DISK=""
             TYPE_TAR="tar"
-            TYPE_IOT="rhel-edge-commit"
+            TYPE_IOT="rhel-edge-commit rhel-edge-container rhel-edge-installer"
         fi
 
         # arch specific compose type selections


### PR DESCRIPTION
It was moved in https://github.com/cockpit-project/bots/commit/7a3c71968d568

----

Backport of PR #1129. This is mostly an excuse to test rhel-8-4/osbuild-composer on the current rhel-8-4 image -- it fails in https://github.com/cockpit-project/bots/pull/1836 and I'd like to see if it's due to the new image or (more probably) due to changes in the compose.