### PR TITLE
Update anaconda's crash messages to watch

### DIFF
--- a/src/pylorax/monitor.py
+++ b/src/pylorax/monitor.py
@@ -51,6 +51,7 @@ class LogRequestHandler(socketserver.BaseRequestHandler):
     ]
 
     re_tests = [
+        r"Process [0-9]+ \(anaconda\) of user [0-9]+ dumped core",
         r"packaging: base repo .* not valid",
         r"packaging: .* requires .*"
     ]


### PR DESCRIPTION
Traceback handling changed due to https://github.com/rhinstaller/anaconda/pull/4350