### PR TITLE
Don't move the restart-anaconda file

### DIFF
--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -9,7 +9,6 @@ SOURCE_DATE_EPOCH = os.environ.get('SOURCE_DATE_EPOCH', str(int(time.time())))
 %>
 
 ## move_stubs()
-move usr/share/anaconda/restart-anaconda usr/bin
 move usr/share/anaconda/list-harddrives-stub usr/bin/list-harddrives
 
 ## move_repos()


### PR DESCRIPTION
The file will be no longer provided by Anaconda.
See: https://github.com/rhinstaller/anaconda/pull/3839