### PR TITLE
fonts packages syncup in template files

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -121,7 +121,6 @@ removefrom audit /usr/sbin/ausearch /usr/sbin/autrace /usr/bin/*
 removefrom audit-libs /etc/* /usr/${libdir}/libauparse*
 removefrom bash /etc/* /usr/bin/bashbug* /usr/share/*
 removefrom bind-utils /usr/bin/host /usr/bin/nsupdate
-removefrom bitmap-fangsongti-fonts /usr/share/fonts/*
 removefrom ca-certificates /etc/pki/java/*
 removefrom ca-certificates /etc/pki/tls/certs/ca-bundle.trust.crt
 removefrom coreutils /usr/bin/link /usr/bin/nice /usr/bin/stty /usr/bin/unlink

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -153,7 +153,6 @@ installpkg dmidecode
 
 ## fonts & themes
 installpkg abattis-cantarell-vf-fonts
-installpkg bitmap-fangsongti-fonts
 installpkg google-noto-sans-vf-fonts google-noto-sans-mono-vf-fonts
 installpkg google-noto-sans-arabic-vf-fonts
 installpkg google-noto-sans-cjk-ttc-fonts
@@ -175,6 +174,7 @@ installpkg paktype-naskh-basic-fonts
 installpkg sil-padauk-fonts
 installpkg rit-meera-new-fonts
 installpkg thai-scalable-waree-fonts
+installpkg vazirmatn-vf-fonts
 
 ## debugging/bug reporting tools
 installpkg gdb-gdbserver


### PR DESCRIPTION
Remove bitmap-fangsongti-fonts because it isn't used at all
and add vazirmatn-vf-fonts according to
https://fedoraproject.org/wiki/Changes/EnhancePersianFontSupport