### PR TITLE
Improvement of unmounting /proc, /dev and binds

### DIFF
--- a/src/pylorax/imgutils.py
+++ b/src/pylorax/imgutils.py
@@ -498,12 +498,14 @@ class DracutChroot(object):
         return self
 
     def __exit__(self, exc_type, exc_value, tracebk):
-        runcmd(["umount", self.root + "/proc" ])
-        runcmd(["umount", self.root + "/dev" ])
+        umount(self.root + '/proc')
+        umount(self.root + '/dev')
 
         # cleanup bind mounts
         for _, d in self.bind:
-            runcmd(["umount", self.root + d ])
+            # In case parallel building of two or more images
+            # some mounts in /var/tmp/lorax can be buzy at the moment of unmounting
+            umount(self.root + d, maxretry=10, retrysleep=5)
 
     def Run(self, args):
         runcmd(["dracut"] + args, root=self.root)

--- a/src/pylorax/imgutils.py
+++ b/src/pylorax/imgutils.py
@@ -504,7 +504,7 @@ class DracutChroot(object):
         # cleanup bind mounts
         for _, d in self.bind:
             # In case parallel building of two or more images
-            # some mounts in /var/tmp/lorax can be buzy at the moment of unmounting
+            # some mounts in /var/tmp/lorax can be busy at the moment of unmounting
             umount(self.root + d, maxretry=10, retrysleep=5)
 
     def Run(self, args):


### PR DESCRIPTION
- Replace direct call of `umount` by function-wrapper `umount`
- Add retries and pauses for unmounting binds, because some mounts  in `/var/tmp/lorax` can be buzy at the moment unmounting in case parallel building of two or more images