### PR TITLE
Replace metacity with gnome-kiosk

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -172,7 +172,7 @@ removefrom gdb-headless /usr/share/* /etc/gdbinit*
 removefrom gdisk /usr/share/*
 removefrom gdk-pixbuf2 /usr/share/locale*
 removefrom gfs2-utils /usr/sbin/*
-removefrom glib2 /usr/bin/* /usr/share/locale/*
+removefrom glib2 /usr/share/locale/*
 removefrom glibc /etc/gai.conf /etc/rpc
 removefrom glibc /${libdir}/libBrokenLocale*
 removefrom glibc /${libdir}/libSegFault* /${libdir}/libanl*


### PR DESCRIPTION
When replacing metacity with gnome-kiosk I started to build on @bcl's Draft for replacing metacity with mutter:
https://github.com/weldr/lorax/pull/1086

With vm dependency moved into anaconda in this PR:
https://github.com/weldr/lorax/commit/8602e653ff999942199faf9100e0a71604980469
the switch itself will be in anaconda dependencies (after the switch I will remove also https://github.com/weldr/lorax/blob/2762cf95da6bee708fe586e5b2e314c935a731c9/share/templates.d/99-generic/runtime-cleanup.tmpl#L110 in a PR).

I am not sure if for gnome-kiosk we need also the part in this PR (compared to the mutter PR) to not remove /usr/bin/* from glib2 anymore, I will ask Ray.
The files that used to be removed:
```
-rwxr-xr-x. 1 rvykydal rvykydal 23832 Apr  8 17:00 gapplication
-rwxr-xr-x. 1 rvykydal rvykydal 52800 Apr  8 17:00 gdbus
-rwxr-xr-x. 1 rvykydal rvykydal 98168 Apr  8 17:00 gio
-rwxr-xr-x. 1 rvykydal rvykydal 15568 Apr  8 17:00 gio-querymodules-64
-rwxr-xr-x. 1 rvykydal rvykydal 52776 Apr  8 17:00 glib-compile-schemas
-rwxr-xr-x. 1 rvykydal rvykydal 32208 Apr  8 17:00 gsettings
```
 