### PR TITLE
Firmware cleanups 20220509

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -233,6 +233,7 @@ removefrom linux-firmware /usr/lib/firmware/qcom/venus*/*
 removefrom linux-firmware /usr/lib/firmware/qcom/vpu*/*
 removefrom linux-firmware /usr/lib/firmware/meson/vdec/*
 removefrom linux-firmware /usr/lib/firmware/mellanox/mlxsw_spectrum*
+removefrom linux-firmware /usr/lib/firmware/mellanox/lc_ini_bundle*
 %if basearch != "aarch64":
     removefrom linux-firmware /usr/lib/firmware/dpaa2/*
 %endif

--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -230,6 +230,7 @@ removefrom linux-firmware /usr/lib/firmware/qcom/apq8096/*
 removefrom linux-firmware /usr/lib/firmware/qcom/sdm845/*
 removefrom linux-firmware /usr/lib/firmware/qcom/sm8250/*
 removefrom linux-firmware /usr/lib/firmware/qcom/venus*/*
+removefrom linux-firmware /usr/lib/firmware/qcom/vpu*/*
 removefrom linux-firmware /usr/lib/firmware/meson/vdec/*
 removefrom linux-firmware /usr/lib/firmware/mellanox/mlxsw_spectrum*
 %if basearch != "aarch64":

--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -234,6 +234,7 @@ removefrom linux-firmware /usr/lib/firmware/qcom/vpu*/*
 removefrom linux-firmware /usr/lib/firmware/meson/vdec/*
 removefrom linux-firmware /usr/lib/firmware/mellanox/mlxsw_spectrum*
 removefrom linux-firmware /usr/lib/firmware/mellanox/lc_ini_bundle*
+removefrom linux-firmware /usr/lib/firmware/phanfw.bin*
 %if basearch != "aarch64":
     removefrom linux-firmware /usr/lib/firmware/dpaa2/*
 %endif

--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -226,6 +226,7 @@ removefrom linux-firmware /usr/lib/firmware/intel/IntcSST2.bin*
 removefrom linux-firmware /usr/lib/firmware/intel/fw_sst*
 removefrom linux-firmware /usr/lib/firmware/intel/dsp*
 removefrom linux-firmware /usr/lib/firmware/as102*
+removefrom linux-firmware /usr/lib/firmware/qcom/apq8096/*
 removefrom linux-firmware /usr/lib/firmware/qcom/sdm845/*
 removefrom linux-firmware /usr/lib/firmware/qcom/sm8250/*
 removefrom linux-firmware /usr/lib/firmware/qcom/venus*/*


### PR DESCRIPTION
Several additional firmware file trims to save back space lost with upstream 20220509 firmware release. This saves 11M in my local testing, nearly all of the 13M that we lost with the update.