### PR TITLE
gitleaks: Add config file to ignore known fake secrets

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,6 @@
+[allowlist]
+description = "Allow known fake secrets in lorax tests and documentation"
+## These are go regexp patterns. See go doc regexp/syntax
+regexes = [
+    '\$6\$CHO2\$3rN8eviE2t50lmVyBYihTgVRHcaecmeCk31L\.\.\.'
+]


### PR DESCRIPTION
In this instance it is scanning the whole repo, including the old composer-cli.rst documentation. So add the fake password to the allowlist.