### PR TITLE
Drop trying to install reiserfs-utils

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -96,7 +96,7 @@ installpkg nm-connection-editor
 installpkg librsvg2
 
 ## filesystem tools
-installpkg btrfs-progs jfsutils xfsprogs reiserfs-utils gfs2-utils ntfs-3g ntfsprogs
+installpkg btrfs-progs jfsutils xfsprogs gfs2-utils ntfs-3g ntfsprogs
 installpkg system-storage-manager
 installpkg device-mapper-persistent-data
 installpkg xfsdump


### PR DESCRIPTION
reiserfs-utils was retired in Fedora, so we don't want to try and
install it anymore.

Signed-off-by: Kevin Fenzi <kevin@scrye.com>