### PR TITLE
cleanup: remove binaries from lilv

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -11,6 +11,8 @@ remove usr/share/i18n
 
 ## no sound support, thanks
 removepkg flac-libs libsndfile pipewire pulseaudio* rtkit sound-theme-freedesktop wireplumber*
+## lv2appy requires removed libsndfile, we don't need the rest either
+removefrom lilv /usr/bin/*
 ## we don't create new initramfs/bootloader conf inside anaconda
 ## (that happens inside the target system after we install dracut/grubby)
 removepkg dracut-network grubby anaconda-dracut


### PR DESCRIPTION
Since we're leaving pipewire-libs in, it'll still pull in liblilv
from 0.3.41 onwards. Currently liblilv is in the same package as
some binaries which we don't need, and one actually requires the
removed libsndfile, so we need to trim it.

Signed-off-by: Adam Williamson <awilliam@redhat.com>