### PR TITLE
Explicitly pull in more filesystem packages

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -118,7 +118,7 @@ installpkg systemd-sysv systemd-units
 installpkg rsyslog
 
 ## filesystem tools
-installpkg btrfs-progs jfsutils xfsprogs ntfs-3g ntfsprogs
+installpkg btrfs-progs jfsutils xfsprogs ntfs-3g ntfsprogs dosfstools e2fsprogs f2fs-tools
 installpkg system-storage-manager
 installpkg device-mapper-persistent-data
 installpkg xfsdump


### PR DESCRIPTION
Turns out we've been relying on udisks2 dependencies to pull in several filesystem tools packages that anaconda actually needs to create and read supported filesystems. udisks2 just changed all those dependencies to Recommends, which don't get pulled into the installer environment. So we need lorax to specifically list all of these. e2fsprogs was already being pulled in through some other dep chain, but let's explicitly list it just to make sure we don't hit the same problem in future. From a look through the blivet code, I don't think pulling in udftools, exfatprogs or nilfs-utils will be useful, but we can check that with @vojtechtrefny  .