### PR TITLE
Add release info flags for livemedia-creator

### DIFF
--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -213,6 +213,15 @@ def lmc_parser(dracut_default=""):
     parser.add_argument("--extra-boot-args", default="", dest="extra_boot_args",
                         help="Extra arguments to add to the bootloader kernel cmdline in the templates")
 
+    parser.add_argument("--release", default="", dest="release",
+                        help="Release for product information")
+    parser.add_argument("--variant", default="", dest="variant",
+                        help="Variant for product information")
+    parser.add_argument("--bugurl", default="", dest="bugurl",
+                        help="Issue tracker URL for product information")
+    parser.add_argument("--final", action="store_true",
+                        help="Mark the image as a final release in the product information")
+
     image_group = parser.add_argument_group("disk/fs image arguments")
     image_group.add_argument("--disk-image", type=os.path.abspath,
                              help="Path to existing disk image to use for creating final image.")

--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -213,14 +213,14 @@ def lmc_parser(dracut_default=""):
     parser.add_argument("--extra-boot-args", default="", dest="extra_boot_args",
                         help="Extra arguments to add to the bootloader kernel cmdline in the templates")
 
-    parser.add_argument("--release", default="", dest="release",
-                        help="Release for product information")
-    parser.add_argument("--variant", default="", dest="variant",
-                        help="Variant for product information")
-    parser.add_argument("--bugurl", default="", dest="bugurl",
-                        help="Issue tracker URL for product information")
-    parser.add_argument("--final", action="store_true",
-                        help="Mark the image as a final release in the product information")
+    parser.add_argument("-r", "--release", help="release information", required=True, metavar="RELEASE")
+    parser.add_argument("-t", "--variant", default="",
+                        help="variant name", metavar="VARIANT")
+    parser.add_argument("-b", "--bugurl",
+                        help="bug reporting URL for the product", metavar="URL",
+                        default="your distribution provided bug reporting tool")
+    parser.add_argument("--isfinal", help="",
+                        action="store_true", default=False, dest="isfinal")
 
     image_group = parser.add_argument_group("disk/fs image arguments")
     image_group.add_argument("--disk-image", type=os.path.abspath,

--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -215,7 +215,7 @@ def make_runtime(opts, mount_dir, work_dir, size=None):
     # Fake arch with only basearch set
     arch = ArchData(kernel_arch)
     product = DataHolder(name=opts.project, version=opts.releasever, release=opts.release,
-                            variant=opts.variant, bugurl=opts.bugurl, isfinal=opts.final)
+                            variant=opts.variant, bugurl=opts.bugurl, isfinal=opts.isfinal)
 
     rb = RuntimeBuilder(product, arch, fake_dbo, skip_branding=True)
     compression, compressargs = squashfs_args(opts)
@@ -336,7 +336,7 @@ def make_livecd(opts, mount_dir, work_dir):
 
     arch = ArchData(kernel_arch)
     product = DataHolder(name=opts.project, version=opts.releasever, release=opts.release,
-                            variant=opts.variant, bugurl=opts.bugurl, isfinal=opts.final)
+                            variant=opts.variant, bugurl=opts.bugurl, isfinal=opts.isfinal)
 
     # Link /images to work_dir/images to make the templates happy
     if os.path.islink(joinpaths(mount_dir, "images")):

--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -214,9 +214,8 @@ def make_runtime(opts, mount_dir, work_dir, size=None):
     fake_dbo = FakeDNF(conf=DataHolder(installroot=mount_dir))
     # Fake arch with only basearch set
     arch = ArchData(kernel_arch)
-    # TODO: Need to get release info from someplace...
-    product = DataHolder(name=opts.project, version=opts.releasever, release="",
-                            variant="", bugurl="", isfinal=False)
+    product = DataHolder(name=opts.project, version=opts.releasever, release=opts.release,
+                            variant=opts.variant, bugurl=opts.bugurl, isfinal=opts.final)
 
     rb = RuntimeBuilder(product, arch, fake_dbo, skip_branding=True)
     compression, compressargs = squashfs_args(opts)
@@ -336,9 +335,8 @@ def make_livecd(opts, mount_dir, work_dir):
     kernel_arch = get_arch(mount_dir)
 
     arch = ArchData(kernel_arch)
-    # TODO: Need to get release info from someplace...
-    product = DataHolder(name=opts.project, version=opts.releasever, release="",
-                            variant="", bugurl="", isfinal=False)
+    product = DataHolder(name=opts.project, version=opts.releasever, release=opts.release,
+                            variant=opts.variant, bugurl=opts.bugurl, isfinal=opts.final)
 
     # Link /images to work_dir/images to make the templates happy
     if os.path.islink(joinpaths(mount_dir, "images")):


### PR DESCRIPTION
This PR allows livemedia-creator to store release information as command line flags, similar to how vanilla allows you to create images with release information,