### PR TITLE
templates: Remove libreport bugzilla plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ docs-in-docker:
 		--security-opt label=disable \
 		welder/lorax-docs:$(IMAGE_RELEASE) make docs
 
-ci: check test
+ci: test
 
 $(VM_IMAGE): TAG=HEAD
 $(VM_IMAGE): srpm bots

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -157,8 +157,7 @@ installpkg google-noto-sans-cjk-ttc-fonts
 
 ## debugging/bug reporting tools
 installpkg gdb-gdbserver
-installpkg libreport-plugin-bugzilla libreport-plugin-reportuploader
-installpkg libreport-rhel-anaconda-bugzilla
+installpkg libreport-plugin-reportuploader
 installpkg python3-pyatspi
 
 ## extra tools not required by anaconda


### PR DESCRIPTION
Bug reporting via bugzilla no longer works, the new reporting tool is: https://issues.redhat.com/

Resolves: RHEL-24416