### PR TITLE
templates.d/99-generic/runtime-cleanup: Purge more sound binaries

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -325,6 +325,13 @@ removefrom xorg-x11-drv-intel /usr/${libdir}/libI*
 removefrom xorg-x11-drv-wacom /usr/bin/*
 removefrom yelp /usr/share/yelp/mathjax*
 
+## Get rid of new binaries added from Weston pulling in new dependencies
+## We cannot use them anyway
+removefrom libbs2b /usr/bin/*
+removefrom ladspa /usr/bin/*
+removefrom rubberband /usr/bin/*
+removefrom flite /usr/bin/*
+
 %if branding.release:
     removefrom ${branding.logos} /usr/share/plymouth/*
     removefrom ${branding.logos} /etc/*


### PR DESCRIPTION
With Weston added to the install ISO, a few more sound things were pulled in due to the mandatory pipewire-libs dependency.

Strip them as we cannot use them anyway.

This is needed for https://github.com/rhinstaller/anaconda/pull/5401.