### PR TITLE
livemedia-creator: Use -cpu host by default, add -cpu option to override

### DIFF
--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -263,8 +263,10 @@ def lmc_parser(dracut_default=""):
     virt_group = parser.add_argument_group("qemu arguments")
     virt_group.add_argument("--ram", metavar="MEMORY", type=int, default=2048,
                             help="Memory to allocate for installer in megabytes.")
+    virt_group.add_argument("--cpu", metavar="CPU",
+                            help="Passed to qemu -cpu command. Default is to use -cpu host.")
     virt_group.add_argument("--vcpus", type=int, default=None,
-                            help="Passed to qemu -smp command")
+                            help="Passed to qemu -smp command. Number of virtual cpus.")
     virt_group.add_argument("--vnc",
                             help="Passed to qemu -display command. eg. vnc=127.0.0.1:5, default is to "
                                  "choose the first unused vnc port.")

--- a/src/pylorax/installer.py
+++ b/src/pylorax/installer.py
@@ -172,6 +172,9 @@ class QEMUInstall(object):
         if not os.path.exists("/usr/bin/"+qemu_cmd[0]):
             raise InstallError("%s does not exist, cannot run qemu" % qemu_cmd[0])
 
+        # Default to using the host cpu capabilities
+        qemu_cmd += ["-cpu", opts.cpu or "host"]
+
         qemu_cmd += ["-no-user-config"]
         qemu_cmd += ["-m", str(memory)]
         if vcpus:


### PR DESCRIPTION
This changes virt installs to use the host cpu capabilities by default. Previously it used the qemu default of 'qemu64'.
This also adds a new cmdline argument allowing the user to override the use of 'host' with their own selection.