### PR TITLE
Use unicode.pf2 from /usr/share/grub/

### DIFF
--- a/share/templates.d/99-generic/efi.tmpl
+++ b/share/templates.d/99-generic/efi.tmpl
@@ -17,7 +17,7 @@ install boot/efi/EFI/*/shim${efiarch32|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch32}
 install boot/efi/EFI/*/mm${efiarch32|lower}.efi ${EFIBOOTDIR}/
 install boot/efi/EFI/*/gcd${efiarch32|lower}.efi ${EFIBOOTDIR}/grub${efiarch32|lower}.efi
 %endif
-install boot/grub2/fonts/unicode.pf2 ${EFIBOOTDIR}/fonts/
+install usr/share/grub/unicode.pf2 ${EFIBOOTDIR}/fonts/
 
 ## actually make the EFI images
 ${make_efiboot("images/efiboot.img")}

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -42,6 +42,7 @@ installpkg glibc-all-langpacks
 %if basearch == "aarch64":
     installpkg efibootmgr
     installpkg grub2-efi-aa64-cdboot>=${GRUB2VER}
+    installpkg grub2-tools>=${GRUB2VER}
     installpkg shim-aa64
     installpkg uboot-tools
 %endif


### PR DESCRIPTION
grub2 wants to remove it from /boot/grub2/fonts/ so use it from a more stable location instead.

Also add grub2-tools on aarch64 to make sure that it is installed.

Related: rhbz#2146545