### PR TITLE
runtime-cleanup: don't strip device-mapper-event

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -34,8 +34,6 @@ removefrom shadow-utils --allbut /usr/bin/chage /usr/sbin/chpasswd \
 ## no services to turn on/off (keep the /etc/init.d link though)
 removefrom initscripts /usr/sbin/* /usr/share/locale/* /usr/share/doc/* /usr/share/man/*
 
-## no storage device monitoring
-removepkg device-mapper-event
 ## logrotate isn't useful in anaconda
 remove /etc/logrotate.d
 ## anaconda needs this to do media check


### PR DESCRIPTION
The openQA install_blivet_lvmthin test - which, as the name implies, does an LVM thinp install - is consistently failing (only on ppc64le, for some reason). The logs show that lvm2 is trying to run dmeventd as part of some kind of check of the pool, but it's failing because dmeventd isn't there:

Failed to call the 'LvCreate' method on the '/com/redhat/lvmdbus1/ThinPool/0' object: GDBus.Error:org.freedesktop.DBus.Python.dbus.exceptions.DBusException: ('com.redhat.lvmdbus1.Lv', 'Exit code 5, stderr = /usr/sbin/dmeventd: stat failed: No such file or directory, /usr/sbin/dmeventd: stat failed: No such file or directory, Check of pool fedora/00 failed (status:64). Manual repair required!, Failed to activate thin pool fedora/00.')

So, apparently we do need this now. Whether to use dmeventd or not seems to be a build time check/config option for lvm2, but I don't think we can turn that off just to save a bit of space in the installer image - the package is only about 50K.