### PR TITLE
livemedia-creator: Do not omit plymouth module from dracut

### DIFF
--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -49,7 +49,7 @@ from pylorax.sysutils import joinpaths, remove
 
 # Default parameters for rebuilding initramfs, override with --dracut-arg or --dracut-conf
 DRACUT_DEFAULT = ["--xz", "--add", "livenet dmsquash-live dmsquash-live-ntfs convertfs pollcdrom qemu qemu-net",
-                  "--omit", "plymouth", "--no-hostonly", "--debug", "--no-early-microcode"]
+                  "--no-hostonly", "--debug", "--no-early-microcode"]
 
 RUNTIME = "images/install.img"
 


### PR DESCRIPTION
This was added in the initial version of livemedia-creator, copied over from the boot.iso dracut cmdline. This was changed in commit 6d1e637731da5eb9f89bb35c4da9c6de3785dc07, but livemedia-creator wasn't updated.