### PR TITLE
runtime-cleanup.tmpl: fix typo 'gschadow'

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -383,4 +383,4 @@ remove /etc/pki/ca-trust/extracted/java/cacerts
 
 ## sort groups
 runcmd chroot ${root} /bin/sh -c "LC_ALL=C sort /etc/group > /etc/group- && mv /etc/group- /etc/group"
-runcmd chroot ${root} /bin/sh -c "LC_ALL=C sort /etc/gshadow > /etc/gshadow- && mv /etc/gshadow- /etc/gschadow"
+runcmd chroot ${root} /bin/sh -c "LC_ALL=C sort /etc/gshadow > /etc/gshadow- && mv /etc/gshadow- /etc/gshadow"


### PR DESCRIPTION
Commit fa2158c7a9 ("Drop non-determinism from default templates") made an attempt to ensure /etc/gshadow is reproducible by sorting it. However, there was a typo causing the sorted version to be saved as /etc/gschadow, leaving the original intact.

Fix the typo to ensure the file is overwritten.