### PR TITLE
runtime-install: excluded renamed olpc firmware package

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -31,7 +31,8 @@ installpkg grubby
     ## various iwl package names were changed in linux-firmware-20230625-151
     ## so need to be excluded or else dnf gets sad - see
     ## https://pagure.io/releng/issue/11511 . These exclusions can
-    ## be dropped after F38 goes EOL
+    ## be dropped after F38 goes EOL . Ditto libertas-usb8388-olpc-firmware
+    ## obsoleted in linux-firmware-20230804-152
     installpkg --optional *-firmware --except alsa* --except midisport-firmware \
                            --except crystalhd-firmware --except ivtv-firmware \
                            --except cx18-firmware --except iscan-firmware \
@@ -49,7 +50,7 @@ installpkg grubby
                            --except iwl6000-firmware --except iwl6000g2a-firmware \
                            --except iwl6000g2b-firmware --except iwl6050-firmware \
                            --except iwl3160-firmware --except iwl7260-firmware \
-                           --except iwlax2xx-firmware
+                           --except iwlax2xx-firmware --except libertas-usb8388-olpc-firmware
     installpkg b43-openfwwf
 %endif
 


### PR DESCRIPTION
Similar to c7c6dc79d97777d00d4d1b23b8807734a56935e5 , this specifically excludes a firmware package that was renamed in the recent linux-firmware update so image builds work with both packages present in the available set (e.g. stable releases with the older firmware in the release repo and the newer one in the updates repo). Must go along with the linux-firmware update.