### PR TITLE
rsyslog.conf: Set WorkDirectory to /var/lib/rsyslog

### DIFF
--- a/share/templates.d/99-generic/config_files/common/rsyslog.conf
+++ b/share/templates.d/99-generic/config_files/common/rsyslog.conf
@@ -39,7 +39,7 @@ $InputRunFileMonitor
 #### GLOBAL DIRECTIVES ####
 
 # Where to place auxiliary files
-#$WorkDirectory /var/lib/rsyslog
+$WorkDirectory /var/lib/rsyslog
 
 # Use default timestamp format
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
@@ -70,7 +70,7 @@ $template virtio_ForwardFormat, "<%PRI%>%TIMESTAMP:::date-rfc3339% localhost %sy
 # directly into files via python logging)
 
 # discard messages from dracut regenerating initrd
-:programname,isequal,"dracut" ~
+:programname,isequal,"dracut" stop
 
 *.*;\
 authpriv.none;\


### PR DESCRIPTION
Without this set rsyslogd will try to use / for things like /imjournal.state.tmp, which will fail due to SELinux.

Resolves: rhbz#2158731