### PR TITLE
tests: Fix the image minimizer test dnf usage

### DIFF
--- a/tests/image-minimizer/test_minimizer.py
+++ b/tests/image-minimizer/test_minimizer.py
@@ -5,10 +5,10 @@ import unittest
 
 from minimizer import ImageMinimizer
 
-class BuildStampTestCase(unittest.TestCase):
+class MinimizerTestCase(unittest.TestCase):
     def test_minimizer_ok(self):
         with tempfile.TemporaryDirectory(prefix="minimize.test.") as rootdir:
-            check_call(["dnf", "--installroot", rootdir, "install", "-y", \
+            check_call(["dnf", "--releasever=/", "--installroot", rootdir, "install", "-y", \
                         "filesystem"])
 
             im = ImageMinimizer("./tests/image-minimizer/im-script.txt", rootdir, False, False)


### PR DESCRIPTION
If the host dnf repos contain $releasever then using --installroot will
fail because it tries to use a rpmdb in the installroot, which starts
out empty. Passing --releasever=/ will use the releasever from the host.