### PR TITLE
Add setpriv as ostree containers dependency (#2125655)

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -312,7 +312,7 @@ removefrom util-linux --allbut \
     /etc/mtab /etc/pam.d/login /etc/pam.d/remote \
     /usr/sbin/{agetty,blkid,blockdev,clock,fdisk,fsck,fstrim,hwclock,losetup} \
     /usr/sbin/{mkswap,swaplabel,nologin,sfdisk,swapoff,swapon,wipefs,partx,fsfreeze} \
-    /usr/bin/{logger,hexdump,flock,lscpu,chmem,lsmem}
+    /usr/bin/{logger,hexdump,flock,lscpu,chmem,lsmem,setpriv}
 removefrom volume_key-libs /usr/share/locale/*
 removefrom wget /etc/* /usr/share/locale/*
 removefrom xorg-x11-drv-intel /usr/${libdir}/libI*


### PR DESCRIPTION
The `rpm-ostree` binary requires `setpriv` binary to be able to deploy containers.

Related to:
https://fedoraproject.org/wiki/Changes/OstreeNativeContainer https://fedoraproject.org/wiki/Changes/OstreeNativeContainerStable

Related: rhbz#2125655
Resolves: https://issues.redhat.com/browse/RHEL-2250