### PR TITLE
Update kdump addon package name

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -6,7 +6,7 @@ GRUB2VER="1:2.06-3"
 %>
 
 ## anaconda package
-installpkg anaconda anaconda-widgets kexec-tools-anaconda-addon anaconda-install-img-deps
+installpkg anaconda anaconda-widgets kdump-anaconda-addon anaconda-install-img-deps
 ## Other available payloads
 installpkg dnf
 installpkg rpm-ostree ostree


### PR DESCRIPTION
It was pulled in via provides which is not well findable.

edit: see https://src.fedoraproject.org/rpms/kdump-anaconda-addon/blob/rawhide/f/kdump-anaconda-addon.spec