### PR TITLE
runtime-cleanup: keep 'unshare' binary present from util-linux-core

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -292,7 +292,7 @@ removefrom util-linux --allbut \
     /etc/pam.d/login /etc/pam.d/remote \
     /usr/sbin/{clock,fdisk,fsfreeze,fstrim,hwclock,nologin,sfdisk,swaplabel,wipefs,zramctl}
 removefrom util-linux-core --allbut \
-    /usr/bin/{dmesg,findmnt,flock,kill,logger,more,mount,mountpoint,umount} \
+    /usr/bin/{dmesg,findmnt,flock,kill,logger,more,mount,mountpoint,umount,unshare} \
     /etc/mtab \
     /usr/sbin/{agetty,blkid,blockdev,fsck,losetup,mkswap,partx,swapoff,swapon}
 removefrom volume_key-libs /usr/share/locale/*


### PR DESCRIPTION
This is being used by 'cockpit-desktop' [1] script that the new anaconda UI is
using.
Calling `unshare` in the installer environment is not really
necessary. However anaconda team prefers [2] to cleanly depend on
'cockpit-desktop' script instead of maintaining a modified copy of it.

[1] https://github.com/cockpit-project/cockpit/blob/main/src/ws/cockpit-desktop.in
[2] https://github.com/rhinstaller/anaconda/pull/3967#issuecomment-1076470675