### PR TITLE
templates: Remove memtest86+

### DIFF
--- a/share/templates.d/99-generic/config_files/x86/isolinux.cfg
+++ b/share/templates.d/99-generic/config_files/x86/isolinux.cfg
@@ -95,15 +95,6 @@ label rescue
   kernel vmlinuz
   append initrd=initrd.img @ROOT@ inst.rescue quiet
 
-label memtest
-  menu label Run a ^memory test
-  text help
-	If your system is having issues, a problem with your
-	system's memory may be the cause. Use this utility to
-	see if the memory is working correctly.
-  endtext
-  kernel memtest
-
 menu separator # insert an empty line
 
 label local

--- a/share/templates.d/99-generic/live/config_files/x86/isolinux.cfg
+++ b/share/templates.d/99-generic/live/config_files/x86/isolinux.cfg
@@ -85,15 +85,6 @@ label basic
   kernel vmlinuz
   append initrd=initrd.img @ROOT@ @EXTRA@ rd.live.image nomodeset quiet rhgb
 
-label memtest
-  menu label Run a ^memory test
-  text help
-	If your system is having issues, a problem with your
-	system's memory may be the cause. Use this utility to
-	see if the memory is working correctly.
-  endtext
-  kernel memtest
-
 menu separator # insert an empty line
 
 label local

--- a/share/templates.d/99-generic/live/live-install.tmpl
+++ b/share/templates.d/99-generic/live/live-install.tmpl
@@ -18,7 +18,7 @@
     installpkg shim-ia32 grub2-efi-ia32-cdboot
 %endif
 %if basearch in ("i386", "x86_64"):
-    installpkg biosdevname memtest86+ syslinux
+    installpkg biosdevname syslinux
     installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
 %endif
 %if basearch == "ppc64le":

--- a/share/templates.d/99-generic/live/x86.tmpl
+++ b/share/templates.d/99-generic/live/x86.tmpl
@@ -40,7 +40,6 @@ install ${configdir}/isolinux.cfg ${BOOTDIR}
 install ${configdir}/boot.msg ${BOOTDIR}
 install ${configdir}/grub.conf ${BOOTDIR}
 install usr/share/anaconda/boot/syslinux-splash.png ${BOOTDIR}/splash.png
-install boot/memtest* ${BOOTDIR}/memtest
 
 ## configure bootloader
 replace @VERSION@ ${product.version} ${BOOTDIR}/grub.conf ${BOOTDIR}/isolinux.cfg ${BOOTDIR}/*.msg

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -52,7 +52,7 @@ installpkg glibc-all-langpacks
     installpkg shim-ia32 grub2-efi-ia32-cdboot
 %endif
 %if basearch in ("i386", "x86_64"):
-    installpkg biosdevname memtest86+ syslinux
+    installpkg biosdevname syslinux
     installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
 %endif
 %if basearch == "ppc64le":

--- a/share/templates.d/99-generic/x86.tmpl
+++ b/share/templates.d/99-generic/x86.tmpl
@@ -40,7 +40,6 @@ install ${configdir}/isolinux.cfg ${BOOTDIR}
 install ${configdir}/boot.msg ${BOOTDIR}
 install ${configdir}/grub.conf ${BOOTDIR}
 install usr/share/anaconda/boot/syslinux-splash.png ${BOOTDIR}/splash.png
-install boot/memtest* ${BOOTDIR}/memtest
 
 ## configure bootloader
 replace @VERSION@ ${product.version} ${BOOTDIR}/grub.conf ${BOOTDIR}/isolinux.cfg ${BOOTDIR}/*.msg


### PR DESCRIPTION
It no longer works and there is currently no good replacement.

See https://pagure.io/fedora-comps/pull-request/676