### PR TITLE
Remove some unneccessary storage packages from runtime-install

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -117,18 +117,9 @@ installpkg tar xz curl bzip2
 installpkg systemd-sysv systemd-units
 installpkg rsyslog
 
-## filesystem tools
-installpkg btrfs-progs jfsutils xfsprogs ntfs-3g ntfsprogs dosfstools e2fsprogs f2fs-tools
-installpkg system-storage-manager
+## extra storage tools for rescue mode
 installpkg device-mapper-persistent-data
 installpkg xfsdump
-
-## extra storage packages
-# hostname is needed for iscsi to work, see RHBZ#1593917
-installpkg udisks2 udisks2-iscsi hostname
-
-## extra libblockdev plugins
-installpkg libblockdev-lvm-dbus
 
 ## needed for LUKS escrow
 installpkg volume_key


### PR DESCRIPTION
Anaconda already depends on following packages:
- filesystem tools: btrfs-progs, ntfs-3g, ntfsprogs, jfsutils, f2fs-tools, xfsprogs, dosfstools, e2fsprogs
- libblockdev-lvm-dbus
- udisks2-iscsi

hostname is no longer needed by dracut for iSCSI, see https://github.com/dracutdevs/dracut/commit/ebe1821

----

Note need make sure https://github.com/rhinstaller/anaconda/pull/5184 is merged first and new Anaconda is released before merging this.