### PR TITLE
Revert "test_minimizer: dnf5 wants --use-host-config"

### DIFF
--- a/tests/image-minimizer/test_minimizer.py
+++ b/tests/image-minimizer/test_minimizer.py
@@ -8,7 +8,7 @@ from minimizer import ImageMinimizer
 class MinimizerTestCase(unittest.TestCase):
     def test_minimizer_ok(self):
         with tempfile.TemporaryDirectory(prefix="minimize.test.") as rootdir:
-            check_call(["dnf", "--use-host-config", "--installroot", rootdir, "install", "-y", \
+            check_call(["dnf", "--releasever=/", "--installroot", rootdir, "install", "-y", \
                         "filesystem", "tzdata"])
 
             im = ImageMinimizer("./tests/image-minimizer/im-script.txt", rootdir, False, False)


### PR DESCRIPTION
This reverts commit b99f9ba93bf4e6b49796c4b718cd19086a872c26.

dnf5 is not the default in Fedora 39/40 so this doesn't work.