### PR TITLE
monitor: Skip repo errors involving CDROM/file source

### DIFF
--- a/src/pylorax/monitor.py
+++ b/src/pylorax/monitor.py
@@ -52,7 +52,7 @@ class LogRequestHandler(socketserver.BaseRequestHandler):
 
     re_tests = [
         r"Process [0-9]+ \(anaconda\) of user [0-9]+ dumped core",
-        r"packaging: base repo .* not valid",
+        r"packaging: base repo (?!\(CDROM/file).* not valid",
         r"packaging: .* requires .*"
     ]
 


### PR DESCRIPTION
When using the rhsm command anaconda first tries the cdrom, and when it fails then tries the CDN. This causes lorax-composer to see the repo failure and exit too early, preventing it from working with rhsm.

This should never show up during normal lmc usage, so it's safe to skip. Includes new tests in LogMonitorTest