### PR TITLE
runtime-install: install rsvg-pixbuf-loader

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -105,6 +105,11 @@ installpkg kbd kbd-misc
 ## required for anaconda-dracut (img-lib etc.)
 installpkg tar xz curl bzip2
 
+## this is only recommended by librsvg2 since 2023-07, but in the
+## installer environment many icons used are only present as SVGs,
+## so we really need it
+installpkg rsvg-pixbuf-loader
+
 ## basic system stuff
 installpkg systemd-sysv systemd-units
 installpkg rsyslog


### PR DESCRIPTION
This was split out of librsvg2 as a subpackage recently, and is only Recommended by the parent (not Required). For size's sake, we don't pull Recommends into the installer env by default. But we do really need this package, because quite a lot of icons used in the installer are only present as SVGs in the installer environment, so if we don't have the SVG loader we can't show the icons.

Right now anaconda actually crashes if the SVG renderer isn't present, which wasn't an expected outcome, but even if the crash is fixed, the result would be that anaconda would run but not show a lot of icons, which obviously isn't what we want. So we should add this regardless of a fix for the crash.
