### PR TITLE
Remove retired paktype-naskh-basic-fonts from runtime-install

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -161,7 +161,6 @@ installpkg lohit-marathi-fonts
 installpkg lohit-odia-fonts
 installpkg lohit-tamil-fonts
 installpkg lohit-telugu-fonts
-installpkg paktype-naskh-basic-fonts
 installpkg sil-padauk-fonts
 installpkg rit-meera-new-fonts
 installpkg vazirmatn-vf-fonts


### PR DESCRIPTION
See https://pagure.io/releng/failed-composes/issue/5031 . I'm hoping the remaining fonts, particularly all the Noto ones, should provide at least sufficient coverage for the language(s) we had this font in the installer environment for.