### PR TITLE
Do not install polkit-gnome for blivet-gui

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -134,10 +134,6 @@ installpkg libblockdev-lvm-dbus
 installpkg volume_key
 installpkg nss-tools
 
-## blivet-gui-runtime requires PolicyKit-authentication-agent, if we
-## don't tell dnf what to pick it picks lxpolkit, which drags in gtk2
-installpkg polkit-gnome
-
 ## SELinux support
 installpkg selinux-policy-targeted audit
 


### PR DESCRIPTION
blivet-gui-runtime doesn't depend on PolicyKit-authentication-agent only blivet-gui which is not on the installation images depends on polkit.

-----

This was originally added by @AdamWill in https://github.com/weldr/lorax/commit/07f3e48c2804ad0a8fe75e4f8397a9ef7a5f3ab5 and I am not sure why, the `blivet-gui-runtime` package never depended on `PolicyKit-authentication-agent`. Maybe this was before the split into `blivet-gui` and `blivet-gui-runtime`.

```
$ sudo dnf repoquery --requires blivet-gui-runtime
Last metadata expiration check: 1:59:21 ago on Tue 19 Sep 2023 10:37:38 AM CEST.
/usr/bin/python3
gtk3
libreport
python(abi) = 3.11
python3
python3-blivet >= 1:3.3.0
python3-gobject
python3-pid
```

I did a quick test without this rule and the resulting image doesn't have any polkit agent installed, so I think it should be safe to remove this.