### PR TITLE
livemedia-creator: Add --product to cmdline args

### DIFF
--- a/docs/fedora-livemedia.ks
+++ b/docs/fedora-livemedia.ks
@@ -302,7 +302,7 @@ download-updates=false
 FOE
 
 # don't autostart gnome-software session service
-rm -f /etc/xdg/autostart/gnome-software-service.desktop
+rm -f /etc/xdg/autostart/org.gnome.Software.desktop
 
 # disable the gnome-software shell search provider
 cat >> /usr/share/gnome-shell/search-providers/org.gnome.Software-search-provider.ini << FOE

--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -304,8 +304,10 @@ def lmc_parser(dracut_default=""):
     vagrant_group.add_argument("--vagrantfile",
                                help="optional vagrantfile")
 
-    parser.add_argument("--project", default="Linux",
-                        help="substituted for @PROJECT@ in bootloader config files")
+    parser.add_argument("--project", default="Linux", metavar="PRODUCT",
+                        help="substituted for @PRODUCT@ in bootloader config files")
+    parser.add_argument("-p", "--product", default="", help="Alias for --project",
+                        metavar="PRODUCT")
     parser.add_argument("--releasever", default=DEFAULT_RELEASEVER,
                         help="substituted for @VERSION@ in bootloader config files")
     parser.add_argument("--volid", default=None, help="volume id")

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -49,6 +49,9 @@ def main():
 
     # Check for invalid combinations of options, print all the errors and exit.
     errors = []
+    if opts.project != "Linux" and opts.product:
+        errors.append("Use one of --project or --product not both.")
+
     if not opts.disk_image and not opts.fs_image and not opts.ks:
         errors.append("Image creation requires a kickstart file")
 
@@ -160,6 +163,10 @@ def main():
 
     if not os.path.exists(opts.result_dir):
         os.makedirs(opts.result_dir)
+
+    # Alias --product to --project
+    if opts.product:
+        opts.project = opts.product
 
     # AMI image is just a fsimage with an AMI label
     if opts.make_ami:


### PR DESCRIPTION
For reasons lost in the past lmc uses --project instead of --product like lorax does to set the name of the iso. It also incorrectly says that 'PROJECT' is substituted in the config files which has never been true.

This fixes the documentation, and adds --product as an alias for --project to make the cmdline args more consistent with lorax.