### PR TITLE
livemedia-creator: Raise an error when no partitions are in the ks

### DIFF
--- a/docs/livemedia-creator.rst
+++ b/docs/livemedia-creator.rst
@@ -173,6 +173,13 @@ changes. Here are the steps I used to convert the Fedora XFCE spin.
     grub2-efi
     syslinux
 
+.. note::
+   The kickstart must contain `part / --size=1024` in order to set the size of the
+   root filesystem's disk image. Other partitions may be included, depending on the
+   image type being created. `autopart` cannot be supported due to lmc needing to
+   create the disk image file before running the installer on it.
+
+
 User created repositories
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -417,10 +417,15 @@ def calculate_disk_size(opts, ks):
     # Disk size for a filesystem image should only be the size of /
     # to prevent surprises when using the same kickstart for different installations.
     unique_partitions = dict((p.mountpoint, p) for p in ks.handler.partition.partitions)
+
     if opts.no_virt and (opts.make_iso or opts.make_fsimage):
         disk_size = 2 + sum(p.size for p in unique_partitions.values() if p.mountpoint == "/")
+        if disk_size == 2:
+            raise RuntimeError("No / partition in the kickstart. Unable to calculate required disk size.")
     else:
         disk_size = 2 + sum(p.size for p in unique_partitions.values())
+        if disk_size == 2:
+            raise RuntimeError("No partitions in the kickstart. Unable to calculate required disk size.")
 
         # reqpart can add 1M, 2M, 200M based on platform. Add 500M to be sure
         if ks.handler.reqpart.seen:


### PR DESCRIPTION
The kickstart needs to have at least 1 partition in order to calculate the size of the disk image. Raise an error when partitions are missing from the kickstart.