### PR TITLE
Process exit code from `mksquashfs`:

### DIFF
--- a/src/pylorax/imgutils.py
+++ b/src/pylorax/imgutils.py
@@ -116,7 +116,13 @@ def mksquashfs(rootdir, outfile, compression="default", compressargs=None):
     compressargs = compressargs or []
     if compression != "default":
         compressargs = ["-comp", compression] + compressargs
-    return execWithRedirect("mksquashfs", [rootdir, outfile] + compressargs)
+    if execWithRedirect("mksquashfs", [rootdir, outfile] + compressargs):
+        msg = (
+            'External program "mksquashfs" is failed. '
+            'See program.log for details'
+        )
+        logger.error(msg)
+        raise RuntimeError(msg)
 
 def mkrootfsimg(rootdir, outfile, label, size=2, sysroot=""):
     """


### PR DESCRIPTION
- Lorax should process an exit code from `mksquashfs` and stop itself execution. Mksquashfs can fail in some cases, e.g. no space left on device. Lorax is failed with non-clear error message and exception in that case, like `OSError: nothing matching /var/tmp/lorax/lorax.1j_tpfz1/installroot/images/install.img in /`.
- That PR improves the error message and can help to a user find a root of issue