### PR TITLE
Drop retired icfg

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -173,7 +173,7 @@ installpkg python3-pyatspi
 installpkg nano nano-default-editor
 installpkg vim-minimal strace lsof dump xz less
 installpkg wget rsync bind-utils ftp mtr vconfig
-installpkg icfg spice-vdagent
+installpkg spice-vdagent
 installpkg gdisk hexedit sg3_utils
 
 ## actually install all the requested packages


### PR DESCRIPTION
Rawhide compose failed because icfg was retired yesterday:
https://src.fedoraproject.org/rpms/icfg/c/64ef393a109dd468b1b6950bfef70b2c45b5b903?branch=rawhide
https://pagure.io/releng/failed-composes/issue/2557