### PR TITLE
Strip some things from gtk4

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -179,6 +179,8 @@ removefrom google-noto-sans-cjk-fonts /usr/share/fonts/google-noto-sans-cjk-font
 removefrom google-noto-sans-vf-fonts /usr/share/fonts/google-noto-vf/NotoSans-Italic-VF.ttf
 removefrom grep /etc/* /usr/share/locale/*
 removefrom gtk3 /usr/${libdir}/gtk-3.0/*
+removefrom gtk4 /usr/${libdir}/gtk-4.0/*
+removefrom gtk4 /usr/bin/*
 removefrom guile22 /usr/${libdir}/guile/2.2/ccache*
 removefrom gzip /usr/bin/{gzexe,zcmp,zdiff,zegrep,zfgrep,zforce,zgrep,zless,zmore,znew}
 removefrom hwdata /usr/share/hwdata/oui.txt /usr/share/hwdata/pnp.ids


### PR DESCRIPTION
gtk4 is now getting sucked into installer images because mutter depends on it (since 44-beta). Strip some stuff the installer env currently doesn't need. The /usr/bin/* removal may not be safe long-term, but it should be OK for now.