### PR TITLE
ltmpl: Check for errors after running the transaction

### DIFF
--- a/src/pylorax/ltmpl.py
+++ b/src/pylorax/ltmpl.py
@@ -832,7 +832,10 @@ class LoraxTemplateRunner(TemplateRunner, InstallpkgMixin):
         self.transaction.set_callbacks(dnf5.rpm.TransactionCallbacksUniquePtr(display))
         with ProcMount(self.outroot):
             try:
-                self.transaction.run()
+                result = self.transaction.run()
+                if result != dnf5.base.Transaction.TransactionRunResult_SUCCESS:
+                    err = "\n".join(self.transaction.get_transaction_problems())
+                    raise RuntimeError(err)
             except Exception as e:
                 logger.error("The transaction process has ended abruptly: %s", e)
                 raise


### PR DESCRIPTION
Thanks to the discussion in
https://github.com/rpm-software-management/dnf5/issues/1074 lorax will now correctly log installation size errors like:

The transaction process has ended abruptly:
installing package llvm-libs-17.0.6-2.fc40.x86_64 needs 107MB more space on the / filesystem installing package libXv-1.0.12-1.fc40.x86_64 needs 107MB more space on the / filesystem installing package libXcomposite-0.4.6-1.fc40.x86_64 needs 107MB more space on the / filesystem