### PR TITLE
templates.d/99-generic/live: Enable automatic persistence for live media

### DIFF
--- a/share/templates.d/99-generic/live/config_files/aarch64/grub2-efi.cfg
+++ b/share/templates.d/99-generic/live/config_files/aarch64/grub2-efi.cfg
@@ -26,16 +26,32 @@ set timeout=60
 search --no-floppy --set=root -l '@ISOLABEL@'
 
 ### BEGIN /etc/grub.d/10_linux ###
-menuentry 'Start @PRODUCT@ @VERSION@' --class red --class gnu-linux --class gnu --class os {
-	linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image quiet rhgb
+menuentry 'Start @PRODUCT@ @VERSION@ with automatic data persistence' --class fedora --class gnu-linux --class gnu --class os {
+	linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist quiet rhgb
 	initrd @INITRDPATH@
 }
-menuentry 'Test this media & start @PRODUCT@ @VERSION@' --class red --class gnu-linux --class gnu --class os {
-	linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.check quiet
+menuentry 'Test this media & start @PRODUCT@ @VERSION@ with automatic data persistence' --class fedora --class gnu-linux --class gnu --class os {
+	linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist rd.live.check quiet
+	initrd @INITRDPATH@
+}
+menuentry 'Delete existing persistence & start @PRODUCT@ @VERSION@' --class fedora --class gnu-linux --class gnu --class os {
+	linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist rd.live.overlay.reset=1 quiet rhgb
 	initrd @INITRDPATH@
 }
 submenu 'Troubleshooting -->' {
-	menuentry 'Install @PRODUCT@ @VERSION@ in basic graphics mode' --class red --class gnu-linux --class gnu --class os {
+	menuentry 'Start @PRODUCT@ @VERSION@ without automatic persistence' --class fedora --class gnu-linux --class gnu --class os {
+		linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image quiet rhgb
+		initrd @INITRDPATH@
+	}
+	menuentry 'Start @PRODUCT@ @VERSION@ in basic graphics mode with automatic data persistence' --class fedora --class gnu-linux --class gnu --class os {
+		linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist nomodeset quiet rhgb
+		initrd @INITRDPATH@
+	}
+	menuentry 'Delete existing persistence & start @PRODUCT@ @VERSION@ in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+		linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist rd.live.overlay.reset=1 nomodeset quiet rhgb
+		initrd @INITRDPATH@
+	}
+	menuentry 'Start @PRODUCT@ @VERSION@ in basic graphics mode without automatic persistence' --class fedora --class gnu-linux --class gnu --class os {
 		linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image nomodeset quiet rhgb
 		initrd @INITRDPATH@
 	}

--- a/share/templates.d/99-generic/live/config_files/x86/grub2-bios.cfg
+++ b/share/templates.d/99-generic/live/config_files/x86/grub2-bios.cfg
@@ -17,16 +17,32 @@ set timeout=60
 search --no-floppy --set=root -l '@ISOLABEL@'
 
 ### BEGIN /etc/grub.d/10_linux ###
-menuentry 'Start @PRODUCT@ @VERSION@' --class fedora --class gnu-linux --class gnu --class os {
-	linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image quiet rhgb
+menuentry 'Start @PRODUCT@ @VERSION@ with automatic data persistence' --class fedora --class gnu-linux --class gnu --class os {
+	linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist quiet rhgb
 	initrd @INITRDPATH@
 }
-menuentry 'Test this media & start @PRODUCT@ @VERSION@' --class fedora --class gnu-linux --class gnu --class os {
-	linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.check quiet
+menuentry 'Test this media & start @PRODUCT@ @VERSION@ with automatic data persistence' --class fedora --class gnu-linux --class gnu --class os {
+	linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist rd.live.check quiet
+	initrd @INITRDPATH@
+}
+menuentry 'Delete existing persistence & start @PRODUCT@ @VERSION@' --class fedora --class gnu-linux --class gnu --class os {
+	linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist rd.live.overlay.reset=1 quiet rhgb
 	initrd @INITRDPATH@
 }
 submenu 'Troubleshooting -->' {
-	menuentry 'Start @PRODUCT@ @VERSION@ in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+	menuentry 'Start @PRODUCT@ @VERSION@ without automatic persistence' --class fedora --class gnu-linux --class gnu --class os {
+		linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image quiet rhgb
+		initrd @INITRDPATH@
+	}
+	menuentry 'Start @PRODUCT@ @VERSION@ in basic graphics mode with automatic data persistence' --class fedora --class gnu-linux --class gnu --class os {
+		linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist nomodeset vga=791 quiet rhgb
+		initrd @INITRDPATH@
+	}
+	menuentry 'Delete existing persistence & start @PRODUCT@ @VERSION@ in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+		linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist rd.live.overlay.reset=1 nomodeset vga=791 quiet rhgb
+		initrd @INITRDPATH@
+	}
+	menuentry 'Start @PRODUCT@ @VERSION@ in basic graphics mode without automatic persistence' --class fedora --class gnu-linux --class gnu --class os {
 		linux @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image nomodeset vga=791 quiet rhgb
 		initrd @INITRDPATH@
 	}

--- a/share/templates.d/99-generic/live/config_files/x86/grub2-efi.cfg
+++ b/share/templates.d/99-generic/live/config_files/x86/grub2-efi.cfg
@@ -20,16 +20,32 @@ set timeout=60
 search --no-floppy --set=root -l '@ISOLABEL@'
 
 ### BEGIN /etc/grub.d/10_linux ###
-menuentry 'Start @PRODUCT@ @VERSION@' --class fedora --class gnu-linux --class gnu --class os {
-	linuxefi @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image quiet rhgb
+menuentry 'Start @PRODUCT@ @VERSION@ with automatic data persistence' --class fedora --class gnu-linux --class gnu --class os {
+	linuxefi @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist quiet rhgb
 	initrdefi @INITRDPATH@
 }
-menuentry 'Test this media & start @PRODUCT@ @VERSION@' --class fedora --class gnu-linux --class gnu --class os {
-	linuxefi @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.check quiet
+menuentry 'Test this media & start @PRODUCT@ @VERSION@ with automatic data persistence' --class fedora --class gnu-linux --class gnu --class os {
+	linuxefi @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist rd.live.check quiet
+	initrdefi @INITRDPATH@
+}
+menuentry 'Delete existing persistence & start @PRODUCT@ @VERSION@' --class fedora --class gnu-linux --class gnu --class os {
+	linuxefi @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist rd.live.overlay.reset=1 quiet rhgb
 	initrdefi @INITRDPATH@
 }
 submenu 'Troubleshooting -->' {
-	menuentry 'Start @PRODUCT@ @VERSION@ in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+	menuentry 'Start @PRODUCT@ @VERSION@ without automatic data persistence' --class fedora --class gnu-linux --class gnu --class os {
+		linuxefi @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image quiet rhgb
+		initrdefi @INITRDPATH@
+	}
+	menuentry 'Start @PRODUCT@ @VERSION@ in basic graphics mode with automatic data persistence' --class fedora --class gnu-linux --class gnu --class os {
+		linuxefi @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist nomodeset quiet rhgb
+		initrdefi @INITRDPATH@
+	}
+	menuentry 'Delete existing persistence & start @PRODUCT@ @VERSION@ in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+		linuxefi @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image rd.live.overlay.overlayfs rd.live.overlay=LABEL=fedorapersist rd.live.overlay.reset=1 nomodeset quiet rhgb
+		initrdefi @INITRDPATH@
+	}
+	menuentry 'Start @PRODUCT@ @VERSION@ in basic graphics mode without automatic persistence' --class fedora --class gnu-linux --class gnu --class os {
 		linuxefi @KERNELPATH@ @ROOT@ @EXTRA@ rd.live.image nomodeset quiet rhgb
 		initrdefi @INITRDPATH@
 	}


### PR DESCRIPTION
This change alters the live environment operating mode to default to operating with full root system persistence using the functionality recently added to Dracut.

It also adds menu entries so that it is possible to reset the persistence or start without persistence at all.

This re-applies the change after it was reverted in Fedora Linux 38.

Reference: https://fedoraproject.org/wiki/Changes/ModernizeLiveMedia