### PR TITLE
fix: POC for a sane dracut chroot environment

### DIFF
--- a/src/pylorax/treebuilder.py
+++ b/src/pylorax/treebuilder.py
@@ -328,14 +328,17 @@ class TreeBuilder(object):
                 # Construct an initrd from the kernel name
                 outfile = kernel.path.replace("vmlinuz-", "initrd-") + ".img"
             logger.info("rebuilding %s", outfile)
-            logger.info("dracut warnings about /proc are safe to ignore")
 
             if backup:
                 initrd = joinpaths(self.vars.inroot, outfile)
                 if os.path.exists(initrd):
                     os.rename(initrd, initrd + backup)
             cmd = dracut + [outfile, kernel.version]
+            runcmd([ "mount", "-t", "proc", "-o", "nosuid,noexec,nodev", "proc", self.vars.inroot + "/proc" ])
+            runcmd([ "mount", "-t", "devtmpfs", "-o", "mode=0755,noexec,nosuid,strictatime", "devtmpfs", self.vars.inroot + "/dev" ])
             runcmd(cmd, root=self.vars.inroot)
+            runcmd([ "umount", self.vars.inroot + "/proc" ])
+            runcmd([ "umount", self.vars.inroot + "/dev" ])
 
     def build(self):
         templatefile = templatemap[self.vars.arch.basearch]


### PR DESCRIPTION
`bash` and various other utilities only work with a sane chroot
environment. At least `bash` needs `/dev/fd` to function properly.

Take this as a POC patch to make things work.

See https://bugzilla.redhat.com/show_bug.cgi?id=1962975#c2

With this patch:
```console
# lsinitrd ./isolinux/initrd.img|fgrep ca-bundle
-r--r--r--   1 root     root       216090 May 18 10:36 etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
lrwxrwxrwx   1 root     root           46 May 18 10:36 etc/pki/tls/certs/ca-bundle.crt -> ../../ca-trust/extracted/pem/tls-ca-bundle.pem
```