### PR TITLE
Firmware cleanups 2022-12

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -233,6 +233,27 @@ removefrom linux-firmware /usr/lib/firmware/phanfw.bin*
 removefrom linux-firmware /usr/lib/firmware/mediatek/mt81*/*
 removefrom linux-firmware /usr/lib/firmware/mediatek/sof/*
 removefrom linux-firmware /usr/lib/firmware/mediatek/sof-tplg/*
+## these are old versions that current qed driver will never load
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values-8.10.9.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values-8.10.9.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values-8.14.6.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values-8.18.9.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values-8.20.0.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values-8.30.12.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values-8.33.12.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values-8.37.7.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values-8.40.33.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values_zipped-8.10.10.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values_zipped-8.10.5.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values_zipped-8.15.3.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values_zipped-8.20.0.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values_zipped-8.33.1.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values_zipped-8.33.11.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values_zipped-8.37.2.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values_zipped-8.37.7.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values_zipped-8.4.2.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values_zipped-8.42.2.0.bin*
+removefrom linux-firmware /usr/lib/firmware/qed/qed_init_values_zipped-8.7.3.0.bin*
 %if basearch != "aarch64":
     removefrom linux-firmware /usr/lib/firmware/dpaa2/*
 %endif

--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -229,6 +229,10 @@ removefrom linux-firmware /usr/lib/firmware/qcom/venus*/*
 removefrom linux-firmware /usr/lib/firmware/qcom/vpu*/*
 removefrom linux-firmware /usr/lib/firmware/meson/vdec/*
 removefrom linux-firmware /usr/lib/firmware/phanfw.bin*
+## these are for SoCs used in Chromebooks, our kernel does not build the drivers
+removefrom linux-firmware /usr/lib/firmware/mediatek/mt81*/*
+removefrom linux-firmware /usr/lib/firmware/mediatek/sof/*
+removefrom linux-firmware /usr/lib/firmware/mediatek/sof-tplg/*
 %if basearch != "aarch64":
     removefrom linux-firmware /usr/lib/firmware/dpaa2/*
 %endif

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -26,13 +26,16 @@ installpkg grubby
     ## for enterprise switch devices, netinst deployment does not work on
     ## these so there is no point shipping them - see
     ## https://bugzilla.redhat.com/show_bug.cgi?id=2011615
+    ## bfa-firmware contains only obsolete files - see
+    ## https://bugzilla.redhat.com/show_bug.cgi?id=2152202
     installpkg --optional *-firmware --except alsa* --except midisport-firmware \
                            --except crystalhd-firmware --except ivtv-firmware \
                            --except cx18-firmware --except iscan-firmware \
                            --except uhd-firmware --except lulzbot-marlin-firmware \
                            --except gnome-firmware --except sigrok-firmware \
                            --except liquidio-firmware --except netronome-firmware \
-                           --except mrvlprestera-firmware --except mlxsw_spectrum-firmware
+                           --except mrvlprestera-firmware --except mlxsw_spectrum-firmware \
+                           --except bfa-firmware
     installpkg b43-openfwwf
 %endif
 


### PR DESCRIPTION
This saves us about 11M, and will solve the Rawhide netinsts being oversize (which was caused by webkitgtk pulling in more gstreamer bits).