### PR TITLE
runtime-install: Remove gfs2-utils

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -170,7 +170,6 @@ removefrom gdb /usr/share/* /usr/include/*
 removefrom gdb-headless /usr/share/* /etc/gdbinit*
 removefrom gdisk /usr/share/*
 removefrom gdk-pixbuf2 /usr/share/locale*
-removefrom gfs2-utils /usr/sbin/*
 removefrom glib2 /usr/bin/* /usr/share/locale/*
 removefrom glibc /etc/gai.conf /etc/rpc
 removefrom glibc /${libdir}/libBrokenLocale*

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -89,7 +89,7 @@ installpkg systemd-sysv systemd-units
 installpkg rsyslog
 
 ## filesystem tools
-installpkg btrfs-progs jfsutils xfsprogs gfs2-utils ntfs-3g ntfsprogs
+installpkg btrfs-progs jfsutils xfsprogs ntfs-3g ntfsprogs
 installpkg system-storage-manager
 installpkg device-mapper-persistent-data
 installpkg xfsdump


### PR DESCRIPTION
It is not needed on the installer media. Also remove references from
runtime-cleanup.tmpl

Related: rhbz#1975378