### PR TITLE
Pass vga=791 for live basic graphics mode on BIOS (#2176782)

### DIFF
--- a/share/templates.d/99-generic/live/config_files/x86/grub2-bios.cfg
+++ b/share/templates.d/99-generic/live/config_files/x86/grub2-bios.cfg
@@ -27,7 +27,7 @@ menuentry 'Test this media & start @PRODUCT@ @VERSION@' --class fedora --class g
 }
 submenu 'Troubleshooting -->' {
 	menuentry 'Start @PRODUCT@ @VERSION@ in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
-		linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image nomodeset quiet rhgb
+		linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image nomodeset vga=791 quiet rhgb
 		initrd @INITRDPATH@
 	}
 	menuentry 'Boot first drive' --class fedora --class gnu-linux --class gnu --class os {


### PR DESCRIPTION
As per https://bugzilla.redhat.com/show_bug.cgi?id=2176782 , this seems to be the best way to make Wayland work on basic graphics mode on BIOS.

We don't need this for non-live, at least currently, as in the traditional installer images, anaconda runs on X.org. We may need to revisit this if we change the traditional installer env to run on Wayland.