### PR TITLE
fedora-livemedia: Make sure GNOME Software service isn't started

### DIFF
--- a/docs/fedora-livemedia.ks
+++ b/docs/fedora-livemedia.ks
@@ -302,7 +302,7 @@ download-updates=false
 FOE
 
 # don't autostart gnome-software session service
-rm -f /etc/xdg/autostart/gnome-software-service.desktop
+rm -f /etc/xdg/autostart/org.gnome.Software.desktop
 
 # disable the gnome-software shell search provider
 cat >> /usr/share/gnome-shell/search-providers/org.gnome.Software-search-provider.ini << FOE


### PR DESCRIPTION
The name of the service has changed to org.gnome.Software.desktop, change the example kickstart to reflect this.