### PR TITLE
livemedia-creator: Allow file: url without networking

### DIFF
--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -604,9 +604,13 @@ def check_kickstart(ks, opts):
         errors.append("repo can only be used with the url install method. Add url to your "
                       "kickstart file.")
 
-    if ks.handler.method.method in ("url", "nfs") and not ks.handler.network.seen:
-        errors.append("The kickstart must activate networking if "
-                      "the url or nfs install method is used.")
+    # file: url does not need networking
+    # other url and nfs sources do need networking
+    if not ks.handler.network.seen:
+        if ks.handler.method.method == "nfs" or \
+           (ks.handler.method.method == "url" and not ks.handler.method.url.startswith("file:")):
+            errors.append("The kickstart must activate networking if "
+                          "the url or nfs install method is used.")
 
     if ks.handler.displaymode.displayMode is not None:
         errors.append("The kickstart must not set a display mode (text, cmdline, "

--- a/tests/pylorax/test_creator.py
+++ b/tests/pylorax/test_creator.py
@@ -254,6 +254,27 @@ class CreatorTest(unittest.TestCase):
         errors = check_kickstart(ks, opts)
         self.assertTrue("The kickstart must activate networking" in errors[0])
 
+    def test_no_network_file(self):
+        """Test a kickstart with file url and no network command"""
+        opts = DataHolder(no_virt=True, make_fsimage=False, make_pxe_live=False)
+        ks_version = makeVersion()
+        ks = KickstartParser(ks_version, errorsAreFatal=False, missingIncludeIsFatal=False)
+        ks.readKickstartFromString("url --url=file://usr/local/installtree\n"
+                                   "part / --size=4096\n"
+                                   "shutdown\n")
+        self.assertEqual(check_kickstart(ks, opts), [])
+
+    def test_network_file(self):
+        """Test a kickstart with file url and network command"""
+        opts = DataHolder(no_virt=True, make_fsimage=False, make_pxe_live=False)
+        ks_version = makeVersion()
+        ks = KickstartParser(ks_version, errorsAreFatal=False, missingIncludeIsFatal=False)
+        ks.readKickstartFromString("network --bootproto=dhcp --activate\n"
+                                   "url --url=file://usr/local/installtree\n"
+                                   "part / --size=4096\n"
+                                   "shutdown\n")
+        self.assertEqual(check_kickstart(ks, opts), [])
+
     def test_displaymode(self):
         """Test a kickstart with displaymode set"""
         opts = DataHolder(no_virt=True, make_fsimage=False, make_pxe_live=False)


### PR DESCRIPTION
Some users use local installtrees and url --url=file:// to point to it, don't require network activation in this case.

Fixes #1272