### PR TITLE
dnfbase: Fix substitutions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Clone Repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run lorax tests in podman
         run: make test-in-podman && cp .test-results/.coverage .coverage
       - name: Coveralls

--- a/src/pylorax/dnfbase.py
+++ b/src/pylorax/dnfbase.py
@@ -153,6 +153,10 @@ def get_dnf_base_object(installroot, sources, mirrorlists=None, repos=None,
     log.info("Using %s for module_platform_id", platform_id)
     conf.module_platform_id = platform_id
 
+    # Set variables used for substitutions
+    dnfbase.get_vars().set("releasever", releasever)
+    dnfbase.get_vars().set("basearch", basearch)
+
     # Add .repo files
     if repos:
         reposdir = os.path.join(tempdir, "dnf.repos")
@@ -209,14 +213,6 @@ def get_dnf_base_object(installroot, sources, mirrorlists=None, repos=None,
         log.error("No enabled repos")
         return None
     log.info("Using repos: %s", ", ".join(r.get_id() for r in rq))
-
-    # Add substitutions to all enabled repos
-    for r in rq:
-        # Substitutions used with the repo url
-        r.set_substitutions({
-                "releasever": releasever,
-                "basearch": basearch,
-        })
 
     log.info("Fetching metadata...")
     try:


### PR DESCRIPTION
Branching for Fedora 40 revealed a problem with using substitutions in the GPG key name, @AdamWill fixed this by setting them on the Base object which appears to be the correct way to do it.

Remove the per-repo kludge and set releasever and basearch on the Base variables so they are used everywhere.