### PR TITLE
runtime-cleanup: Remove ncurses package

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -60,6 +60,8 @@ removepkg rmt rpcbind squashfs-tools
 removepkg tigervnc-license xml-common
 removepkg mkfontscale fonttosfnt
 removepkg xorg-x11-server-common
+# do not remove this, required for ppc64le and s390x !!!
+removepkg ncurses
 
 ## other removals
 remove /home /media /opt /srv /tmp/*


### PR DESCRIPTION
Remove the ncurses package -- on ppc64le and s390x it was pulled in and
the library check would fail because the library files have been
removed.

Re-adding commit 46ba3d541d623062794c44857ac65f3e575ef863 after a template cleanup based on usage on x86.