### PR TITLE
templates: adjust for mellanox firmware split to subpackage

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -232,8 +232,6 @@ removefrom linux-firmware /usr/lib/firmware/qcom/sm8250/*
 removefrom linux-firmware /usr/lib/firmware/qcom/venus*/*
 removefrom linux-firmware /usr/lib/firmware/qcom/vpu*/*
 removefrom linux-firmware /usr/lib/firmware/meson/vdec/*
-removefrom linux-firmware /usr/lib/firmware/mellanox/mlxsw_spectrum*
-removefrom linux-firmware /usr/lib/firmware/mellanox/lc_ini_bundle*
 removefrom linux-firmware /usr/lib/firmware/phanfw.bin*
 %if basearch != "aarch64":
     removefrom linux-firmware /usr/lib/firmware/dpaa2/*

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -31,7 +31,7 @@ installpkg grubby
                            --except uhd-firmware --except lulzbot-marlin-firmware \
                            --except gnome-firmware --except sigrok-firmware \
                            --except liquidio-firmware --except netronome-firmware \
-                           --except mrvlprestera-firmware
+                           --except mrvlprestera-firmware --except mlxsw_spectrum-firmware
     installpkg b43-openfwwf
 %endif
 


### PR DESCRIPTION
In Rawhide, Mellanox firmwares have been split to a subpackage,
so as usual we need to exclude that from the *-firmware install
and drop the stripping of it from linux-firmware.

Signed-off-by: Adam Williamson <awilliam@redhat.com>