### PR TITLE
templates: Remove libreport bugzilla plugins

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -162,8 +162,7 @@ installpkg google-noto-sans-cjk-ttc-fonts
 
 ## debugging/bug reporting tools
 installpkg gdb-gdbserver
-installpkg libreport-plugin-bugzilla libreport-plugin-reportuploader
-installpkg libreport-rhel-anaconda-bugzilla
+installpkg libreport-plugin-reportuploader
 installpkg python3-pyatspi
 
 ## extra tools not required by anaconda


### PR DESCRIPTION
Bug reporting via bugzilla no longer works, the new reporting tool is: https://issues.redhat.com/

Resolves: RHEL-24420