### PR TITLE
Add setpriv as ostree containers dependency (#2125655)

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -311,7 +311,7 @@ removefrom smartmontools /usr/share/smartmontools/*
 removefrom tar /usr/share/locale/*
 removefrom usbutils /usr/bin/*
 removefrom util-linux --allbut \
-    /usr/bin/{chmem,eject,getopt,hexdump,login,lscpu,lsmem,lsblk} \
+    /usr/bin/{chmem,eject,getopt,hexdump,login,lscpu,lsmem,lsblk,setpriv} \
     /etc/pam.d/login /etc/pam.d/remote \
     /usr/sbin/{clock,fdisk,fsfreeze,fstrim,hwclock,nologin,sfdisk,swaplabel,wipefs,zramctl}
 removefrom util-linux-core --allbut \


### PR DESCRIPTION
The `rpm-ostree` binary requires `setpriv` binary to be able to deploy containers.

Related to:
https://fedoraproject.org/wiki/Changes/OstreeNativeContainer https://fedoraproject.org/wiki/Changes/OstreeNativeContainerStable

[Related: rhbz#2125655](https://bugzilla.redhat.com/show_bug.cgi?id=2125655)

Related PRs:
https://github.com/pykickstart/pykickstart/pull/434
https://github.com/rhinstaller/anaconda/pull/4561

We would like to get this to Fedora 38 after freeze because it's change accepted to Fedora 38.