### PR TITLE
Add nvme-cli to the install image

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -140,6 +140,7 @@ installpkg rng-tools
 %if basearch in ("x86_64", "aarch64"):
 installpkg dmidecode
 %endif
+installpkg nvme-cli
 
 
 ## fonts & themes


### PR DESCRIPTION
Include the nvme command in the install image.  This goes with other disk utilities like smartmontools.  Having it in the install image allows switching an NVMe device to 4K sectors, which requires formatting (so needs to be done before installing an OS).