### PR TITLE
Use wildcard for grub2 modules in livemedia.ks example

### DIFF
--- a/docs/rhel-livemedia.ks
+++ b/docs/rhel-livemedia.ks
@@ -398,7 +398,7 @@ dracut-config-generic
 dracut-live
 glibc-all-langpacks
 grub2-efi
-grub2-pc-modules
+grub2-*-modules
 kernel
 # Make sure that DNF doesn't pull in debug kernel to satisfy kmod() requires
 kernel-modules


### PR DESCRIPTION
This will make it easier to use the kickstart on different arches.

Resolves: rhbz#1973530