### PR TITLE
Firmware cleanup 202212 2

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -34,7 +34,9 @@ installpkg grubby
                            --except uhd-firmware --except lulzbot-marlin-firmware \
                            --except gnome-firmware --except sigrok-firmware \
                            --except liquidio-firmware --except netronome-firmware \
-                           --except mrvlprestera-firmware --except mlxsw_spectrum-firmware
+                           --except mrvlprestera-firmware --except mlxsw_spectrum-firmware \
+                           --except hackrf-firmware --except python-virt-firmware \
+                           --except python3-virt-firmware
     installpkg b43-openfwwf
 %endif
 

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -34,8 +34,7 @@ installpkg grubby
                            --except uhd-firmware --except lulzbot-marlin-firmware \
                            --except gnome-firmware --except sigrok-firmware \
                            --except liquidio-firmware --except netronome-firmware \
-                           --except mrvlprestera-firmware --except mlxsw_spectrum-firmware \
-                           --except bfa-firmware
+                           --except mrvlprestera-firmware --except mlxsw_spectrum-firmware
     installpkg b43-openfwwf
 %endif
 


### PR DESCRIPTION
We don't need to exclude bfa-firmware any more as I got it retired - https://bugzilla.redhat.com/show_bug.cgi?id=2152202 . I confirmed it's not in today's Rawhide compose at all. Checking lorax output from today's Rawhide I also found a couple more *-firmware packages we can exclude as they're not for hardware that's likely to be used during install. Probably these don't save much space, but every little helps.