### PR TITLE
Trim some font packages (and Noto Sans Italic) to save space

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -303,7 +303,6 @@ removefrom wget /etc/* /usr/share/locale/*
 removefrom xorg-x11-drv-intel /usr/${libdir}/libI*
 removefrom xorg-x11-drv-openchrome /usr/${libdir}/libchrome*
 removefrom xorg-x11-drv-wacom /usr/bin/*
-removefrom xorg-x11-fonts-misc --allbut /usr/share/X11/fonts/misc/{6x13,encodings,fonts,*cursor}*
 
 %if branding.release:
     removefrom ${branding.logos} /usr/share/plymouth/*

--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -185,6 +185,7 @@ removefrom glibc-common /usr/bin/tzselect
 removefrom glibc-common /usr/sbin/*
 removefrom gnutls /usr/share/locale/*
 removefrom google-noto-sans-cjk-ttc-fonts /usr/share/fonts/google-noto-cjk/NotoSansCJK-{Black,Bold,*Light,Medium,Thin}.ttc
+removefrom google-noto-sans-vf-fonts /usr/share/fonts/google-noto-vf/NotoSans-Italic-VF.ttf
 removefrom grep /etc/* /usr/share/locale/*
 removefrom gtk2 /usr/bin/update-gtk-immodules
 removefrom gtk3 /usr/${libdir}/gtk-3.0/*

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -154,14 +154,11 @@ installpkg dmidecode
 installpkg abattis-cantarell-vf-fonts
 installpkg bitmap-fangsongti-fonts
 installpkg google-noto-sans-vf-fonts google-noto-sans-mono-vf-fonts
-installpkg google-noto-sans-arabic-vf-fonts google-noto-sans-armenian-vf-fonts
-installpkg google-noto-sans-canadian-aboriginal-vf-fonts google-noto-sans-cherokee-vf-fonts
+installpkg google-noto-sans-arabic-vf-fonts
 installpkg google-noto-sans-cjk-ttc-fonts
 installpkg google-noto-sans-ethiopic-vf-fonts google-noto-sans-georgian-vf-fonts
 installpkg google-noto-sans-gurmukhi-vf-fonts google-noto-sans-hebrew-vf-fonts
-installpkg google-noto-sans-lao-vf-fonts google-noto-sans-math-vf-fonts
 installpkg google-noto-sans-sinhala-vf-fonts
-installpkg google-noto-sans-thaana-vf-fonts
 installpkg jomolhari-fonts
 installpkg khmer-os-system-fonts
 installpkg lohit-assamese-fonts
@@ -174,12 +171,9 @@ installpkg lohit-odia-fonts
 installpkg lohit-tamil-fonts
 installpkg lohit-telugu-fonts
 installpkg paktype-naskh-basic-fonts
-installpkg sil-abyssinica-fonts
 installpkg sil-padauk-fonts
-installpkg sil-scheherazade-fonts
 installpkg rit-meera-new-fonts
 installpkg thai-scalable-waree-fonts
-installpkg xorg-x11-fonts-misc
 
 ## debugging/bug reporting tools
 installpkg gdb-gdbserver

--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -117,8 +117,3 @@ remove etc/lvm/lvm.conf
 append etc/lvm/lvm.conf "global {\n\tuse_lvmetad = 1\n}\n"
 
 ## TODO: we could run prelink here if we wanted?
-
-## fix fonconfig cache containing timestamps
-runcmd chroot ${root} /usr/bin/find /usr/share/fonts /usr/share/X11/fonts -newermt "@${SOURCE_DATE_EPOCH}" -exec \
-    touch --no-dereference --date="@${SOURCE_DATE_EPOCH}" {} +
-runcmd chroot ${root} /usr/bin/fc-cache -f


### PR DESCRIPTION
The recent https://github.com/weldr/lorax/pull/1207 included several fonts that don't really seem to be necessary in the installer, as we don't have translations of the languages the fonts are useful for. While cleaning that up, I also noticed that several older font packages that are no longer necessary are still hanging around the list, and cleaned those up too.

I checked against Fedora 35; between Fedora 35 and current Rawhide we have also apparently lost the Tibetan translation, which would let us drop jomolhari-fonts too, but it seemed safer to leave it in in case the Tibetan translation gets picked up again.

The second commit drops the Noto Sans Italic face, which is in line with how we previously dropped the DejaVu Sans Oblique face to save space. AIUI the font rendering engine will synthesize oblique characters by tilting the regular face in the rare cases where they're used in the installer environment, which should be good enough. Of course, if we think having the superior pre-made oblique characters is sufficiently important to justify half a meg of space, we can drop that commit.