### PR TITLE
grub2 changed location of fonts in rawhide

### DIFF
--- a/share/templates.d/99-generic/efi.tmpl
+++ b/share/templates.d/99-generic/efi.tmpl
@@ -6,7 +6,6 @@ APPLE_EFI_DISKNAME=inroot+"/usr/share/pixmaps/bootloader/fedora-media.vol"
 %>
 
 mkdir ${EFIBOOTDIR}
-mkdir ${EFIBOOTDIR}/fonts/
 %if efiarch64:
 install boot/efi/EFI/*/shim${efiarch64|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch64}.EFI
 install boot/efi/EFI/*/mm${efiarch64|lower}.efi ${EFIBOOTDIR}/
@@ -17,7 +16,7 @@ install boot/efi/EFI/*/shim${efiarch32|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch32}
 install boot/efi/EFI/*/mm${efiarch32|lower}.efi ${EFIBOOTDIR}/
 install boot/efi/EFI/*/gcd${efiarch32|lower}.efi ${EFIBOOTDIR}/grub${efiarch32|lower}.efi
 %endif
-install boot/efi/EFI/*/fonts/unicode.pf2 ${EFIBOOTDIR}/fonts/
+install boot/grub2/fonts/unicode.pf2 grub2/fonts/
 
 ## actually make the EFI images
 ${make_efiboot("images/efiboot.img")}

--- a/share/templates.d/99-generic/live/efi.tmpl
+++ b/share/templates.d/99-generic/live/efi.tmpl
@@ -6,7 +6,6 @@ APPLE_EFI_DISKNAME=inroot+"/usr/share/pixmaps/bootloader/fedora-media.vol"
 %>
 
 mkdir ${EFIBOOTDIR}
-mkdir ${EFIBOOTDIR}/fonts/
 %if efiarch64:
 install boot/efi/EFI/*/shim${efiarch64|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch64}.EFI
 install boot/efi/EFI/*/mm${efiarch64|lower}.efi ${EFIBOOTDIR}/
@@ -17,7 +16,7 @@ install boot/efi/EFI/*/shim${efiarch32|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch32}
 install boot/efi/EFI/*/mm${efiarch32|lower}.efi ${EFIBOOTDIR}/
 install boot/efi/EFI/*/gcd${efiarch32|lower}.efi ${EFIBOOTDIR}/grub${efiarch32|lower}.efi
 %endif
-install boot/efi/EFI/*/fonts/unicode.pf2 ${EFIBOOTDIR}/fonts/
+install boot/grub2/fonts/unicode.pf2 grub2/fonts/
 
 ## actually make the EFI images
 ${make_efiboot("images/efiboot.img")}


### PR DESCRIPTION
grub2 used to install efi fonts in boot/efi/EFI/*/fonts/ but now it's
installing them in boot/grub2/fonts/

Adjust the lorax templates to install the new location.

This should hopefully fix the rawhide compose error:
DEBUG util.py:446: 2021-07-08 16:10:05,585: template command error in x86.tmpl:
DEBUG util.py:446: template command error in x86.tmpl:
DEBUG util.py:446: 2021-07-08 16:10:05,585: install boot/efi/EFI//fonts/unicode.pf2 EFI/BOOT/fonts/
DEBUG util.py:446: install boot/efi/EFI//fonts/unicode.pf2 EFI/BOOT/fonts/
DEBUG util.py:446: 2021-07-08 16:10:05,586: OSError: nothing matching /var/tmp/lorax/lorax.t80f74er/installroot/boot/efi/EFI//fonts/unicode.pf2 in /
DEBUG util.py:446: OSError: nothing matching /var/tmp/lorax/lorax.t80f74er/installroot/boot/efi/EFI//fonts/unicode.pf2
in /

Signed-off-by: Kevin Fenzi <kevin@scrye.com>