### PR TITLE
logging: Remove duplicate stream logging

### DIFF
--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -206,7 +206,6 @@ class Lorax(BaseLoraxClass):
         if not os.path.isdir(logdir):
             os.makedirs(logdir)
 
-        self.init_stream_logging()
         self.init_file_logging(logdir)
 
         logger.debug("version is %s", vernum)


### PR DESCRIPTION
The library shouldn't be logging to the stream by default, and when combined with lorax setting up logging it results in duplicated lines to the console.

If a library user needs basic stream logging they can call init_stream_logging themselves, or setup their own 'pylorax' logger.