### PR TITLE
lorax.spec: Fix changelog

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -364,23 +364,10 @@ make DESTDIR=$RPM_BUILD_ROOT mandir=%{_mandir} install
 - Improve lmc no-virt error handling (bcl@redhat.com)
 - lorax.spec: Drop GConf2 requirement (bcl@redhat.com)
 
-* Wed Dec 02 2020 Brian C. Lane <bcl@redhat.com> 34.3-4
+* Wed Dec 02 2020 Brian C. Lane <bcl@redhat.com> 34.5-1
 - lorax.spec: Update for RHEL 9 Alpha changes (bcl@redhat.com)
 - lorax: Strip ' from product cmdline argument (bcl@redhat.com)
 - Change rootfs default size to 3GiB (sgallagh@redhat.com)
-
-* Mon Nov 30 2020 Brian C. Lane <bcl@redhat.com> 34.5-1
-- Don't remove libldap_r libraries during runtime-cleanup.tmpl (spichugi@redhat.com)
-- Do not use '--loglevel' option when running Anaconda (vtrefny@redhat.com)
-- Makefile: quiet rsync use in testing (bcl@redhat.com)
-- Switch to using GitHub Actions instead of Travis CI (bcl@redhat.com)
-
-* Mon Nov 02 2020 Brian C. Lane <bcl@redhat.com> 34.4-1
-- Update the default release version to 34 (bcl@redhat.com)
-- Remove mdmonitor service from boot.iso (bcl@redhat.com)
-- Switch to using upstream mk-s390image for s390 cdboot.img creation (bcl@redhat.com)
-- sshd_config: Apply suggested changes (bcl@redhat.com)
-- lorax.spec: Add BuildRequires on systemd-rpm-macros for tmpfilesdir macro (bcl@redhat.com)
 
 * Thu Oct 29 2020 Brian C. Lane <bcl@redhat.com> - 34.3-4
 - Drop unused proc/mount patch


### PR DESCRIPTION
Back in December 2020 the changelog got scrambled due to imports from
upstream overlapping commits rhel9-branch. This fixes the version
numbers to match the commits and removes a couple of entries
that were included in the 34.5 rebase.

Resolves: rhbz#1972099