### PR TITLE
tests: Use Fedora 36 for test-in-podman

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:rawhide
+FROM registry.fedoraproject.org/fedora:36
 COPY test-packages .
 RUN dnf -y install $(cat test-packages) && touch /.in-container
 RUN useradd weldr


### PR DESCRIPTION
rawhide (Fedora 37) has been rebuilt for python 3.11 which isn't
supported by pylint/astroid yet. Use Fedora 36 and python 3.10
until it is ready.