### PR TITLE
ltmpl: Remove duplicate package objects from dnf5 results

### DIFF
--- a/tests/pylorax/test_ltmpl.py
+++ b/tests/pylorax/test_ltmpl.py
@@ -136,6 +136,7 @@ class LoraxTemplateRunnerTestCase(unittest.TestCase):
         makeFakeRPM(self.repo2_dir, "fake-milhouse", 0, "1.3.0", "1", ["/fake-milhouse/1.3.0-1"])
         makeFakeRPM(self.repo2_dir, "fake-lisa", 0, "1.2.0", "1", ["/fake-lisa/1.2.0-1"])
         makeFakeRPM(self.repo2_dir, "fake-lisa", 0, "1.1.4", "5", ["/fake-lisa/1.1.4-5"])
+        makeFakeRPM(self.repo2_dir, "fake-marge", 0, "2.3.0", "1", ["/fake-marge/2.3.0-1"])
         os.system("createrepo_c " + self.repo2_dir)
 
         self.repo3_dir = tempfile.mkdtemp(prefix="lorax.test.debug.repo.")


### PR DESCRIPTION
In dnf5 if you have multiple repositories with overlapping content, and the repo priorities are the same (eg. the default of 99) it will return multiple results with the same nevra. The transaction will fail when trying to install the duplicate rpms.

This de-duplicates the results from `_pkgver`, assuming that packages with the same nevra and repo priority are interchangeable.

Note that this only works at an individual `installpkg` level, not across the whole transaction. So it is possible for separate `installpkg` commands that select the same package to cause a crash -- currently this is not an issue, but is something to fix in the future.

Fixes #1356