### PR TITLE
Update spec for syslinux->grub2 switch

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -61,12 +61,7 @@ Requires:       hfsplus-tools
 %endif
 %endif
 
-%ifarch %{ix86} x86_64
-Requires:       syslinux >= 6.03-1
-Requires:       syslinux-nonlinux >= 6.03-1
-%endif
-
-%ifarch ppc64le
+%ifarch %{ix86} x86_64 ppc64le
 Requires:       grub2
 Requires:       grub2-tools
 %endif


### PR DESCRIPTION
Since we're now using grub2 not syslinux on ix86 and x86_64, we
need to require the right things in the spec file.

Signed-off-by: Adam Williamson <awilliam@redhat.com>