### PR TITLE
runtime-install: drop kdump-anaconda-addon

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -7,7 +7,7 @@ GRUB2VER="1:2.06-67"
 %>
 
 ## anaconda package
-installpkg anaconda anaconda-widgets kdump-anaconda-addon
+installpkg anaconda anaconda-widgets
 ## work around dnf5 bug - https://github.com/rpm-software-management/dnf5/issues/1111
 installpkg anaconda-install-img-deps>=40.15
 ## Other available payloads


### PR DESCRIPTION
I'm proposing making this part of anaconda-install-env-deps instead in https://github.com/rhinstaller/anaconda/pull/5205 . It's more correct.

Do not merge this until https://github.com/rhinstaller/anaconda/pull/5205 is merged. This is not at all urgent.