### PR TITLE
runtime-postinstall: Turn off lvm monitoring

### DIFF
--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -112,6 +112,8 @@ remove etc/lvm/cache/*
 remove etc/lvm/cache
 remove etc/lvm/lvm.conf
 append etc/lvm/lvm.conf "global {\n\tuse_lvmetad = 1\n}\n"
+# dmeventd and event libraries are not installed
+append etc/lvm/lvm.conf "activation {\n\tmonitoring = 0\n}\n"
 
 ## Remove machine specific nvme-cli files
 remove etc/nvme/hostid


### PR DESCRIPTION
We don't install dmeventd or the event libraries so monitoring will fail to start. The should solve #1328 and rhbz#2236524

With this in place there are no syslog messages about dmeventd or event libraries. lvm.conf does contain logged messages about dmeventd falling back to various things, but no actual errors.