### PR TITLE
ltmpl: Pass packages to add_rpm_install as strings

### DIFF
--- a/src/pylorax/ltmpl.py
+++ b/src/pylorax/ltmpl.py
@@ -338,7 +338,7 @@ class InstallpkgMixin:
                 ##
                 ## ASSUME the same nevra is the same package, no matter what repo it comes
                 ## from.
-                nodupes = dict(zip([p.get_nevra() for p in pkgobjs], pkgobjs))
+                nodupes = dict(zip([p.get_full_nevra() for p in pkgobjs], pkgobjs))
                 pkgobjs = nodupes.values()
 
                 # Apply excludes to the name only
@@ -351,7 +351,13 @@ class InstallpkgMixin:
 
                 for p in pkgobjs:
                     try:
-                        self.goal.add_rpm_install(p)
+                        # Pass them to dnf as NEVRA strings, duplicates are handled differntly
+                        # than when they are passed as objects. See:
+                        # https://github.com/rpm-software-management/dnf5/issues/1090#issuecomment-1873837189
+                        # With the dupe removal code above this isn't strictly needed, but it should
+                        # prevent problems if two separate install commands try to add the same
+                        # package.
+                        self.goal.add_rpm_install(p.get_full_nevra())
                     except Exception as e: # pylint: disable=broad-except
                         if required:
                             raise


### PR DESCRIPTION
According to the discussion in:
https://github.com/rpm-software-management/dnf5/issues/1090#issuecomment-1873837189

dnf5 handles NEVRA strings and package objects differently. So instead of passing in objects pass in the full NEVRA string. If a single install command has duplicates this won't matter, I already remove the dupes. But it should prevent problems where separate install commands end up selecting duplicate packages.