### PR TITLE
runtime-cleanup: Do not purge pam binaries

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -293,7 +293,7 @@ removefrom openssh /usr/libexec/*
 removefrom openssh-clients /etc/ssh/* /usr/bin/ssh-*
 removefrom openssh-clients /usr/libexec/*
 removefrom openssh-server /etc/ssh/* /usr/libexec/openssh/sftp-server
-removefrom pam /usr/sbin/* /usr/share/locale/*
+removefrom pam /usr/share/locale/*
 removefrom policycoreutils /etc/* /usr/bin/* /usr/share/locale/*
 removefrom polkit /usr/bin/*
 removefrom popt /usr/share/locale/*


### PR DESCRIPTION
In order to migrate from X.Org to Wayland [1], GNOME Kiosk needs to be run in a new PAM session.

After an update in systemd, the session is failing to start because the PAM binaries are not found with the following error:

    Starting user@0.service - User Manager for UID 0...
    pam_unix(systemd-user:account): helper binary execve failed: No such file or directory
    pam_unix(systemd-user:account): helper binary execve failed: No such file or directory
    PAM failed: Authentication service cannot retrieve authentication info
    user@0.service: Failed to set up PAM session: Operation not permitted

Do not remove the PAM binaries in /usr/sbin to avoid this issue.

[1] https://github.com/rhinstaller/anaconda/pull/5485