### PR TITLE
runtime-cleanup: anaconda's new interface needs stdbuf

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -132,7 +132,7 @@ removefrom coreutils /usr/bin/pinky /usr/bin/pr /usr/bin/printenv
 removefrom coreutils /usr/bin/printf /usr/bin/ptx /usr/bin/runcon
 removefrom coreutils /usr/bin/sha224sum /usr/bin/sha384sum
 removefrom coreutils /usr/bin/sha512sum /usr/bin/shuf /usr/bin/stat
-removefrom coreutils /usr/bin/stdbuf /usr/bin/sum /usr/bin/test
+removefrom coreutils /usr/bin/sum /usr/bin/test
 removefrom coreutils /usr/bin/timeout /usr/bin/truncate /usr/bin/tsort
 removefrom coreutils /usr/bin/unexpand /usr/bin/users /usr/bin/vdir
 removefrom coreutils /usr/bin/who /usr/bin/whoami /usr/bin/yes


### PR DESCRIPTION
Depends indirectly on stdbuf because cockpit-storage is using it.