### PR TITLE
cleanup: handle RPM database move to /usr

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -74,7 +74,7 @@ remove /usr/share/mime/multipart /usr/share/mime/packages /usr/share/mime/text
 remove /usr/share/mime/video /usr/share/mime/x-content /usr/share/mime/x-epoc
 remove /var/db /var/games /var/tmp /var/yp /var/nis /var/opt /var/local
 remove /var/mail /var/spool /var/preserve /var/report
-remove /var/lib/rpm/* /var/lib/yum /var/lib/dnf
+remove /usr/lib/sysimage/rpm/* /var/lib/rpm/* /var/lib/yum /var/lib/dnf
 ## clean up the files created by various '> /dev/null's
 remove /dev/*
 


### PR DESCRIPTION
In F36, the RPM database is being moved from /var/lib/rpm to
/usr/lib/sysimage/rpm:

https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr
https://bugzilla.redhat.com/show_bug.cgi?id=2042099

So we need to empty that location in runtime-cleanup. Seems fine
to just list both locations, for a while at least.

Signed-off-by: Adam Williamson <awilliam@redhat.com>