### PR TITLE
pylorax: Fix mksparse ftruncate size handling

### DIFF
--- a/src/pylorax/imgutils.py
+++ b/src/pylorax/imgutils.py
@@ -141,7 +141,7 @@ def mkrootfsimg(rootdir, outfile, label, size=2, sysroot=""):
 def mksparse(outfile, size):
     '''use os.ftruncate to create a sparse file of the given size.'''
     with open(outfile, "w") as fobj:
-        os.ftruncate(fobj.fileno(), size)
+        os.ftruncate(fobj.fileno(), int(size))
 
 def mkqcow2(outfile, size, options=None):
     '''use qemu-img to create a file of the given size.


### PR DESCRIPTION
Make sure that os.ftruncate() is called with an int() size. Before python
3.10 it used to handle this internally, but in 3.9 it was deprecated and
in 3.10 it now raises an error:

    TypeError: 'float' object cannot be interpreted as an integer

This makes sure that the size is truncated to an int(). The value is in
bytes, so truncation does not lose anything.