### PR TITLE
runtime-cleanup: remove pipewire-related packages

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -10,7 +10,7 @@ remove usr/share/i18n
 ## perl is needed by /usr/bin/rxe_cfg from libibverbs
 
 ## no sound support, thanks
-removepkg flac-libs libsndfile pulseaudio* sound-theme-freedesktop
+removepkg flac-libs libsndfile pipewire pulseaudio* rtkit sound-theme-freedesktop wireplumber*
 ## we don't create new initramfs/bootloader conf inside anaconda
 ## (that happens inside the target system after we install dracut/grubby)
 removepkg dracut-network grubby anaconda-dracut


### PR DESCRIPTION
We aim to remove all sound support from the installer root, but
this was never updated for Pipewire. This just started causing
compose failures because of a dep chain from pipewire to lilv.

Signed-off-by: Adam Williamson <awilliam@redhat.com>