### PR TITLE
Update runtime-install/cleanup for Marvell Prestera fw split

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -236,7 +236,6 @@ removefrom linux-firmware /usr/lib/firmware/qcom/sm8250/*
 removefrom linux-firmware /usr/lib/firmware/qcom/venus*/*
 removefrom linux-firmware /usr/lib/firmware/meson/vdec/*
 removefrom linux-firmware /usr/lib/firmware/mellanox/mlxsw_spectrum*
-removefrom linux-firmware /usr/lib/firmware/mrvl/prestera/*
 %if basearch != "aarch64":
     removefrom linux-firmware /usr/lib/firmware/dpaa2/*
 %endif

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -30,7 +30,8 @@ installpkg grubby
                            --except cx18-firmware --except iscan-firmware \
                            --except uhd-firmware --except lulzbot-marlin-firmware \
                            --except gnome-firmware --except sigrok-firmware \
-                           --except liquidio-firmware --except netronome-firmware
+                           --except liquidio-firmware --except netronome-firmware \
+                           --except mrvlprestera-firmware
     installpkg b43-openfwwf
 %endif
 


### PR DESCRIPTION
Marvell Prestera firmware has been split into its own subpackage,
so instead of stripping the files from linux-firmware, exclude
the package from the globed install command.

Signed-off-by: Adam Williamson <awilliam@redhat.com>