### PR TITLE
livemedia-creator: Check for mkfs.hfsplus

### DIFF
--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -145,6 +145,9 @@ def main():
             if not os.path.exists(joinpaths(opts.ovmf_path, f)):
                 errors.append("OVMF secure boot firmware file %s is missing from %s" % (f, opts.ovmf_path))
 
+    if opts.domacboot and not os.path.exists("/usr/sbin/mkfs.hfsplus"):
+        errors.append("mkfs.hfsplus is missing. Install hfsplus-tools, or pass --nomacboot")
+
     if os.getuid() != 0:
         errors.append("You need to run this as root")
 


### PR DESCRIPTION
mkfs.hfsplus may not be installed so instead of crashing near the end of
the install check for it and print a useful error message.

Resolves: rhbz#1969743