### PR TITLE
Revert "Add blacklist_exceptions to multipath.conf"

### DIFF
--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -103,7 +103,6 @@ append etc/depmod.d/dd.conf "search updates built-in"
 
 ## create multipath.conf so multipath gets auto-started
 append etc/multipath.conf "defaults {\n\tfind_multipaths smart\n\tuser_friendly_names yes\n}\n"
-append etc/multipath.conf "blacklist_exceptions {\n\tproperty \"(SCSI_IDENT_|ID_WWN)\"\n}\n"
 
 ## make lvm auto-activate
 remove etc/lvm/archive/*


### PR DESCRIPTION
This reverts commit b1407900ac4b19d58951e1283070aadaa9b4729e.

blacklist_exceptions prevents the installed system from booting. See https://bugzilla.redhat.com/show_bug.cgi?id=1853668 for details.