### PR TITLE
runtime-install: drop retired pcmciautils

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -141,9 +141,6 @@ installpkg nmap-ncat
 installpkg pciutils usbutils ipmitool
 installpkg mt-st smartmontools
 installpkg hdparm
-%if basearch not in ("aarch64", "ppc64le", "s390x"):
-installpkg pcmciautils
-%endif
 installpkg rdma-core
 installpkg rng-tools
 %if basearch in ("x86_64", "aarch64"):


### PR DESCRIPTION
pcmciautils was just retired in Rawhide:
https://src.fedoraproject.org/rpms/pcmciautils/c/24639b0