### PR TITLE
spec: Don't require grub2 on x86-32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ test:
 	@echo "*** Running tests ***"
 	PYTHONPATH=$(PYTHONPATH):./src/ $(PYTHON) -X dev -m pytest -v --cov-branch \
 					--cov=pylorax \
+					--cov=mkksiso \
+					--cov=minimizer \
 					./tests/pylorax/ \
 					./tests/image-minimizer/ \
 					./tests/mkksiso/

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,10 @@ check:
 test:
 	@echo "*** Running tests ***"
 	PYTHONPATH=$(PYTHONPATH):./src/ $(PYTHON) -X dev -m pytest -v --cov-branch \
-					--cov=pylorax ./tests/pylorax/ ./tests/image-minimizer/
+					--cov=pylorax \
+					./tests/pylorax/ \
+					./tests/image-minimizer/ \
+					./tests/mkksiso/
 
 	coverage3 report -m
 	[ -f "/usr/bin/coveralls" ] && [ -n "$(COVERALLS_REPO_TOKEN)" ] && coveralls || echo

--- a/docs/mkksiso.rst
+++ b/docs/mkksiso.rst
@@ -96,6 +96,39 @@ When this iso is booted it will execute the kickstart and install the liveimg
 contents to the system without any prompting.
 
 
+Modifying kernel cmdline arguments
+----------------------------------
+
+You can add arguments to the kernel cmdline in the ISO config files by using
+``--cmdline``, like this::
+
+    mkksiso --cmdline "console=ttyS0,115200n8" /PATH/TO/ISO /PATH/TO/NEW-ISO
+
+
+Removing arguments
+^^^^^^^^^^^^^^^^^^
+
+mkksiso version 37.3 and later support removing arguments from the cmdline. This can be done
+with or without adding a kickstart to the iso::
+
+    mkksiso --rm "quiet console" /PATH/TO/ISO /PATH/TO/NEW-ISO
+
+will remove the quiet and console arguments from all the the kernel cmdlines on the ISO.
+
+
+Changing existing arguments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With the combination of ``--rm`` and ``--command`` it is now possible to change
+existing arguments. For example let's say the ISO has a console=tty3 set on the
+cmdline. You want to change that to ttyS0 so you run this::
+
+    mkksiso --cmdline "console=ttyS0,115200n8" --rm "console" /PATH/TO/ISO /PATH/TO/NEW-ISO
+
+which will first remove all instances of console in the config files, and
+then add the new console argument.
+
+
 How it works
 ------------
 

--- a/docs/mkksiso.rst
+++ b/docs/mkksiso.rst
@@ -20,31 +20,10 @@ do not need to be root.
 mkksiso cmdline arguments
 -------------------------
 
-Add a kickstart and files to an iso
-
-    ``usage: mkksiso [-h] [-a ADD_PATHS] [-c CMDLINE] [--debug] ks input_iso output_iso``
-
-Optional arguments
-^^^^^^^^^^^^^^^^^^
-
-      -h, --help            show this help message and exit
-      -a ADD_PATHS, --add ADD_PATHS
-                            File or directory to add to ISO (may be used multiple
-                            times)
-      -c CMDLINE, --cmdline CMDLINE
-                            Arguments to add to kernel cmdline
-      --debug               print debugging info
-      -V VOLID, --volid VOLID
-                            Set the ISO volume id, defaults to input's
-
-Positional arguments
-^^^^^^^^^^^^^^^^^^^^
-
-    :ks: Kickstart to add to the ISO
-
-    :input_iso: ISO to modify
-
-    :output_iso: Full pathname of iso to be created
+.. argparse::
+   :filename: ../src/bin/mkksiso
+   :func: setup_arg_parser
+   :prog: mkksiso
 
 
 Create a kickstart boot.iso or DVD
@@ -56,7 +35,7 @@ Create a kickstart like you normally would, kickstart documentation can be
 content on the DVD you can use the ``cdrom`` command to install without a
 network connection. Then run ``mkksiso`` like this::
 
-    mkksiso /PATH/TO/KICKSTART /PATH/TO/ISO /PATH/TO/NEW-ISO
+    mkksiso --ks /PATH/TO/KICKSTART /PATH/TO/ISO /PATH/TO/NEW-ISO
 
 This will create a new iso with the kickstart in the root directory, and the
 kernel cmdline will have ``inst.ks=...`` added to it so that it will be
@@ -69,7 +48,7 @@ the iso will have th custom volume id.
 
 eg.::
 
-    mkksiso -V "Test Only" /PATH/TO/KICKSTART /PATH/TO/ISO /PATH/TO/NEW-ISO
+    mkksiso -V "Test Only" --ks /PATH/TO/KICKSTART /PATH/TO/ISO /PATH/TO/NEW-ISO
 
 
 Adding package repos to a boot.iso
@@ -85,7 +64,7 @@ the kickstart like this::
 
 Run ``mkksiso`` like so::
 
-    mkksiso --add /PATH/TO/REPO/ /PATH/TO/KICKSTART /PATH/TO/ISO /PATH/TO/NEW-ISO
+    mkksiso --add /PATH/TO/REPO/ --ks /PATH/TO/KICKSTART /PATH/TO/ISO /PATH/TO/NEW-ISO
 
 
 Create a liveimg boot.iso
@@ -111,7 +90,7 @@ and in the kickstart reference it with the ``liveimg`` command like this::
 It is also a good idea to use the ``--checksum`` argument to ``liveimg``  to be
 sure the file hasn't been corrupted::
 
-    mkksiso --add /PATH/TO/root.tar.xz /PATH/TO/KICKSTART /PATH/TO/ISO /PATH/TO/NEW-ISO
+    mkksiso --add /PATH/TO/root.tar.xz --ks /PATH/TO/KICKSTART /PATH/TO/ISO /PATH/TO/NEW-ISO
 
 When this iso is booted it will execute the kickstart and install the liveimg
 contents to the system without any prompting.

--- a/lorax.spec
+++ b/lorax.spec
@@ -61,7 +61,7 @@ Requires:       hfsplus-tools
 %endif
 %endif
 
-%ifarch %{ix86} x86_64 ppc64le
+%ifarch x86_64 ppc64le
 Requires:       grub2
 Requires:       grub2-tools
 %endif

--- a/src/bin/mkksiso
+++ b/src/bin/mkksiso
@@ -365,7 +365,7 @@ def MakeKickstartISO(ks, input_iso, output_iso, add_paths, cmdline="", new_volid
         ImplantMD5(output_iso)
 
 
-def setup_args():
+def setup_arg_parser():
     """ Return argparse.Parser object of cmdline."""
     parser = argparse.ArgumentParser(description="Add a kickstart and files to an iso")
 
@@ -379,18 +379,19 @@ def setup_args():
                         help="print debugging info")
     parser.add_argument("--no-md5sum", action="store_false", default=True,
                         help="Do not run implantisomd5 on the ouput iso")
+    parser.add_argument("--ks", metavar="KICKSTART",
+                        help="Kickstart to add to the ISO")
+    parser.add_argument("-V", "--volid", dest="volid", help="Set the ISO volume id, defaults to input's", default=None)
 
-    parser.add_argument("ks", type=os.path.abspath, help="Kickstart to add to the ISO")
     parser.add_argument("input_iso", type=os.path.abspath, help="ISO to modify")
     parser.add_argument("output_iso", type=os.path.abspath, help="Full pathname of iso to be created")
-    parser.add_argument("-V", "--volid", dest="volid", help="Set the ISO volume id, defaults to input's", default=None)
-    args = parser.parse_args()
 
-    return args
+    return parser
 
 
 def main():
-    args = setup_args()
+    parser = setup_arg_parser()
+    args = parser.parse_args()
     log.basicConfig(format='%(levelname)s:%(message)s', level=args.loglevel)
 
     try:
@@ -400,7 +401,7 @@ def main():
                 log.error("%s binary is missing", t)
                 errors = True
 
-        for f in [args.ks, args.input_iso] + args.add_paths:
+        for f in [args.input_iso] + args.add_paths:
             if not os.path.exists(f):
                 log.error("%s is missing", f)
                 errors = True

--- a/src/bin/mkksiso
+++ b/src/bin/mkksiso
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import argparse
+from collections import OrderedDict
 import logging as log
 import os
 import shutil
@@ -27,6 +28,86 @@ import tempfile
 
 # Maximum filename length
 MAX_FNAME = 253
+
+
+def SplitCmdline(cmdline):
+    """
+    Split the commandline into an OrderedDict of arguments
+
+    If the argument appears multiple times its entry will have a list of the values,
+    and its position in the dictionary will be that of the first occurrence.
+    If the argument has no value its entry will be [None]
+    Arguments with a single value will be [VALUE]
+
+    Quotes strings are maintained, and values may contain equals signs which
+    will be preserved.
+    """
+    kernel_args = OrderedDict()
+    for a in shlex.split(cmdline):
+        if "=" in a:
+            k,v = a.split("=", 1)
+        else:
+            k, v = a, None
+        if k in kernel_args:
+            kernel_args[k].append(v)
+        else:
+            kernel_args[k] = [v]
+
+    return kernel_args
+
+
+def quote(s):
+    """
+    Return a quoted string if it contains spaces.
+    Otherwise just return the string.
+    """
+    if " " in s:
+        return f"\"{s}\""
+    return s
+
+
+def JoinKernelArgs(kernel_args):
+    """
+    Join an OrderedDict of kernel argument and values into a kernel cmdline string
+
+    The dictionary is the output from SplitCmdline.
+    Values with spaces are quoted with ""
+    """
+    kernel_cmdline = []
+    for k, vs in kernel_args.items():
+        for v in vs:
+            if v is None:
+                kernel_cmdline.append(f"{k}")
+            else:
+                kernel_cmdline.append(f"{k}={quote(v)}")
+    return " ".join(kernel_cmdline)
+
+
+def AlterKernelArgs(kernel_args, rm_args, add_args):
+    """
+    Modify the kernel argument OrderedDict
+
+    This first removes all arguments listed in rm_args. It will ignore
+    arguments that are not present.
+
+    It then extends the arguments listed in the add_args dictionary if they are
+    already present, otherwise it adds them to kernel_args
+
+    It returns the modified kernel_args OrderedDict.
+    """
+    # Remove arguments
+    for k in rm_args:
+        if k in kernel_args:
+            del kernel_args[k]
+
+    # Add new arguments and update existing ones
+    for k, vs in add_args.items():
+        if k in kernel_args:
+            kernel_args[k].extend(vs)
+        else:
+            kernel_args[k] = vs
+
+    return kernel_args
 
 
 def GetISODetails(isopath):

--- a/src/bin/mkksiso
+++ b/src/bin/mkksiso
@@ -66,9 +66,9 @@ def quote(s):
     return s
 
 
-def JoinKernelArgs(kernel_args):
+def ListKernelArgs(kernel_args):
     """
-    Join an OrderedDict of kernel argument and values into a kernel cmdline string
+    Return a list of quoted kernel arguments and values
 
     The dictionary is the output from SplitCmdline.
     Values with spaces are quoted with ""
@@ -80,7 +80,18 @@ def JoinKernelArgs(kernel_args):
                 kernel_cmdline.append(f"{k}")
             else:
                 kernel_cmdline.append(f"{k}={quote(v)}")
-    return " ".join(kernel_cmdline)
+
+    return kernel_cmdline
+
+
+def JoinKernelArgs(kernel_args):
+    """
+    Return a string of quoted kernel arguments and values
+
+    The dictionary is the output from SplitCmdline.
+    Values with spaces are quoted with ""
+    """
+    return " ".join(ListKernelArgs(kernel_args))
 
 
 def AlterKernelArgs(kernel_args, rm_args, add_args):
@@ -108,6 +119,27 @@ def AlterKernelArgs(kernel_args, rm_args, add_args):
             kernel_args[k] = vs
 
     return kernel_args
+
+
+def WrapKernelArgs(kernel_args, width=80):
+    """
+    Return a wordwrapped string
+
+    It breaks the lines at spaces inbetween commands,
+    preserving quoted strings verbatim.
+    """
+    result = kernel_args[0]
+    cols = len(result)
+    for arg in kernel_args[1:]:
+        if 1 + cols + len(arg) > width:
+            result += "\n"
+            result += arg
+            cols = len(arg)
+        else:
+            result += " " + arg
+            cols = cols + len(arg) + 1
+    result += "\n"
+    return result
 
 
 def GetISODetails(isopath):
@@ -202,10 +234,31 @@ def ImplantMD5(output_iso):
         raise RuntimeError("implantisomd5 failed")
 
 
-def EditIsolinux(new_args, new_volid, old_volid, tmpdir):
+def GetCmdline(line, commands):
+    """
+    Get the cmdline portion of a line that starts with a command
+
+    returns the indented command prefix, and the cmdline.
+    """
+    for c in commands:
+        if c not in line:
+            continue
+
+        # The command must be the first non-whitespace word
+        first, _ = line.strip().split(" ", 1)
+        if first != c:
+            continue
+
+        indent, prefix, cmdline = line.partition(c)
+        return indent+prefix, cmdline.strip()
+
+    return "", line
+
+
+def EditIsolinux(rm_args, add_args, new_volid, old_volid, tmpdir):
     """
     Modify the cmdline for an isolinux.cfg
-    Add the new arguments and change existing volid if requested
+    Remove args, add new arguments and change existing volid if requested
     """
     orig_cfg = os.path.join(tmpdir, "isolinux/isolinux.cfg")
     if not os.path.exists(orig_cfg):
@@ -220,15 +273,19 @@ def EditIsolinux(new_args, new_volid, old_volid, tmpdir):
             for line in in_fp:
                 if change_volid and old_volid in line:
                     line = line.replace(old_volid, new_volid)
-                out_fp.write(line.rstrip("\n"))
-                if "append" in line:
-                    out_fp.write(" " + new_args)
-                out_fp.write("\n")
+                prefix, cmdline = GetCmdline(line, ["append"])
+                if prefix:
+                    args = SplitCmdline(cmdline)
+                    new_args = AlterKernelArgs(args, rm_args, add_args)
+                    out_fp.write(prefix+" "+JoinKernelArgs(new_args))
+                    out_fp.write("\n")
+                else:
+                    out_fp.write(line)
             out_fp.close()
         os.replace(orig_cfg + ".new", orig_cfg)
 
 
-def EditGrub2(new_args, new_volid, old_volid, tmpdir):
+def EditGrub2(rm_args, add_args, new_volid, old_volid, tmpdir):
     """
     Modify the cmdline for GRUB2 UEFI and BIOS config files
     Add the new arguments and change existing volid if requested
@@ -252,16 +309,20 @@ def EditGrub2(new_args, new_volid, old_volid, tmpdir):
                 for line in in_fp:
                     if change_volid and old_volid in line:
                         line = line.replace(old_volid, new_volid)
-                    out_fp.write(line.rstrip("\n"))
                     # Some start with linux (BIOS/aarch64), others with linuxefi (x86_64)
-                    if line.strip().startswith("linux"):
-                        out_fp.write(" "+new_args)
-                    out_fp.write("\n")
+                    prefix, cmdline = GetCmdline(line, ["linuxefi", "linux"])
+                    if prefix:
+                        args = SplitCmdline(cmdline)
+                        new_args = AlterKernelArgs(args, rm_args, add_args)
+                        out_fp.write(prefix+" "+JoinKernelArgs(new_args))
+                        out_fp.write("\n")
+                    else:
+                        out_fp.write(line)
                 out_fp.close()
         os.replace(orig_cfg + ".new", orig_cfg)
 
 
-def EditS390(new_args, new_volid, old_volid, tmpdir):
+def EditS390(rm_args, add_args, new_volid, old_volid, tmpdir):
     """
     Modify the cmdline for s390 config files
     Add the new arguments and change existing volid if requested
@@ -280,15 +341,23 @@ def EditS390(new_args, new_volid, old_volid, tmpdir):
             log.warning("No %s file found", cfg)
             continue
 
-        # Append to the config file
         with open(orig_cfg, "r") as in_fp:
-            with open(orig_cfg + ".new", "w") as out_fp:
-                for line in in_fp:
-                    if change_volid and old_volid in line:
-                        line = line.replace(old_volid, new_volid)
-                    out_fp.write(line)
-                out_fp.write(new_args+"\n")
-                out_fp.close()
+            # Read the config file and turn it into a line
+            lines = in_fp.readlines()
+
+        cmdline = " ".join(l.strip() for l in lines)
+        # Replace the volid
+        if change_volid and old_volid in cmdline:
+            cmdline = cmdline.replace(old_volid, new_volid)
+        args = SplitCmdline(cmdline)
+        new_args = AlterKernelArgs(args, rm_args, add_args)
+
+        cmdline = ListKernelArgs(new_args)
+
+        # Write the new config file, breaking at 80 columns
+        with open(orig_cfg + ".new", "w") as out_fp:
+            out_fp.write(WrapKernelArgs(cmdline, width=80))
+            out_fp.close()
         os.replace(orig_cfg + ".new", orig_cfg)
 
 
@@ -308,10 +377,14 @@ def CheckDiscinfo(path):
             raise RuntimeError("iso arch does not match the host arch.")
 
 
-def MakeKickstartISO(ks, input_iso, output_iso, add_paths, cmdline="", new_volid="", implantmd5=True):
+def MakeKickstartISO(input_iso, output_iso, ks="", add_paths=None,
+                    cmdline="", rm_args="", new_volid="", implantmd5=True):
     """
     Make a kickstart ISO from a boot.iso or dvd
     """
+    if add_paths is None:
+        add_paths = []
+
     # Gather information about the input iso
     old_volid, files = GetISODetails(input_iso)
     if not old_volid and not new_volid:
@@ -333,12 +406,17 @@ def MakeKickstartISO(ks, input_iso, output_iso, add_paths, cmdline="", new_volid
         new_volid = udev_escape(new_volid)
         old_volid = udev_escape(old_volid)
 
-        new_args = "inst.ks=hd:LABEL=%s:/%s %s" % (new_volid or old_volid, os.path.basename(ks), cmdline)
+        remove_args = rm_args.split(' ') if rm_args else []
+        add_args = SplitCmdline(cmdline)
+
+        if ks:
+            add_args["inst.ks"] = ["hd:LABEL=%s:/%s" % (new_volid or old_volid, os.path.basename(ks))]
+            add_paths.append(ks)
 
         # Add kickstart command and optionally change the volid of the available config files
-        EditIsolinux(new_args, new_volid, old_volid, tmpdir)
-        EditGrub2(new_args, new_volid, old_volid, tmpdir)
-        EditS390(new_args, new_volid, old_volid, tmpdir)
+        EditIsolinux(remove_args, add_args, new_volid, old_volid, tmpdir)
+        EditGrub2(remove_args, add_args, new_volid, old_volid, tmpdir)
+        EditS390(remove_args, add_args, new_volid, old_volid, tmpdir)
 
         # Build the command to rebuild the iso with the changes and additions
         cmd = ["xorriso", "-indev", input_iso, "-outdev", output_iso, "-boot_image", "any", "replay"]
@@ -352,7 +430,7 @@ def MakeKickstartISO(ks, input_iso, output_iso, add_paths, cmdline="", new_volid
                 cmd.extend(["-update", os.path.join(root, f), os.path.join(isoroot, f)])
 
         # Add the kickstart and the new files and directories
-        for p in [ks, *add_paths]:
+        for p in add_paths:
             cmd.extend(["-map", p, os.path.basename(p)])
 
         if CheckBigFiles(add_paths):
@@ -374,6 +452,8 @@ def setup_arg_parser():
                         help="File or directory to add to ISO (may be used multiple times)")
     parser.add_argument("-c", "--cmdline", dest="cmdline", metavar="CMDLINE", default="",
                         help="Arguments to add to kernel cmdline")
+    parser.add_argument("-r", "--rm-args", dest="rm_args", metavar="ARGS", default="",
+                        help="Space separated list of arguments to remove from the kernel cmdline")
     parser.add_argument("--debug", action="store_const", const=log.DEBUG,
                         dest="loglevel", default=log.INFO,
                         help="print debugging info")
@@ -401,7 +481,10 @@ def main():
                 log.error("%s binary is missing", t)
                 errors = True
 
-        for f in [args.input_iso] + args.add_paths:
+        files = [args.input_iso, *args.add_paths]
+        if args.ks:
+            files += [args.ks]
+        for f in files:
             if not os.path.exists(f):
                 log.error("%s is missing", f)
                 errors = True
@@ -410,11 +493,20 @@ def main():
             log.error("%s already exists", args.output_iso)
             errors = True
 
+        if "=" in args.rm_args:
+            log.error("--rm-args should only list the arguments to remove, not values")
+            errors = True
+
+        if not any([args.ks, args.add_paths, args.cmdline, args.rm_args, args.volid]):
+            log.error("Nothing to do - pass one or more of --ks, --add, --cmdline, --rm-args, --volid")
+            errors = True
+
         if errors:
             raise RuntimeError("Problems running %s" % sys.argv[0])
 
-        MakeKickstartISO(args.ks, args.input_iso, args.output_iso,
-                         args.add_paths, args.cmdline, args.volid, args.no_md5sum)
+        MakeKickstartISO(args.input_iso, args.output_iso, args.ks,
+                         args.add_paths, args.cmdline, args.rm_args,
+                         args.volid, args.no_md5sum)
     except RuntimeError as e:
         log.error(str(e))
         return 1

--- a/src/bin/mkksiso
+++ b/src/bin/mkksiso
@@ -177,7 +177,7 @@ def ExtractISOFiles(isopath, files, tmpdir):
     """
     cmd = ["osirrox", "-indev", isopath]
     for f in files:
-        cmd.extend(["-extract", f, os.path.join(tmpdir, f)])
+        cmd.extend(["-extract", f, tmpdir + "/" + f])
     subprocess.run(cmd, check=True, capture_output=False, env={"LANG": "C"})
 
 
@@ -210,7 +210,7 @@ def CheckBigFiles(add_paths):
                 for f in files + dirs:
                     if len(f) > MAX_FNAME:
                         raise RuntimeError("iso contains filenames that are too long: %s" % f)
-                    if os.stat(os.path.join(top,f)).st_size >= 4*1024**3:
+                    if os.stat(top + "/" + f).st_size >= 4*1024**3:
                         big_file = True
         else:
             if len(src) > MAX_FNAME:
@@ -260,7 +260,7 @@ def EditIsolinux(rm_args, add_args, new_volid, old_volid, tmpdir):
     Modify the cmdline for an isolinux.cfg
     Remove args, add new arguments and change existing volid if requested
     """
-    orig_cfg = os.path.join(tmpdir, "isolinux/isolinux.cfg")
+    orig_cfg = tmpdir + "/isolinux/isolinux.cfg"
     if not os.path.exists(orig_cfg):
         log.warning("No isolinux/isolinux.cfg file found")
         return
@@ -293,14 +293,14 @@ def EditGrub2(rm_args, add_args, new_volid, old_volid, tmpdir):
     grub_cfgs = ["EFI/BOOT/grub.cfg", "EFI/BOOT/BOOT.conf",
                  "boot/grub2/grub.cfg", "boot/grub/grub.cfg"]
 
-    if not any(os.path.exists(os.path.join(tmpdir, c)) for c in grub_cfgs):
+    if not any(os.path.exists(tmpdir + "/" + c) for c in grub_cfgs):
         log.warning("No grub config files found")
         return
 
     change_volid = old_volid != new_volid
 
     for cfg in grub_cfgs:
-        orig_cfg = os.path.join(tmpdir, cfg)
+        orig_cfg = tmpdir + "/" + cfg
         if not os.path.exists(orig_cfg):
             continue
 
@@ -329,14 +329,14 @@ def EditS390(rm_args, add_args, new_volid, old_volid, tmpdir):
     """
     s390_cfgs = ["images/generic.prm", "images/cdboot.prm"]
 
-    if not any(os.path.exists(os.path.join(tmpdir, c)) for c in s390_cfgs):
+    if not any(os.path.exists(tmpdir + "/" + c) for c in s390_cfgs):
         log.warning("No s390 config files found")
         return
 
     change_volid = old_volid != new_volid
 
     for cfg in s390_cfgs:
-        orig_cfg = os.path.join(tmpdir, cfg)
+        orig_cfg = tmpdir + "/" + cfg
         if not os.path.exists(orig_cfg):
             log.warning("No %s file found", cfg)
             continue
@@ -398,7 +398,7 @@ def MakeKickstartISO(input_iso, output_iso, ks="", add_paths=None,
     extract_files = set(files) & known_configs
     with tempfile.TemporaryDirectory(prefix="mkksiso-") as tmpdir:
         ExtractISOFiles(input_iso, extract_files, tmpdir)
-        CheckDiscinfo(os.path.join(tmpdir, ".discinfo"))
+        CheckDiscinfo(tmpdir + "/.discinfo")
         new_volid = new_volid or old_volid
         log.info("Volume Id = %s", new_volid)
 
@@ -427,7 +427,7 @@ def MakeKickstartISO(input_iso, output_iso, ks="", add_paths=None,
         for root, _, files in os.walk(tmpdir, topdown=False):
             isoroot = root.replace(tmpdir, "")
             for f in files:
-                cmd.extend(["-update", os.path.join(root, f), os.path.join(isoroot, f)])
+                cmd.extend(["-update", root + "/" + f, isoroot + "/" + f])
 
         # Add the kickstart and the new files and directories
         for p in add_paths:

--- a/test-packages
+++ b/test-packages
@@ -2,6 +2,7 @@ anaconda-tui
 beakerlib
 e2fsprogs
 git
+isomd5sum
 libselinux-python3
 make
 pbzip2
@@ -26,4 +27,5 @@ rsync
 squashfs-tools
 sudo
 which
+xorriso
 xz-lzma-compat

--- a/tests/mkksiso/data/BOOT.conf
+++ b/tests/mkksiso/data/BOOT.conf
@@ -1,0 +1,40 @@
+set default="1"
+
+function load_video {
+  insmod efi_gop
+  insmod efi_uga
+  insmod video_bochs
+  insmod video_cirrus
+  insmod all_video
+}
+
+load_video
+set gfxpayload=keep
+insmod gzio
+insmod part_gpt
+insmod ext2
+
+set timeout=60
+### END /etc/grub.d/00_header ###
+
+search --no-floppy --set=root -l 'Fedora-rawhide-test'
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Install Fedora rawhide' --class fedora --class gnu-linux --class gnu --class os {
+	linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-rawhide-test console=ttyUSB0 quiet
+	initrdefi /images/pxeboot/initrd.img
+}
+menuentry 'Test this media & install Fedora rawhide' --class fedora --class gnu-linux --class gnu --class os {
+	linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-rawhide-test rd.live.check quiet
+	initrdefi /images/pxeboot/initrd.img
+}
+submenu 'Troubleshooting -->' {
+	menuentry 'Install Fedora rawhide in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+		linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-rawhide-test nomodeset quiet
+		initrdefi /images/pxeboot/initrd.img
+	}
+	menuentry 'Rescue a Fedora system' --class fedora --class gnu-linux --class gnu --class os {
+		linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-rawhide-test inst.rescue quiet
+		initrdefi /images/pxeboot/initrd.img
+	}
+}

--- a/tests/mkksiso/data/BOOT.conf.result
+++ b/tests/mkksiso/data/BOOT.conf.result
@@ -1,0 +1,40 @@
+set default="1"
+
+function load_video {
+  insmod efi_gop
+  insmod efi_uga
+  insmod video_bochs
+  insmod video_cirrus
+  insmod all_video
+}
+
+load_video
+set gfxpayload=keep
+insmod gzio
+insmod part_gpt
+insmod ext2
+
+set timeout=60
+### END /etc/grub.d/00_header ###
+
+search --no-floppy --set=root -l 'Fedora-mkksiso-rawhide-test'
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Install Fedora rawhide' --class fedora --class gnu-linux --class gnu --class os {
+	linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+	initrdefi /images/pxeboot/initrd.img
+}
+menuentry 'Test this media & install Fedora rawhide' --class fedora --class gnu-linux --class gnu --class os {
+	linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test rd.live.check inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+	initrdefi /images/pxeboot/initrd.img
+}
+submenu 'Troubleshooting -->' {
+	menuentry 'Install Fedora rawhide in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+		linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test nomodeset inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+		initrdefi /images/pxeboot/initrd.img
+	}
+	menuentry 'Rescue a Fedora system' --class fedora --class gnu-linux --class gnu --class os {
+		linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test inst.rescue inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+		initrdefi /images/pxeboot/initrd.img
+	}
+}

--- a/tests/mkksiso/data/bios-grub.cfg
+++ b/tests/mkksiso/data/bios-grub.cfg
@@ -1,0 +1,36 @@
+set default="1"
+
+function load_video {
+  insmod all_video
+}
+
+load_video
+set gfxpayload=keep
+insmod gzio
+insmod part_gpt
+insmod ext2
+
+set timeout=60
+### END /etc/grub.d/00_header ###
+
+search --no-floppy --set=root -l 'Fedora-rawhide-test'
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Install Fedora rawhide' --class fedora --class gnu-linux --class gnu --class os {
+	linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-rawhide-test console=ttyUSB0 quiet
+	initrd /images/pxeboot/initrd.img
+}
+menuentry 'Test this media & install Fedora rawhide' --class fedora --class gnu-linux --class gnu --class os {
+	linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-rawhide-test rd.live.check quiet
+	initrd /images/pxeboot/initrd.img
+}
+submenu 'Troubleshooting -->' {
+	menuentry 'Install Fedora rawhide in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+		linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-rawhide-test nomodeset quiet
+		initrd /images/pxeboot/initrd.img
+	}
+	menuentry 'Rescue a Fedora system' --class fedora --class gnu-linux --class gnu --class os {
+		linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-rawhide-test inst.rescue quiet
+		initrd /images/pxeboot/initrd.img
+	}
+}

--- a/tests/mkksiso/data/bios-grub.cfg.result
+++ b/tests/mkksiso/data/bios-grub.cfg.result
@@ -1,0 +1,36 @@
+set default="1"
+
+function load_video {
+  insmod all_video
+}
+
+load_video
+set gfxpayload=keep
+insmod gzio
+insmod part_gpt
+insmod ext2
+
+set timeout=60
+### END /etc/grub.d/00_header ###
+
+search --no-floppy --set=root -l 'Fedora-mkksiso-rawhide-test'
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Install Fedora rawhide' --class fedora --class gnu-linux --class gnu --class os {
+	linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+	initrd /images/pxeboot/initrd.img
+}
+menuentry 'Test this media & install Fedora rawhide' --class fedora --class gnu-linux --class gnu --class os {
+	linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test rd.live.check inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+	initrd /images/pxeboot/initrd.img
+}
+submenu 'Troubleshooting -->' {
+	menuentry 'Install Fedora rawhide in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+		linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test nomodeset inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+		initrd /images/pxeboot/initrd.img
+	}
+	menuentry 'Rescue a Fedora system' --class fedora --class gnu-linux --class gnu --class os {
+		linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test inst.rescue inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+		initrd /images/pxeboot/initrd.img
+	}
+}

--- a/tests/mkksiso/data/cdboot.prm
+++ b/tests/mkksiso/data/cdboot.prm
@@ -1,0 +1,3 @@
+ro inst.stage2=hd:LABEL=Fedora-rawhide-test
+console=ttyUSB0
+quiet

--- a/tests/mkksiso/data/cdboot.prm.result
+++ b/tests/mkksiso/data/cdboot.prm.result
@@ -1,0 +1,3 @@
+ro inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test inst.ks=file:///installer.ks
+quoted="A longer string with spaces that is quoted should not be split"
+console=ttyS0,115200n8 console=tty1

--- a/tests/mkksiso/data/efi-grub.cfg.result
+++ b/tests/mkksiso/data/efi-grub.cfg.result
@@ -1,0 +1,40 @@
+set default="1"
+
+function load_video {
+  insmod efi_gop
+  insmod efi_uga
+  insmod video_bochs
+  insmod video_cirrus
+  insmod all_video
+}
+
+load_video
+set gfxpayload=keep
+insmod gzio
+insmod part_gpt
+insmod ext2
+
+set timeout=60
+### END /etc/grub.d/00_header ###
+
+search --no-floppy --set=root -l 'Fedora-mkksiso-rawhide-test'
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Install Fedora rawhide' --class fedora --class gnu-linux --class gnu --class os {
+	linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+	initrdefi /images/pxeboot/initrd.img
+}
+menuentry 'Test this media & install Fedora rawhide' --class fedora --class gnu-linux --class gnu --class os {
+	linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test rd.live.check inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+	initrdefi /images/pxeboot/initrd.img
+}
+submenu 'Troubleshooting -->' {
+	menuentry 'Install Fedora rawhide in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+		linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test nomodeset inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+		initrdefi /images/pxeboot/initrd.img
+	}
+	menuentry 'Rescue a Fedora system' --class fedora --class gnu-linux --class gnu --class os {
+		linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test inst.rescue inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+		initrdefi /images/pxeboot/initrd.img
+	}
+}

--- a/tests/mkksiso/data/generic.prm
+++ b/tests/mkksiso/data/generic.prm
@@ -1,0 +1,3 @@
+ro ramdisk_size=40000 cio_ignore=all,!condev
+console=ttyUSB0
+quiet

--- a/tests/mkksiso/data/generic.prm.result
+++ b/tests/mkksiso/data/generic.prm.result
@@ -1,0 +1,3 @@
+ro ramdisk_size=40000 cio_ignore=all,!condev inst.ks=file:///installer.ks
+quoted="A longer string with spaces that is quoted should not be split"
+console=ttyS0,115200n8 console=tty1

--- a/tests/mkksiso/data/isolinux.cfg
+++ b/tests/mkksiso/data/isolinux.cfg
@@ -1,0 +1,111 @@
+default vesamenu.c32
+timeout 600
+
+display boot.msg
+
+# Clear the screen when exiting the menu, instead of leaving the menu displayed.
+# For vesamenu, this means the graphical background is still displayed without
+# the menu itself for as long as the screen remains in graphics mode.
+menu clear
+menu background splash.png
+menu title Fedora rawhide
+menu vshift 8
+menu rows 18
+menu margin 8
+#menu hidden
+menu helpmsgrow 15
+menu tabmsgrow 13
+
+# Border Area
+menu color border * #00000000 #00000000 none
+
+# Selected item
+menu color sel 0 #ffffffff #00000000 none
+
+# Title bar
+menu color title 0 #ff7ba3d0 #00000000 none
+
+# Press [Tab] message
+menu color tabmsg 0 #ff3a6496 #00000000 none
+
+# Unselected menu item
+menu color unsel 0 #84b8ffff #00000000 none
+
+# Selected hotkey
+menu color hotsel 0 #84b8ffff #00000000 none
+
+# Unselected hotkey
+menu color hotkey 0 #ffffffff #00000000 none
+
+# Help text
+menu color help 0 #ffffffff #00000000 none
+
+# A scrollbar of some type? Not sure.
+menu color scrollbar 0 #ffffffff #ff355594 none
+
+# Timeout msg
+menu color timeout 0 #ffffffff #00000000 none
+menu color timeout_msg 0 #ffffffff #00000000 none
+
+# Command prompt text
+menu color cmdmark 0 #84b8ffff #00000000 none
+menu color cmdline 0 #ffffffff #00000000 none
+
+# Do not display the actual menu unless the user presses a key. All that is displayed is a timeout message.
+
+menu tabmsg Press Tab for full configuration options on menu items.
+
+menu separator # insert an empty line
+menu separator # insert an empty line
+
+label linux
+  menu label ^Install Fedora rawhide
+  kernel vmlinuz
+  append initrd=initrd.img inst.stage2=hd:LABEL=Fedora-rawhide-test console=ttyUSB0 quiet
+
+label check
+  menu label Test this ^media & install Fedora rawhide
+  menu default
+  kernel vmlinuz
+  append initrd=initrd.img inst.stage2=hd:LABEL=Fedora-rawhide-test rd.live.check quiet
+
+menu separator # insert an empty line
+
+# utilities submenu
+menu begin ^Troubleshooting
+  menu title Troubleshooting Fedora rawhide
+
+label basic
+  menu indent count 5
+  menu label Install using ^basic graphics mode
+  text help
+	Try this option out if you're having trouble installing
+	Fedora rawhide.
+  endtext
+  kernel vmlinuz
+  append initrd=initrd.img inst.stage2=hd:LABEL=Fedora-rawhide-test nomodeset quiet
+
+label rescue
+  menu indent count 5
+  menu label ^Rescue a Fedora system
+  text help
+	If the system will not boot, this lets you access files
+	and edit config files to try to get it booting again.
+  endtext
+  kernel vmlinuz
+  append initrd=initrd.img inst.stage2=hd:LABEL=Fedora-rawhide-test inst.rescue quiet
+
+menu separator # insert an empty line
+
+label local
+  menu label Boot from ^local drive
+  localboot 0xffff
+
+menu separator # insert an empty line
+menu separator # insert an empty line
+
+label returntomain
+  menu label Return to ^main menu
+  menu exit
+
+menu end

--- a/tests/mkksiso/data/isolinux.cfg.result
+++ b/tests/mkksiso/data/isolinux.cfg.result
@@ -1,0 +1,111 @@
+default vesamenu.c32
+timeout 600
+
+display boot.msg
+
+# Clear the screen when exiting the menu, instead of leaving the menu displayed.
+# For vesamenu, this means the graphical background is still displayed without
+# the menu itself for as long as the screen remains in graphics mode.
+menu clear
+menu background splash.png
+menu title Fedora rawhide
+menu vshift 8
+menu rows 18
+menu margin 8
+#menu hidden
+menu helpmsgrow 15
+menu tabmsgrow 13
+
+# Border Area
+menu color border * #00000000 #00000000 none
+
+# Selected item
+menu color sel 0 #ffffffff #00000000 none
+
+# Title bar
+menu color title 0 #ff7ba3d0 #00000000 none
+
+# Press [Tab] message
+menu color tabmsg 0 #ff3a6496 #00000000 none
+
+# Unselected menu item
+menu color unsel 0 #84b8ffff #00000000 none
+
+# Selected hotkey
+menu color hotsel 0 #84b8ffff #00000000 none
+
+# Unselected hotkey
+menu color hotkey 0 #ffffffff #00000000 none
+
+# Help text
+menu color help 0 #ffffffff #00000000 none
+
+# A scrollbar of some type? Not sure.
+menu color scrollbar 0 #ffffffff #ff355594 none
+
+# Timeout msg
+menu color timeout 0 #ffffffff #00000000 none
+menu color timeout_msg 0 #ffffffff #00000000 none
+
+# Command prompt text
+menu color cmdmark 0 #84b8ffff #00000000 none
+menu color cmdline 0 #ffffffff #00000000 none
+
+# Do not display the actual menu unless the user presses a key. All that is displayed is a timeout message.
+
+menu tabmsg Press Tab for full configuration options on menu items.
+
+menu separator # insert an empty line
+menu separator # insert an empty line
+
+label linux
+  menu label ^Install Fedora rawhide
+  kernel vmlinuz
+  append initrd=initrd.img inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+
+label check
+  menu label Test this ^media & install Fedora rawhide
+  menu default
+  kernel vmlinuz
+  append initrd=initrd.img inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test rd.live.check inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+
+menu separator # insert an empty line
+
+# utilities submenu
+menu begin ^Troubleshooting
+  menu title Troubleshooting Fedora rawhide
+
+label basic
+  menu indent count 5
+  menu label Install using ^basic graphics mode
+  text help
+	Try this option out if you're having trouble installing
+	Fedora rawhide.
+  endtext
+  kernel vmlinuz
+  append initrd=initrd.img inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test nomodeset inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+
+label rescue
+  menu indent count 5
+  menu label ^Rescue a Fedora system
+  text help
+	If the system will not boot, this lets you access files
+	and edit config files to try to get it booting again.
+  endtext
+  kernel vmlinuz
+  append initrd=initrd.img inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test inst.rescue inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+
+menu separator # insert an empty line
+
+label local
+  menu label Boot from ^local drive
+  localboot 0xffff
+
+menu separator # insert an empty line
+menu separator # insert an empty line
+
+label returntomain
+  menu label Return to ^main menu
+  menu exit
+
+menu end

--- a/tests/mkksiso/data/uefi-grub.cfg
+++ b/tests/mkksiso/data/uefi-grub.cfg
@@ -1,0 +1,40 @@
+set default="1"
+
+function load_video {
+  insmod efi_gop
+  insmod efi_uga
+  insmod video_bochs
+  insmod video_cirrus
+  insmod all_video
+}
+
+load_video
+set gfxpayload=keep
+insmod gzio
+insmod part_gpt
+insmod ext2
+
+set timeout=60
+### END /etc/grub.d/00_header ###
+
+search --no-floppy --set=root -l 'Fedora-rawhide-test'
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Install Fedora rawhide' --class fedora --class gnu-linux --class gnu --class os {
+	linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-rawhide-test console=ttyUSB0 quiet
+	initrdefi /images/pxeboot/initrd.img
+}
+menuentry 'Test this media & install Fedora rawhide' --class fedora --class gnu-linux --class gnu --class os {
+	linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-rawhide-test rd.live.check quiet
+	initrdefi /images/pxeboot/initrd.img
+}
+submenu 'Troubleshooting -->' {
+	menuentry 'Install Fedora rawhide in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+		linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-rawhide-test nomodeset quiet
+		initrdefi /images/pxeboot/initrd.img
+	}
+	menuentry 'Rescue a Fedora system' --class fedora --class gnu-linux --class gnu --class os {
+		linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-rawhide-test inst.rescue quiet
+		initrdefi /images/pxeboot/initrd.img
+	}
+}

--- a/tests/mkksiso/data/uefi-grub.cfg.result
+++ b/tests/mkksiso/data/uefi-grub.cfg.result
@@ -1,0 +1,40 @@
+set default="1"
+
+function load_video {
+  insmod efi_gop
+  insmod efi_uga
+  insmod video_bochs
+  insmod video_cirrus
+  insmod all_video
+}
+
+load_video
+set gfxpayload=keep
+insmod gzio
+insmod part_gpt
+insmod ext2
+
+set timeout=60
+### END /etc/grub.d/00_header ###
+
+search --no-floppy --set=root -l 'Fedora-mkksiso-rawhide-test'
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Install Fedora rawhide' --class fedora --class gnu-linux --class gnu --class os {
+	linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+	initrdefi /images/pxeboot/initrd.img
+}
+menuentry 'Test this media & install Fedora rawhide' --class fedora --class gnu-linux --class gnu --class os {
+	linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test rd.live.check inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+	initrdefi /images/pxeboot/initrd.img
+}
+submenu 'Troubleshooting -->' {
+	menuentry 'Install Fedora rawhide in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+		linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test nomodeset inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+		initrdefi /images/pxeboot/initrd.img
+	}
+	menuentry 'Rescue a Fedora system' --class fedora --class gnu-linux --class gnu --class os {
+		linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-mkksiso-rawhide-test inst.rescue inst.ks=file:///installer.ks quoted="A longer string with spaces that is quoted should not be split" console=ttyS0,115200n8 console=tty1
+		initrdefi /images/pxeboot/initrd.img
+	}
+}

--- a/tests/mkksiso/mkksiso.py
+++ b/tests/mkksiso/mkksiso.py
@@ -1,0 +1,1 @@
+../../src/bin/mkksiso

--- a/tests/mkksiso/test_boot_repo.sh
+++ b/tests/mkksiso/test_boot_repo.sh
@@ -18,7 +18,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Make new iso with kickstart and extra-repo"
-        rlRun -t -c "$CLI --add $TMP_DIR/extra-repo $2 $1 $TMP_DIR/ks-boot.iso"
+        rlRun -t -c "$CLI --add $TMP_DIR/extra-repo --ks $2 $1 $TMP_DIR/ks-boot.iso"
         rlAssertExists "$TMP_DIR/ks-boot.iso"
     rlPhaseEnd
 

--- a/tests/mkksiso/test_liveimg.sh
+++ b/tests/mkksiso/test_liveimg.sh
@@ -18,7 +18,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Make a new iso with kickstart and root.tar.xz"
-        rlRun -t -c "$CLI --add $TMP_DIR/root.tar.xz $2 $1 $TMP_DIR/liveimg-boot.iso"
+        rlRun -t -c "$CLI --add $TMP_DIR/root.tar.xz --ks $2 $1 $TMP_DIR/liveimg-boot.iso"
         rlAssertExists "$TMP_DIR/liveimg-boot.iso"
     rlPhaseEnd
 

--- a/tests/mkksiso/test_mkksiso.py
+++ b/tests/mkksiso/test_mkksiso.py
@@ -1,0 +1,36 @@
+from collections import OrderedDict
+from mkksiso import AlterKernelArgs, JoinKernelArgs, SplitCmdline, quote
+import unittest
+
+
+class MkksisoTestCase(unittest.TestCase):
+    def test_AlterKernelArgs(self):
+        new_kernel_args = AlterKernelArgs(
+                OrderedDict({"BOOT_IMAGE": ["kernel-command-stuff"], "console": ["tty1"]}),
+                ["quiet", "rd.break"],
+                OrderedDict({"inst.ks": ["file:///foo.cfg"], "console": ["ttyS0", "ttyS1"]}))
+        self.assertTrue("quiet" not in new_kernel_args)
+        self.assertTrue("rd.break" not in new_kernel_args)
+        self.assertEqual(["tty1", "ttyS0", "ttyS1"], new_kernel_args["console"])
+        self.assertEqual(["file:///foo.cfg"], new_kernel_args["inst.ks"])
+
+    def test_quote(self):
+        self.assertEqual('"this is quoted"', quote("this is quoted"))
+        self.assertEqual("thisisnotquoted", quote("thisisnotquoted"))
+
+    def test_SplitCmdline(self):
+        args = SplitCmdline("BOOT_IMAGE=(hd0,msdos1)/vmlinuz-5.18.0-0.rc5.20220503git9050ba3a61a4b5b.41.fc37.x86_64 root=UUID=6be5119f-8de7-4da1-8e19-3e84cbe5d792 ro console=ttyS0,115200,N81 console=tty1 rhgb quiet")
+        self.assertTrue("BOOT_IMAGE" in args)
+        self.assertTrue("root" in args)
+        self.assertEqual(["UUID=6be5119f-8de7-4da1-8e19-3e84cbe5d792"], args["root"])
+        self.assertTrue("ro" in args)
+        self.assertEqual([None], args["ro"])
+        self.assertTrue("console" in args)
+        self.assertTrue(len(args["console"]) == 2)
+        self.assertEqual(["ttyS0,115200,N81", "tty1"], args["console"])
+
+    def test_JoinKernelArgs(self):
+        args = OrderedDict({"root": ["UUID=6be5119f-8de7-4da1-8e19-3e84cbe5d792"],
+                "ro": [None], "quiet": [None],
+                "console": ["ttyS0,115200,N81", "tty1"]})
+        self.assertEqual("root=UUID=6be5119f-8de7-4da1-8e19-3e84cbe5d792 ro quiet console=ttyS0,115200,N81 console=tty1", JoinKernelArgs(args))

--- a/tests/mkksiso/test_mkksiso.py
+++ b/tests/mkksiso/test_mkksiso.py
@@ -1,7 +1,31 @@
 from collections import OrderedDict
-from mkksiso import AlterKernelArgs, JoinKernelArgs, SplitCmdline, quote
+import os
+import shutil
+import subprocess
+import tempfile
+import time
 import unittest
 
+from mkksiso import AlterKernelArgs, JoinKernelArgs, SplitCmdline, quote, WrapKernelArgs
+from mkksiso import GetCmdline, ListKernelArgs, udev_escape
+from mkksiso import EditIsolinux, EditGrub2, EditS390
+from mkksiso import CheckDiscinfo, GetISODetails, ExtractISOFiles, MakeKickstartISO
+
+
+def check_cfg_results(self, tmpdir, configs):
+    """
+    Helper function to check config file changes against .result files
+    """
+    test_data = os.path.dirname(__file__) + "/data"
+    for cfg in configs:
+        with open(test_data + "/" + cfg + ".result") as f:
+            expected_cfg = f.read()
+        for path in configs[cfg]:
+            with open(tmpdir + "/" + path) as f:
+                new_cfg = f.read()
+
+            self.maxDiff = None
+            self.assertEqual(expected_cfg, new_cfg)
 
 class MkksisoTestCase(unittest.TestCase):
     def test_AlterKernelArgs(self):
@@ -19,7 +43,7 @@ class MkksisoTestCase(unittest.TestCase):
         self.assertEqual("thisisnotquoted", quote("thisisnotquoted"))
 
     def test_SplitCmdline(self):
-        args = SplitCmdline("BOOT_IMAGE=(hd0,msdos1)/vmlinuz-5.18.0-0.rc5.20220503git9050ba3a61a4b5b.41.fc37.x86_64 root=UUID=6be5119f-8de7-4da1-8e19-3e84cbe5d792 ro console=ttyS0,115200,N81 console=tty1 rhgb quiet")
+        args = SplitCmdline("BOOT_IMAGE=(hd0,msdos1)/vmlinuz-5.18.0-0.rc5.20220503git9050ba3a61a4b5b.41.fc37.x86_64 root=UUID=6be5119f-8de7-4da1-8e19-3e84cbe5d792 ro console=ttyS0,115200n8 console=tty1 rhgb quiet")
         self.assertTrue("BOOT_IMAGE" in args)
         self.assertTrue("root" in args)
         self.assertEqual(["UUID=6be5119f-8de7-4da1-8e19-3e84cbe5d792"], args["root"])
@@ -27,10 +51,199 @@ class MkksisoTestCase(unittest.TestCase):
         self.assertEqual([None], args["ro"])
         self.assertTrue("console" in args)
         self.assertTrue(len(args["console"]) == 2)
-        self.assertEqual(["ttyS0,115200,N81", "tty1"], args["console"])
+        self.assertEqual(["ttyS0,115200n8", "tty1"], args["console"])
 
     def test_JoinKernelArgs(self):
         args = OrderedDict({"root": ["UUID=6be5119f-8de7-4da1-8e19-3e84cbe5d792"],
                 "ro": [None], "quiet": [None],
-                "console": ["ttyS0,115200,N81", "tty1"]})
-        self.assertEqual("root=UUID=6be5119f-8de7-4da1-8e19-3e84cbe5d792 ro quiet console=ttyS0,115200,N81 console=tty1", JoinKernelArgs(args))
+                "console": ["ttyS0,115200n8", "tty1"]})
+        self.assertEqual("root=UUID=6be5119f-8de7-4da1-8e19-3e84cbe5d792 ro quiet console=ttyS0,115200n8 console=tty1", JoinKernelArgs(args))
+
+    def test_WrapKernelArgs(self):
+        kernel_args = OrderedDict({"BOOT_IMAGE": ["(hd0,msdos1)/vmlinuz-5.18.0-0.rc5.20220503git9050ba3a61a4b5b.41.fc37.x86_64"],
+                             "root": ["UUID=6be5119f-8de7-4da1-8e19-3e84cbe5d792"],
+                             "inst.ks": ["file:///installer.ks"],
+                             "quoted": ["A longer string with spaces that is quoted should not be split"],
+                             "console": ["tty1"], "quiet": [None], "rhgb": [None]})
+        expected = """BOOT_IMAGE=(hd0,msdos1)/vmlinuz-5.18.0-0.rc5.20220503git9050ba3a61a4b5b.41.fc37.x86_64
+root=UUID=6be5119f-8de7-4da1-8e19-3e84cbe5d792 inst.ks=file:///installer.ks
+quoted="A longer string with spaces that is quoted should not be split"
+console=tty1 quiet rhgb
+"""
+        self.assertEqual(WrapKernelArgs(ListKernelArgs(kernel_args)), expected)
+
+    def test_udev_escape(self):
+        self.assertEqual(udev_escape("Si!ly <volid> te$t"), r"Si\x21ly\x20\x3cvolid\x3e\x20te\x24t")
+
+    def test_GetCmdline(self):
+        self.assertEqual(GetCmdline("     append ro inst.ks=http://kickstart.cfg quiet", ["append"]),
+                        ("     append", "ro inst.ks=http://kickstart.cfg quiet"))
+        self.assertEqual(GetCmdline("\t\tlinux ro console=ttyS0 rhgb", ["linuxefi", "linux"]),
+                        ("\t\tlinux", "ro console=ttyS0 rhgb"))
+        self.assertEqual(GetCmdline("\t\tlinux ro console=ttyS0 rhgb", ["linuxefi", "linux"]),
+                        ("\t\tlinux", "ro console=ttyS0 rhgb"))
+        self.assertEqual(GetCmdline("\t\tinitrd /images/pxeboot/initrd.img", ["linuxefi", "linux"]),
+                        ("", "\t\tinitrd /images/pxeboot/initrd.img"))
+
+    def test_CheckDiscinfo(self):
+        with tempfile.TemporaryDirectory(prefix="mkksiso-") as tmpdir:
+            with open(tmpdir + "/.discinfo.good", "wt") as f:
+                f.write(str(time.time()) + "\n")
+                f.write("Fedora mkksiso discinfo test\n")
+                f.write(os.uname().machine + "\n")
+                f.close()
+
+            with open(tmpdir + "/.discinfo.bad", "wt") as f:
+                f.write(str(time.time()) + "\n")
+                f.write("Fedora mkksiso discinfo test\n")
+                f.write("NOT_AN_ARCH\n")
+                f.close()
+
+            # Should not raise an error
+            CheckDiscinfo(tmpdir + "/.discinfo.good")
+
+            # Raises an error
+            with self.assertRaises(RuntimeError):
+                CheckDiscinfo(tmpdir + "/.discinfo.bad")
+
+
+class EditConfigsTestCase(unittest.TestCase):
+    def setUp(self):
+        # pylint: disable=attribute-defined-outside-init
+        self.rm_args = ["console", "quiet", "inst.cmdline"]
+        self.add_args = OrderedDict({
+                            "inst.ks": ["file:///installer.ks"],
+                            "quoted": ["A longer string with spaces that is quoted should not be split"],
+                            "console": ["ttyS0,115200n8", "tty1"]
+            })
+        self.new_volid = "Fedora-mkksiso-rawhide-test"
+        self.old_volid = "Fedora-rawhide-test"
+
+    def run_test(self, configs, tmpdir, test_fn):
+        """
+        Run the test_fn on the configs
+
+        configs is a dict, like this:
+        {
+            "isolinux.cfg": ["isolinux/isolinux.cfg"],
+        }
+
+        The key is a config file under ./data/ and the list is the paths and filenames
+        to write to.
+
+        The function is called, and the results are compared to the results
+        which are in the file named for the key with '.result' appended. eg.
+        './data/isolinux.cfg.result'
+        """
+        test_data = os.path.dirname(__file__) + "/data"
+        # Copy the test data under tmpdir, simulating the root of an ISO
+        for cfg in configs:
+            for path in configs[cfg]:
+                os.makedirs(os.path.dirname(tmpdir + "/" + path), exist_ok=True)
+                shutil.copy(test_data + "/" + cfg, tmpdir + "/" + path)
+
+        test_fn(self.rm_args, self.add_args, self.new_volid, self.old_volid, tmpdir)
+
+        # Read the modified config file(s) and compare to result file
+        check_cfg_results(self, tmpdir, configs)
+
+    def test_EditIsolinux(self):
+        with tempfile.TemporaryDirectory(prefix="mkksiso-") as tmpdir:
+            self.run_test({"isolinux.cfg": ["isolinux/isolinux.cfg"]}, tmpdir, EditIsolinux)
+
+    def test_EditGrub2(self):
+        with tempfile.TemporaryDirectory(prefix="mkksiso-") as tmpdir:
+            self.run_test({
+                "uefi-grub.cfg": ["EFI/BOOT/grub.cfg"],
+                "bios-grub.cfg": ["boot/grub2/grub.cfg", "boot/grub/grub.cfg"],
+                "BOOT.conf": ["EFI/BOOT/BOOT.conf"]}, tmpdir, EditGrub2)
+
+    def test_EditS390(self):
+        with tempfile.TemporaryDirectory(prefix="mkksiso-") as tmpdir:
+            self.run_test({"generic.prm": ["images/generic.prm"],
+                           "cdboot.prm": ["images/cdboot.prm"]}, tmpdir, EditS390)
+
+
+class ISOTestCase(unittest.TestCase):
+    test_iso = None
+    out_iso = None
+    expected_files = []
+
+    def setUp(self):
+        self.configs = {
+            "isolinux.cfg": ["isolinux/isolinux.cfg"],
+            "uefi-grub.cfg": ["EFI/BOOT/grub.cfg"],
+            "bios-grub.cfg": ["boot/grub2/grub.cfg", "boot/grub/grub.cfg"],
+            "BOOT.conf": ["EFI/BOOT/BOOT.conf"],
+            "generic.prm": ["images/generic.prm"],
+            "cdboot.prm": ["images/cdboot.prm"]}
+
+        # Make a fake iso that just has the config files in it
+        test_data = os.path.dirname(__file__) + "/data"
+        with tempfile.TemporaryDirectory(prefix="mkksiso-") as tmpdir:
+            grafts = set()
+            # Copy the test data under tmpdir, simulating the root of an ISO
+            for cfg in self.configs:
+                for path in self.configs[cfg]:
+                    os.makedirs(os.path.dirname(tmpdir + "/" + path), exist_ok=True)
+                    shutil.copy(test_data + "/" + cfg, tmpdir + "/" + path)
+
+                    # Add the top as a graft point
+                    grafts.add(path.split("/")[0])
+                    self.expected_files.append(path)
+
+            # NOTE: Just want a random filename here, not an open file, so mktemp() is used
+            self.test_iso = tempfile.mktemp(prefix="mkksiso-")
+            # Make an iso with volid and default config files
+            cmd = ["xorrisofs", "-o", self.test_iso, "-R", "-J", "-V", "Fedora-rawhide-test",
+                   "-graft-points"]
+            cmd.extend(f"{g}={tmpdir}/{g}" for g in grafts)
+            subprocess.run(cmd, check=True, capture_output=False, env={"LANG": "C"})
+
+    def tearDown(self):
+        if self.test_iso and os.path.exists(self.test_iso):
+            os.unlink(self.test_iso)
+
+        if self.out_iso and os.path.exists(self.out_iso):
+            os.unlink(self.out_iso)
+
+    def test_GetISODetails(self):
+        """
+        Test getting the volid and list of files from the test iso
+        """
+        volid, files = GetISODetails(self.test_iso)
+
+        self.assertEqual(volid, "Fedora-rawhide-test")
+        self.assertTrue(len(files) > 0)
+
+        # File list also includes directories, we only care about the files:
+        diff = set(self.expected_files) - set(files)
+        self.assertEqual(len(diff), 0, diff)
+
+    def test_ExtractISOFiles(self):
+        """
+        Test extracting files from the test iso
+        """
+        with tempfile.TemporaryDirectory(prefix="mkksiso-") as tmpdir:
+            ExtractISOFiles(self.test_iso, self.expected_files, tmpdir)
+
+            missing = [f for f in self.expected_files if not os.path.exists(tmpdir + "/" + f)]
+            self.assertEqual(len(missing), 0, missing)
+
+    def test_MakeKickstartISO(self):
+        """
+        Test the full process of editing the cmdline and adding a kickstart
+        """
+        rm_args = "console quiet inst.cmdline"
+        cmdline = "inst.ks=file:///installer.ks quoted=\"A longer string with spaces that is quoted should not be split\" console=ttyS0,115200n8 console=tty1"
+        new_volid = "Fedora-mkksiso-rawhide-test"
+
+        self.out_iso = tempfile.mktemp(prefix="mkksiso-")
+        MakeKickstartISO(self.test_iso, self.out_iso, cmdline=cmdline, rm_args=rm_args,
+                new_volid=new_volid, implantmd5=True)
+
+        with tempfile.TemporaryDirectory(prefix="mkksiso-") as tmpdir:
+            ExtractISOFiles(self.out_iso, self.expected_files, tmpdir)
+
+            # Read the modified config file(s) and compare to result file
+            check_cfg_results(self, tmpdir, self.configs)


### PR DESCRIPTION
It doesn't exist, so this will cause build failures. Instead allow it to
be built, but be aware that 100% functionality may not be possible based
on the templates being used.