### PR TITLE
runtime-install: Work around problem with conflicting packages

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -7,7 +7,9 @@ GRUB2VER="1:2.06-67"
 %>
 
 ## anaconda package
-installpkg anaconda anaconda-widgets kdump-anaconda-addon anaconda-install-img-deps
+installpkg anaconda anaconda-widgets kdump-anaconda-addon
+## work around dnf5 bug - https://github.com/rpm-software-management/dnf5/issues/1111
+installpkg anaconda-install-img-deps>=40.15
 ## Other available payloads
 installpkg dnf
 installpkg rpm-ostree ostree


### PR DESCRIPTION
See:
https://github.com/rpm-software-management/dnf5/issues/1111

dnf5 is returning anaconda-install-img-deps for 2 arches even though the noarch version number is lower than the x86_64 package.

Work around this by selecting version 40.15 or later.