### PR TITLE
runtime-cleanup: wget2-wget has replaced wget

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -324,7 +324,7 @@ removefrom util-linux-core --allbut \
     /etc/mtab \
     /usr/sbin/{agetty,blkid,blockdev,fsck,losetup,mkswap,partx,swapoff,swapon}
 removefrom volume_key-libs /usr/share/locale/*
-removefrom wget /etc/* /usr/share/locale/*
+removefrom wget2 /usr/share/locale/*
 removefrom wpa_supplicant /usr/sbin/eapol_test
 removefrom xorg-x11-drv-intel /usr/${libdir}/libI*
 removefrom xorg-x11-drv-wacom /usr/bin/*


### PR DESCRIPTION
wget2-wget is just symlinks to wget2, which provides the actual content. wget2 has no files in /etc though.

This is a follow-up to commit 9b703f53ef59601c8a0f362edae5b81bfe709a5a (#1370).

This is already in lorax-templates-rhel for EL10+: https://src.fedoraproject.org/rpms/lorax-templates-rhel/c/b78f09a8fd2a9fa58ecf3b3bac4e0b808ef968fa?branch=eln

/cc @AdamWill 
