### PR TITLE
Handle all possible dnf group_install errors

### DIFF
--- a/src/pylorax/api/projects.py
+++ b/src/pylorax/api/projects.py
@@ -19,6 +19,7 @@ log = logging.getLogger("lorax-composer")
 
 from configparser import ConfigParser
 import dnf
+from dnf.exceptions import MarkingError, CompsError
 from glob import glob
 import os
 import time
@@ -235,7 +236,7 @@ def _depsolve(dbo, projects, groups):
     for name in groups:
         try:
             dbo.group_install(name, ["mandatory", "default"])
-        except dnf.exceptions.MarkingError as e:
+        except (MarkingError, ValueError, CompsError) as e:
             install_errors.append(("Group %s" % (name), str(e)))
 
     for name, version in projects:

--- a/tests/pylorax/test_projects.py
+++ b/tests/pylorax/test_projects.py
@@ -219,6 +219,10 @@ class ProjectsTest(unittest.TestCase):
         self.assertTrue("ctags" in names)               # default package
         self.assertFalse("cmake" in names)              # optional package
 
+    def test_groups_depsolve_error(self):
+        with self.assertRaises(ProjectsError):
+            projects_depsolve(self.dbo, [], ["notagroup"])
+
 
 class ConfigureTest(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
dnf has changed what it will raise when trying to group_install a
nonexistent group, this adds handling for all of them.

Related: rhbz#1947958