### PR TITLE
lorax-composer: Catch dnf unknown group error

### DIFF
--- a/src/pylorax/api/projects.py
+++ b/src/pylorax/api/projects.py
@@ -235,7 +235,7 @@ def _depsolve(dbo, projects, groups):
     for name in groups:
         try:
             dbo.group_install(name, ["mandatory", "default"])
-        except dnf.exceptions.MarkingError as e:
+        except (dnf.exceptions.MarkingError, ValueError) as e:
             install_errors.append(("Group %s" % (name), str(e)))
 
     for name, version in projects:


### PR DESCRIPTION
dnf-4.2.23-4 is raising a ValueError if the group doesn't exist, catch
that and add it to the error list when depsolving. Includes tests for
depsolve and freeze.

Resolves: rhbz#1943206