### PR TITLE
Drop anaconda auditd replacement

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -116,9 +116,6 @@ removefrom gsettings-desktop-schemas /usr/share/locale/*
 removefrom NetworkManager-libnm /usr/share/locale/*/NetworkManager.mo
 removefrom nm-connection-editor /usr/share/applications/*
 removefrom atk /usr/share/locale/*
-removefrom audit /etc/* /usr/sbin/auditctl /usr/sbin/aureport
-removefrom audit /usr/sbin/ausearch /usr/sbin/autrace /usr/bin/*
-removefrom audit-libs /etc/* /usr/${libdir}/libauparse*
 removefrom bash /etc/* /usr/bin/bashbug* /usr/share/*
 removefrom bind-utils /usr/bin/host /usr/bin/nsupdate
 removefrom ca-certificates /etc/pki/java/*

--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -91,7 +91,6 @@ replace "root:\*:" "root::" etc/shadow
 install ${configdir}/org.gtk.Settings.Debug.gschema.override usr/share/glib-2.0/schemas
 runcmd chroot ${root} glib-compile-schemas /usr/share/glib-2.0/schemas
 
-move usr/libexec/anaconda/auditd sbin
 
 ## for compatibility with Ancient Anaconda Traditions
 symlink lib/modules /modules


### PR DESCRIPTION
- [ ] Please do not merge yet, subject to further discussion.
- [x] anaconda PR: https://github.com/rhinstaller/anaconda/pull/4358

---

This means: Keep all things from the audit package as-is, do not erase or overwrite.

Previously:
- clean up most things audit in the template
- install a custom replacement for auditd from the anaconda packages
- in anaconda, run the replacement manually

Now:
- keep audit things as they are
- do not install the custom replacement
- in anaconda, run `auditctl -e 0` instead of the custom binary

Overall goals remain the same and met:
- keep boot.iso small: this adds +200 KiB-ish
- do not run auditd to lower runtime memory requirements: still ok
- do not spam journal/syslog with audit messages: still ok

Note: Most audit messages come from dracut, where it is not turned off anyway.