### PR TITLE
runtime-install: wget2-wget has replaced wget

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -184,7 +184,7 @@ installpkg python3-pyatspi
 ## extra tools not required by anaconda
 installpkg nano nano-default-editor
 installpkg vim-minimal strace lsof dump xz less
-installpkg wget rsync bind-utils ftp mtr vconfig
+installpkg wget2-wget rsync bind-utils ftp mtr vconfig
 installpkg spice-vdagent
 installpkg gdisk hexedit sg3_utils
 


### PR DESCRIPTION
wget has been retired:
https://src.fedoraproject.org/rpms/wget/c/ce69c17
in favor of wget2-wget:
https://fedoraproject.org/wiki/Changes/Wget2asWget