### PR TITLE
dnf5: set releasever in the base object's vars

### DIFF
--- a/src/pylorax/dnfbase.py
+++ b/src/pylorax/dnfbase.py
@@ -153,6 +153,9 @@ def get_dnf_base_object(installroot, sources, mirrorlists=None, repos=None,
     log.info("Using %s for module_platform_id", platform_id)
     conf.module_platform_id = platform_id
 
+    # set releasever
+    dnfbase.get_vars().set("releasever", releasever)
+
     # Add .repo files
     if repos:
         reposdir = os.path.join(tempdir, "dnf.repos")


### PR DESCRIPTION
With Fedora 40 now branched, openQA installer build tests started failing with an error:

  RuntimeError: cannot open file: (2) - No such file or directory [/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-x86_64]

it seems like setting releasever via set_substitutions just does not fully work as expected, and libdnf goes looking for a file with a literal `$releasever` in it based on the gpgkey line in the repo file. Though it seems like the releasever substitution must work to *some* extent because we at least manage to resolve and download packages before the failure.

This seems to fix it, anyhow, and is based on code from libdnf5 itself in dnf5/main.cpp RootCommand::set_argument_parser() .