### PR TITLE
Add comment for squashfs-only

### DIFF
--- a/docs/man/livemedia-creator.1
+++ b/docs/man/livemedia-creator.1
@@ -265,7 +265,7 @@ Default: \(dq36\(dq
 volume id
 .TP
 .B \-\-squashfs\-only
-Use a plain squashfs filesystem for the runtime.
+Use a plain squashfs filesystem for the runtime. Only used by --make-iso, ignored for others.
 .sp
 Default: False
 .TP


### PR DESCRIPTION
I found out (from reading the source) that squashfs-only is only suppported for `--make-iso`