### PR TITLE
Increase example kickstart root partitions to at least 4000MB

### DIFF
--- a/docs/rhel-container.ks
+++ b/docs/rhel-container.ks
@@ -27,7 +27,7 @@ bootloader --disabled
 # Partition clearing information
 clearpart --all --initlabel
 # Disk partitioning information
-part / --fstype="ext4" --size=3000
+part / --fstype="ext4" --size=4000
 
 %post
 # Remove random-seed

--- a/docs/rhel-minimal.ks
+++ b/docs/rhel-minimal.ks
@@ -34,7 +34,7 @@ bootloader --location=mbr
 # Partition clearing information
 clearpart --all --initlabel
 # Disk partitioning information
-part / --fstype="ext4" --size=2000
+part / --fstype="ext4" --size=4000
 part swap --size=512
 
 %post

--- a/docs/rhel-openstack.ks
+++ b/docs/rhel-openstack.ks
@@ -31,7 +31,7 @@ zerombr
 # Partition clearing information
 clearpart --all
 # Disk partitioning information
-part / --fstype="ext4" --size=3000
+part / --fstype="ext4" --size=4000
 
 %post
 # Remove random-seed


### PR DESCRIPTION
Anaconda needs enough space to download the rpms and install the packages
when running livemedia-creator with virt mode so the / partition needs
to be larger.

Resolves: rhbz#1973407