### PR TITLE
Adjust runtime-postinstall.tmpl for systemd config files move

### DIFF
--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -52,7 +52,8 @@ remove usr/lib/tmpfiles.d/etc.conf
 
 ## Make logind activate anaconda-shell@.service on switch to empty VT
 symlink anaconda-shell@.service lib/systemd/system/autovt@.service
-replace "#ReserveVT=6" "ReserveVT=2" etc/systemd/logind.conf
+mkdir usr/lib/systemd/logind.conf.d
+append usr/lib/systemd/logind.conf.d/anaconda-shell.conf "[Login]\nReserveVT=2"
 
 ## Don't write the journal to the overlay, just keep it in RAM
 remove var/log/journal


### PR DESCRIPTION
Systemd config files were moved from /etc to /usr/lib/systemd, so this snippet fails. Instead of editing the config file, just create a drop-in snippet with the desired configuration.