### PR TITLE
runtime-cleanup: Remove dropped package from template

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -338,7 +338,7 @@ removefrom gstreamer1-plugins-base --allbut \
 removepkg geoclue2
 
 ## And remove the packages that those extra libraries pulled in
-removepkg cdparanoia-libs opus libtheora libvisual flac-libs gsm avahi-glib avahi-libs \
+removepkg opus libtheora libvisual flac-libs gsm avahi-glib avahi-libs \
           ModemManager-glib
 
 ## gnome-kiosk dependencies require libvorbis and libvorbisfile, but enc/dec are no longer needed


### PR DESCRIPTION
cdparanoia has been dropped from the release.

Related: rhbz#1991006