### PR TITLE
mkksiso: option --replace to replace arbitrary text in boot config.

### DIFF
--- a/src/bin/mkksiso
+++ b/src/bin/mkksiso
@@ -312,7 +312,7 @@ def GetCmdline(line, commands):
     return "", line
 
 
-def EditIsolinux(rm_args, add_args, new_volid, old_volid, tmpdir):
+def EditIsolinux(rm_args, add_args, replace_list, tmpdir):
     """
     Modify the cmdline for an isolinux.cfg
     Remove args, add new arguments and change existing volid if requested
@@ -322,14 +322,13 @@ def EditIsolinux(rm_args, add_args, new_volid, old_volid, tmpdir):
         log.warning("No isolinux/isolinux.cfg file found")
         return
 
-    change_volid = old_volid != new_volid
-
     # Edit the config file, save the new one as .new
     with open(orig_cfg, "r") as in_fp:
         with open(orig_cfg + ".new", "w") as out_fp:
             for line in in_fp:
-                if change_volid and old_volid in line:
-                    line = line.replace(old_volid, new_volid)
+                for from_item, to_item in replace_list:
+                    if from_item in line:
+                        line = line.replace(from_item, to_item)
                 prefix, cmdline = GetCmdline(line, ["append"])
                 if prefix:
                     args = SplitCmdline(cmdline)
@@ -342,7 +341,7 @@ def EditIsolinux(rm_args, add_args, new_volid, old_volid, tmpdir):
         os.replace(orig_cfg + ".new", orig_cfg)
 
 
-def EditGrub2(rm_args, add_args, new_volid, old_volid, tmpdir):
+def EditGrub2(rm_args, add_args, replace_list, tmpdir):
     """
     Modify the cmdline for GRUB2 UEFI and BIOS config files
     Add the new arguments and change existing volid if requested
@@ -354,8 +353,6 @@ def EditGrub2(rm_args, add_args, new_volid, old_volid, tmpdir):
         log.warning("No grub config files found")
         return
 
-    change_volid = old_volid != new_volid
-
     for cfg in grub_cfgs:
         orig_cfg = tmpdir + "/" + cfg
         if not os.path.exists(orig_cfg):
@@ -364,8 +361,9 @@ def EditGrub2(rm_args, add_args, new_volid, old_volid, tmpdir):
         with open(orig_cfg, "r") as in_fp:
             with open(orig_cfg + ".new", "w") as out_fp:
                 for line in in_fp:
-                    if change_volid and old_volid in line:
-                        line = line.replace(old_volid, new_volid)
+                    for from_item, to_item in replace_list:
+                        if from_item in line:
+                            line = line.replace(from_item, to_item)
                     # Some start with linux (BIOS/aarch64), others with linuxefi (x86_64)
                     prefix, cmdline = GetCmdline(line, ["linuxefi", "linux"])
                     if prefix:
@@ -435,13 +433,15 @@ def CheckDiscinfo(path):
 
 
 def MakeKickstartISO(input_iso, output_iso, ks="", updates_image="", add_paths=None,
-                    cmdline="", rm_args="", new_volid="", implantmd5=True,
+                    cmdline="", rm_args="", new_volid="", replace_list=None, implantmd5=True,
                     skip_efi=False):
     """
     Make a kickstart ISO from a boot.iso or dvd
     """
     if add_paths is None:
         add_paths = []
+    if replace_list is None:
+        replace_list = []
 
     # Gather information about the input iso
     old_volid, files = GetISODetails(input_iso)
@@ -476,9 +476,11 @@ def MakeKickstartISO(input_iso, output_iso, ks="", updates_image="", add_paths=N
             add_args["inst.ks"] = ["hd:LABEL=%s:/%s" % (new_volid or old_volid, os.path.basename(ks))]
             add_paths.append(ks)
 
+        replace_list.append((old_volid, new_volid))
+        log.debug(replace_list)
         # Add kickstart command and optionally change the volid of the available config files
-        EditIsolinux(remove_args, add_args, new_volid, old_volid, tmpdir)
-        EditGrub2(remove_args, add_args, new_volid, old_volid, tmpdir)
+        EditIsolinux(remove_args, add_args, replace_list, tmpdir)
+        EditGrub2(remove_args, add_args, replace_list, tmpdir)
         EditS390(remove_args, add_args, new_volid, old_volid, tmpdir)
 
         if os.uname().machine.startswith("s390"):
@@ -563,6 +565,8 @@ def setup_arg_parser():
     parser.add_argument("-u", "--updates", type=os.path.abspath, metavar="IMAGE",
                         help="Optional updates image to add to the ISO")
     parser.add_argument("-V", "--volid", dest="volid", help="Set the ISO volume id, defaults to input's", default=None)
+    parser.add_argument("-R", "--replace", nargs=2, action="append", metavar=("FROM", "TO"),
+                        help="Replace string in grub.cfg. Can be used multiple times")
     parser.add_argument("--skip-mkefiboot", action="store_true", dest="skip_efi",
                         help="Skip running mkefiboot")
 
@@ -606,8 +610,8 @@ def main():
             log.error("Use either --ks KICKSTART or positional KICKSTART but not both")
             errors = True
 
-        if not any([args.ks or args.ks_pos, args.updates, args.add_paths, args.cmdline, args.rm_args, args.volid]):
-            log.error("Nothing to do - pass one or more of --ks, --updates, --add, --cmdline, --rm-args, --volid")
+        if not any([args.ks or args.ks_pos, args.updates, args.add_paths, args.cmdline, args.rm_args, args.volid, args.replace]):
+            log.error("Nothing to do - pass one or more of --ks, --updates, --add, --cmdline, --rm-args, --volid, --replace")
             errors = True
 
         if errors:
@@ -615,7 +619,7 @@ def main():
 
         MakeKickstartISO(args.input_iso, args.output_iso, args.ks or args.ks_pos, args.updates,
                          args.add_paths, args.cmdline, args.rm_args,
-                         args.volid, args.no_md5sum, args.skip_efi)
+                         args.volid, args.replace, args.no_md5sum, args.skip_efi)
     except RuntimeError as e:
         log.error(str(e))
         return 1

--- a/src/bin/mkksiso
+++ b/src/bin/mkksiso
@@ -377,7 +377,7 @@ def EditGrub2(rm_args, add_args, replace_list, tmpdir):
         os.replace(orig_cfg + ".new", orig_cfg)
 
 
-def EditS390(rm_args, add_args, new_volid, old_volid, tmpdir):
+def EditS390(rm_args, add_args, replace_list, tmpdir):
     """
     Modify the cmdline for s390 config files
     Add the new arguments and change existing volid if requested
@@ -387,8 +387,6 @@ def EditS390(rm_args, add_args, new_volid, old_volid, tmpdir):
     if not any(os.path.exists(tmpdir + "/" + c) for c in s390_cfgs):
         log.warning("No s390 config files found")
         return
-
-    change_volid = old_volid != new_volid
 
     for cfg in s390_cfgs:
         orig_cfg = tmpdir + "/" + cfg
@@ -402,8 +400,9 @@ def EditS390(rm_args, add_args, new_volid, old_volid, tmpdir):
 
         cmdline = " ".join(l.strip() for l in lines)
         # Replace the volid
-        if change_volid and old_volid in cmdline:
-            cmdline = cmdline.replace(old_volid, new_volid)
+        for from_item, to_item in replace_list:
+            if from_item in cmdline:
+                cmdline = cmdline.replace(from_item, to_item)
         args = SplitCmdline(cmdline)
         new_args = AlterKernelArgs(args, rm_args, add_args)
 
@@ -481,7 +480,7 @@ def MakeKickstartISO(input_iso, output_iso, ks="", updates_image="", add_paths=N
         # Add kickstart command and optionally change the volid of the available config files
         EditIsolinux(remove_args, add_args, replace_list, tmpdir)
         EditGrub2(remove_args, add_args, replace_list, tmpdir)
-        EditS390(remove_args, add_args, new_volid, old_volid, tmpdir)
+        EditS390(remove_args, add_args, replace_list, tmpdir)
 
         if os.uname().machine.startswith("s390"):
             RebuildS390CDBoot(tmpdir)

--- a/tests/mkksiso/test_mkksiso.py
+++ b/tests/mkksiso/test_mkksiso.py
@@ -118,6 +118,8 @@ class EditConfigsTestCase(unittest.TestCase):
             })
         self.new_volid = "Fedora-mkksiso-rawhide-test"
         self.old_volid = "Fedora-rawhide-test"
+        self.replace_list = [(self.old_volid, self.new_volid)]
+
 
     def run_test(self, configs, tmpdir, test_fn):
         """
@@ -142,7 +144,7 @@ class EditConfigsTestCase(unittest.TestCase):
                 os.makedirs(os.path.dirname(tmpdir + "/" + path), exist_ok=True)
                 shutil.copy(test_data + "/" + cfg, tmpdir + "/" + path)
 
-        test_fn(self.rm_args, self.add_args, self.new_volid, self.old_volid, tmpdir)
+        test_fn(self.rm_args, self.add_args, self.replace_list, tmpdir)
 
         # Read the modified config file(s) and compare to result file
         check_cfg_results(self, tmpdir, configs)


### PR DESCRIPTION
  - It is a generalized version of the code that replaces the volume ID.

  - Test adjusted accordingly because signature changed slightly.

  - This can be used to augment/change the user visible boot menu to add more information about the kickstart installation that is going to happen.

  - Implemented for grub and isolinux, not s390 (don't know how to test).

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
