### PR TITLE
mount.py: Fix docstring

### DIFF
--- a/src/pylorax/mount.py
+++ b/src/pylorax/mount.py
@@ -92,7 +92,7 @@ class IsoMountpoint(object):
 
     def get_iso_label(self):
         """
-        Get the iso's label using isoinfo
+        Get the iso's label using pycdlib
 
         Sets self.label if one is found
         """


### PR DESCRIPTION
Probably forgotten docstring unpdate during isoinfo to pycdlib transition.