### PR TITLE
tests: Fix pocketlint use of removed pylint messages

### DIFF
--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -33,6 +33,18 @@ class LoraxLintConfig(PocketLintConfig):
     def extraArgs(self):
         return ["--extension-pkg-whitelist=rpm"]
 
+    @property
+    def disabledOptions(self):
+        retval = super(LoraxLintConfig, self).disabledOptions
+
+        # Remove messages that are no longer supported in py3
+        for msg in ["W0110", "W0141", "W0142", "I0012"]:
+            try:
+                retval.remove(msg)
+            except ValueError:
+                pass
+        return retval
+
 if __name__ == "__main__":
     conf = LoraxLintConfig()
     linter = PocketLinter(conf)


### PR DESCRIPTION
pylint has removed python2 only messages so running
pocketlint is causing tracebacks in every file.

This removes the problem messages from the disabledOptions property
until pocketlint can be fixed upstream.