### PR TITLE
Don't strip gtk4 binaries or libtiff (#2170716)

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -53,7 +53,6 @@ removepkg mtools glibc-gconv-extra
 ## various other things we remove to save space
 removepkg diffutils file
 removepkg libasyncns
-removepkg libtiff
 removepkg lvm2-libs
 removepkg mobile-broadband-provider-info
 removepkg rmt rpcbind squashfs-tools
@@ -180,7 +179,6 @@ removefrom google-noto-sans-vf-fonts /usr/share/fonts/google-noto-vf/NotoSans-It
 removefrom grep /etc/* /usr/share/locale/*
 removefrom gtk3 /usr/${libdir}/gtk-3.0/*
 removefrom gtk4 /usr/${libdir}/gtk-4.0/*
-removefrom gtk4 /usr/bin/*
 removefrom guile22 /usr/${libdir}/guile/2.2/ccache*
 removefrom gzip /usr/bin/{gzexe,zcmp,zdiff,zegrep,zfgrep,zforce,zgrep,zless,zmore,znew}
 removefrom hwdata /usr/share/hwdata/oui.txt /usr/share/hwdata/pnp.ids


### PR DESCRIPTION
It turns out that, somehow, stripping the gtk4 binaries caused: https://bugzilla.redhat.com/show_bug.cgi?id=2170716 at least, I tested a scratch build with this change and that bug didn't seem to happen any more. This puts the gtk4 binaries back, and also stops stripping libtiff, because gtk4-launch depends on it so we need to keep it in. This doesn't seem to cause too much of a size difference; I see 723417088 bytes for the netinst with this change, compared to 723197952 bytes for today's nightly.