### PR TITLE
runtime-install: exclude renamed iwl firmware packages

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -28,6 +28,10 @@ installpkg grubby
     ## https://bugzilla.redhat.com/show_bug.cgi?id=2011615
     ## bfa-firmware contains only obsolete files - see
     ## https://bugzilla.redhat.com/show_bug.cgi?id=2152202
+    ## various iwl package names were changed in linux-firmware-20230625-151
+    ## so need to be excluded or else dnf gets sad - see
+    ## https://pagure.io/releng/issue/11511 . These exclusions can
+    ## be dropped after F38 goes EOL
     installpkg --optional *-firmware --except alsa* --except midisport-firmware \
                            --except crystalhd-firmware --except ivtv-firmware \
                            --except cx18-firmware --except iscan-firmware \
@@ -36,7 +40,16 @@ installpkg grubby
                            --except liquidio-firmware --except netronome-firmware \
                            --except mrvlprestera-firmware --except mlxsw_spectrum-firmware \
                            --except hackrf-firmware --except python-virt-firmware \
-                           --except python3-virt-firmware
+                           --except python3-virt-firmware \
+                           --except iwl3945-firmware --except iwl4965-firmware \
+                           --except iwl100-firmware --except iwl105-firmware \
+                           --except iwl135-firmware --except iwl1000-firmware \
+                           --except iwl2000-firmware --except iwl2030-firmware \
+                           --except iwl5000-firmware --except iwl5150-firmware \
+                           --except iwl6000-firmware --except iwl6000g2a-firmware \
+                           --except iwl6000g2b-firmware --except iwl6050-firmware \
+                           --except iwl3160-firmware --except iwl7260-firmware \
+                           --except iwlax2xx-firmware
     installpkg b43-openfwwf
 %endif
 


### PR DESCRIPTION
@pbrobinson renamed the Intel wireless firmware packages in the 20230625 build of linux-firmware. This causes installer image builds to fail because they want to pull in the old packages from the release repo because they fall in the "*-firmware" glob, but those packages are now obsoleted by the newer ones from updates/updates-testing, and dnf doesn't like that. This should resolve the problem by specifically excluding all the renamed packages from the glob. Of course, this change must go along with the newer linux-firmware package, or else you'll get an image that's missing a lot of wireless firmware.