### PR TITLE
Add erofs compressed rootfs support

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -39,6 +39,7 @@ Requires:       isomd5sum
 Requires:       module-init-tools
 Requires:       parted
 Requires:       squashfs-tools >= 4.2
+Requires:       erofs-utils
 Requires:       util-linux
 Requires:       xz-lzma-compat
 Requires:       xz

--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -64,7 +64,7 @@ DRACUT_DEFAULT = ["--xz", "--install", "/.buildstamp", "--no-early-microcode", "
 DEFAULT_PLATFORM_ID = "platform:f41"
 DEFAULT_RELEASEVER = "41"
 
-ROOTFSTYPES = ["squashfs", "squashfs-ext4", "erofs"]
+ROOTFSTYPES = ["squashfs", "squashfs-ext4", "erofs", "erofs-ext4"]
 
 # XXX - Temporarily lifted from dnf.rpm module
 def _invert(dct):
@@ -366,11 +366,17 @@ class Lorax(BaseLoraxClass):
                     compression=compression, compressargs=compressargs,
                     size=size)
         elif rootfs_type == "erofs":
-            raise RuntimeError("erofs not yet implemented")
             # Create a erofs compressed rootfs.img
-##            rc = rb.create_erofs_runtime(joinpaths(installroot,runtime),
-##                    compression=compression, compressargs=compressargs,
-##                    size=size)
+            # NOTE it does not support the same compression args as the other options
+            # so they are not passed to it.
+            rc = rb.create_erofs_runtime(joinpaths(installroot,runtime),
+                    size=size)
+        elif rootfs_type == "erofs-ext4":
+            # Create an ext4 rootfs.img and compress it with erofs
+            # NOTE it does not support the same compression args as the other options
+            # so they are not passed to it.
+            rc = rb.create_erofs_ext4_runtime(joinpaths(installroot,runtime),
+                    size=size)
         else:
             raise RuntimeError(f"{rootfs_type} is not a supported type for the root filesystem")
         if rc != 0:

--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -153,6 +153,10 @@ class Lorax(BaseLoraxClass):
         self.conf.set("compression", "args", "")
         self.conf.set("compression", "bcj", "on")
 
+        self.conf.add_section("compression.erofs")
+        self.conf.set("compression.erofs", "type", "lzma")
+        self.conf.set("compression.erofs", "args", "")
+
         # read the config file
         if os.path.isfile(conf_file):
             self.conf.read(conf_file)
@@ -209,6 +213,24 @@ class Lorax(BaseLoraxClass):
         fh = logging.FileHandler(filename=joinpaths(logdir, logname), mode="w")
         fh.setLevel(logging.DEBUG)
         logger.addHandler(fh)
+
+    def squashfs_args(self):
+        """Return compression type and args for squashfs compression"""
+        compression = self.conf.get("compression", "type")
+        compressargs = self.conf.get("compression", "args").split()     # pylint: disable=no-member
+        if self.conf.getboolean("compression", "bcj"):
+            if self.arch.bcj:
+                compressargs += ["-Xbcj", self.arch.bcj]
+            else:
+                logger.info("no BCJ filter for arch %s", self.arch.basearch)
+
+        return (compression, compressargs)
+
+    def erofs_args(self):
+        """Return compression type and args for erofs compression"""
+        compression = self.conf.get("compression.erofs", "type")
+        compressargs = self.conf.get("compression.erofs", "args").split()     # pylint: disable=no-member
+        return (compression, compressargs)
 
     def run(self, dbo, product, version, release, variant="", bugurl="",
             isfinal=False, workdir=None, outputdir=None, buildarch=None, volid=None,
@@ -348,34 +370,29 @@ class Lorax(BaseLoraxClass):
 
         logger.info("creating the runtime image")
         runtime = "images/install.img"
-        compression = self.conf.get("compression", "type")
-        compressargs = self.conf.get("compression", "args").split()     # pylint: disable=no-member
-        if self.conf.getboolean("compression", "bcj"):
-            if self.arch.bcj:
-                compressargs += ["-Xbcj", self.arch.bcj]
-            else:
-                logger.info("no BCJ filter for arch %s", self.arch.basearch)
         if rootfs_type == "squashfs":
             # Create a squashfs compressed rootfs.img
+            compression, compressargs = self.squashfs_args()
             rc = rb.create_squashfs_runtime(joinpaths(installroot,runtime),
                     compression=compression, compressargs=compressargs,
                     size=size)
         elif rootfs_type == "squashfs-ext4":
             # Create an ext4 rootfs.img and compress it with squashfs
+            compression, compressargs = self.squashfs_args()
             rc = rb.create_ext4_runtime(joinpaths(installroot,runtime),
                     compression=compression, compressargs=compressargs,
                     size=size)
         elif rootfs_type == "erofs":
             # Create a erofs compressed rootfs.img
-            # NOTE it does not support the same compression args as the other options
-            # so they are not passed to it.
+            compression, compressargs = self.erofs_args()
             rc = rb.create_erofs_runtime(joinpaths(installroot,runtime),
+                    compression=compression, compressargs=compressargs,
                     size=size)
         elif rootfs_type == "erofs-ext4":
             # Create an ext4 rootfs.img and compress it with erofs
-            # NOTE it does not support the same compression args as the other options
-            # so they are not passed to it.
+            compression, compressargs = self.erofs_args()
             rc = rb.create_erofs_ext4_runtime(joinpaths(installroot,runtime),
+                    compression=compression, compressargs=compressargs,
                     size=size)
         else:
             raise RuntimeError(f"{rootfs_type} is not a supported type for the root filesystem")

--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -64,6 +64,8 @@ DRACUT_DEFAULT = ["--xz", "--install", "/.buildstamp", "--no-early-microcode", "
 DEFAULT_PLATFORM_ID = "platform:f41"
 DEFAULT_RELEASEVER = "41"
 
+ROOTFSTYPES = ["squashfs", "squashfs-ext4", "erofs"]
+
 # XXX - Temporarily lifted from dnf.rpm module
 def _invert(dct):
     return {v: k for k in dct for v in dct[k]}
@@ -219,7 +221,7 @@ class Lorax(BaseLoraxClass):
             add_arch_template_vars=None,
             verify=True,
             user_dracut_args=None,
-            squashfs_only=False,
+            rootfs_type="squashfs",
             skip_branding=False):
 
         assert self._configured
@@ -353,16 +355,24 @@ class Lorax(BaseLoraxClass):
                 compressargs += ["-Xbcj", self.arch.bcj]
             else:
                 logger.info("no BCJ filter for arch %s", self.arch.basearch)
-        if squashfs_only:
-            # Create an ext4 rootfs.img and compress it with squashfs
+        if rootfs_type == "squashfs":
+            # Create a squashfs compressed rootfs.img
             rc = rb.create_squashfs_runtime(joinpaths(installroot,runtime),
                     compression=compression, compressargs=compressargs,
                     size=size)
-        else:
+        elif rootfs_type == "squashfs-ext4":
             # Create an ext4 rootfs.img and compress it with squashfs
             rc = rb.create_ext4_runtime(joinpaths(installroot,runtime),
                     compression=compression, compressargs=compressargs,
                     size=size)
+        elif rootfs_type == "erofs":
+            raise RuntimeError("erofs not yet implemented")
+            # Create a erofs compressed rootfs.img
+##            rc = rb.create_erofs_runtime(joinpaths(installroot,runtime),
+##                    compression=compression, compressargs=compressargs,
+##                    size=size)
+        else:
+            raise RuntimeError(f"{rootfs_type} is not a supported type for the root filesystem")
         if rc != 0:
             logger.error("rootfs.img creation failed. See program.log")
             sys.exit(1)

--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -22,7 +22,7 @@ import os
 import sys
 import argparse
 
-from pylorax import DEFAULT_RELEASEVER, vernum
+from pylorax import DEFAULT_RELEASEVER, ROOTFSTYPES, vernum
 
 version = "{0}-{1}".format(os.path.basename(sys.argv[0]), vernum)
 
@@ -109,10 +109,14 @@ def lorax_parser(dracut_default=""):
                           help="Do not verify SSL certificates")
     optional.add_argument("--dnfplugin", action="append", default=[], dest="dnfplugins",
                           help="Enable a DNF plugin by name/glob, or * to enable all of them.")
-    optional.add_argument("--squashfs-only", action="store_true", default=False,
+    optional.add_argument("--squashfs-only", action="store_const", const="squashfs",
+                          dest="rootfs_type",
                           help="Use a plain squashfs filesystem for the runtime.")
     optional.add_argument("--skip-branding", action="store_true", default=False,
                           help="Disable automatic branding package selection. Use --installpkgs to add custom branding.")
+    optional.add_argument("--rootfs-type", metavar="ROOTFSTYPE", default="squashfs",
+                          dest="rootfs_type",
+                          help="Type of rootfs: %s" % ",".join(ROOTFSTYPES))
 
     # dracut arguments
     dracut_group = parser.add_argument_group("dracut arguments: (default: %s)" % dracut_default)
@@ -324,8 +328,11 @@ def lmc_parser(dracut_default=""):
     parser.add_argument("--releasever", default=DEFAULT_RELEASEVER,
                         help="substituted for @VERSION@ in bootloader config files")
     parser.add_argument("--volid", default=None, help="volume id")
-    parser.add_argument("--squashfs-only", action="store_true", default=False,
+    parser.add_argument("--squashfs-only", action="store_const", const="squashfs",
+                        dest="rootfs_type",
                         help="Use a plain squashfs filesystem for the runtime.")
+    parser.add_argument("--rootfs-type", metavar="ROOTFSTYPE", default="squashfs",
+                        help="Type of rootfs: %s" % ",".join(ROOTFSTYPES))
     parser.add_argument("--timeout", default=None, type=int,
                         help="Cancel installer after X minutes")
 

--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -219,18 +219,25 @@ def make_runtime(opts, mount_dir, work_dir, size=None):
                             variant=opts.variant, bugurl=opts.bugurl, isfinal=opts.isfinal)
 
     rb = RuntimeBuilder(product, arch, skip_branding=True, root=mount_dir)
-    compression, compressargs = squashfs_args(opts)
 
     if opts.rootfs_type == "squashfs":
+        compression, compressargs = squashfs_args(opts)
         log.info("Creating a squashfs only runtime")
         return rb.create_squashfs_runtime(joinpaths(work_dir, RUNTIME), size=size,
                   compression=compression, compressargs=compressargs)
     elif opts.rootfs_type == "squashfs-ext4":
+        compression, compressargs = squashfs_args(opts)
         log.info("Creating a squashfs+ext4 runtime")
         return rb.create_ext4_runtime(joinpaths(work_dir, RUNTIME), size=size,
                   compression=compression, compressargs=compressargs)
     elif opts.rootfs_type == "erofs":
-        raise RuntimeError("erofs not supported yet")
+        log.info("Creating a erofs only runtime")
+        return rb.create_erofs_runtime(joinpaths(work_dir, RUNTIME), size=size,
+                  compression="lzma")
+    elif opts.rootfs_type == "erofs-ext4":
+        log.info("Creating a erofs+ext4 runtime")
+        return rb.create_erofs_ext4_runtime(joinpaths(work_dir, RUNTIME), size=size,
+                  compression="lzma")
     else:
         raise RuntimeError(f"{opts.rootfs_type} is not a supported type for the root filesystem")
 

--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -221,14 +221,18 @@ def make_runtime(opts, mount_dir, work_dir, size=None):
     rb = RuntimeBuilder(product, arch, skip_branding=True, root=mount_dir)
     compression, compressargs = squashfs_args(opts)
 
-    if opts.squashfs_only:
+    if opts.rootfs_type == "squashfs":
         log.info("Creating a squashfs only runtime")
         return rb.create_squashfs_runtime(joinpaths(work_dir, RUNTIME), size=size,
                   compression=compression, compressargs=compressargs)
-    else:
+    elif opts.rootfs_type == "squashfs-ext4":
         log.info("Creating a squashfs+ext4 runtime")
         return rb.create_ext4_runtime(joinpaths(work_dir, RUNTIME), size=size,
                   compression=compression, compressargs=compressargs)
+    elif opts.rootfs_type == "erofs":
+        raise RuntimeError("erofs not supported yet")
+    else:
+        raise RuntimeError(f"{opts.rootfs_type} is not a supported type for the root filesystem")
 
 
 def rebuild_initrds_for_live(opts, sys_root_dir, results_dir):

--- a/src/pylorax/imgutils.py
+++ b/src/pylorax/imgutils.py
@@ -118,6 +118,12 @@ def mksquashfs(rootdir, outfile, compression="default", compressargs=None):
         compressargs = ["-comp", compression] + compressargs
     return execWithRedirect("mksquashfs", [rootdir, outfile] + compressargs)
 
+def mkerofs(rootdir, outfile, compression="lzma", compressargs=None):
+    '''Make an erofs image containing the given rootdir.'''
+    compressargs = compressargs or []
+    compressargs = ["-z", compression] + compressargs
+    return execWithRedirect("mkfs.erofs", [outfile, rootdir] + compressargs)
+
 def mkrootfsimg(rootdir, outfile, label, size=2, sysroot=""):
     """
     Make rootfs image from a directory

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -37,7 +37,7 @@ import shutil
 #import librepo
 
 import pylorax
-from pylorax import DRACUT_DEFAULT, log_selinux_state
+from pylorax import DRACUT_DEFAULT, ROOTFSTYPES, log_selinux_state
 from pylorax.cmdline import lorax_parser
 from pylorax.dnfbase import get_dnf_base_object
 
@@ -103,6 +103,9 @@ def main():
         parser.error("argument --dracut-arg: not allowed with argument --dracut-conf")
     if opts.dracut_conf and not os.path.exists(opts.dracut_conf):
         parser.error("dracut config file %s doesn't exist." % opts.dracut_conf)
+
+    if opts.rootfs_type not in ROOTFSTYPES:
+        parser.error("--rootfs-type must be one of %s" % ",".join(ROOTFSTYPES))
 
     setup_logging(opts)
     log.debug(opts)
@@ -201,7 +204,7 @@ def main():
               add_arch_template_vars=parsed_add_arch_template_vars,
               remove_temp=True, verify=opts.verify,
               user_dracut_args=user_dracut_args,
-              squashfs_only=opts.squashfs_only,
+              rootfs_type=opts.rootfs_type,
               skip_branding=opts.skip_branding)
 
     # Release the lock on the tempdir

--- a/test-packages
+++ b/test-packages
@@ -28,6 +28,7 @@ python3-sphinx_rtd_theme
 qemu-img
 rsync
 squashfs-tools
+erofs-utils
 sudo
 which
 xorriso

--- a/tests/pylorax/test_creator.py
+++ b/tests/pylorax/test_creator.py
@@ -153,7 +153,7 @@ class CreatorTest(unittest.TestCase):
                 mkFakeBoot(mount_dir)
                 opts = DataHolder(project="Fedora", releasever="devel", compression="xz", compress_args=[],
                                   release="", variant="", bugurl="", isfinal=False,
-                                  arch="x86_64", squashfs_only=True)
+                                  arch="x86_64", rootfs_type="squashfs")
                 make_runtime(opts, mount_dir, work_dir)
 
                 # Make sure it made an install.img
@@ -178,7 +178,7 @@ class CreatorTest(unittest.TestCase):
                 mkFakeBoot(mount_dir)
                 opts = DataHolder(project="Fedora", releasever="devel", compression="xz", compress_args=[],
                                   release="", variant="", bugurl="", isfinal=False,
-                                  arch="x86_64", squashfs_only=False)
+                                  arch="x86_64", rootfs_type="squashfs-ext4")
                 make_runtime(opts, mount_dir, work_dir)
 
                 # Make sure it made an install.img

--- a/tests/pylorax/test_imgutils.py
+++ b/tests/pylorax/test_imgutils.py
@@ -24,7 +24,8 @@ import unittest
 
 from ..lib import get_file_magic
 from pylorax.executils import runcmd
-from pylorax.imgutils import mkcpio, mktar, mksquashfs, mksparse, mkqcow2, loop_attach, loop_detach
+from pylorax.imgutils import mkcpio, mktar, mksquashfs, mksparse, mkqcow2, mkerofs
+from pylorax.imgutils import loop_attach, loop_detach
 from pylorax.imgutils import get_loop_name, LoopDev, dm_attach, dm_detach, DMDev, Mount
 from pylorax.imgutils import mkdosimg, mkext4img, mkbtrfsimg, mkhfsimg, default_image_name
 from pylorax.imgutils import mount, umount, kpartx_disk_img, PartitionMount, mkfsimage_from_disk
@@ -182,6 +183,18 @@ class ImgUtilsTest(unittest.TestCase):
                 self.assertTrue(os.path.exists(disk_img.name))
                 file_details = get_file_magic(disk_img.name)
                 self.assertTrue("Squashfs" in file_details, file_details)
+
+    def test_mkerofs(self):
+        """Test mkerofs function"""
+        with tempfile.TemporaryDirectory(prefix="lorax.test.") as work_dir:
+            with tempfile.NamedTemporaryFile(prefix="lorax.test.disk.") as disk_img:
+                mkfakerootdir(work_dir)
+                disk_img.close()
+                mkerofs(work_dir, disk_img.name)
+
+                self.assertTrue(os.path.exists(disk_img.name))
+                file_details = get_file_magic(disk_img.name)
+                self.assertTrue("EROFS filesystem" in file_details, file_details)
 
     def test_mksparse(self):
         """Test mksparse function"""


### PR DESCRIPTION
This adds support for creating the rootfs using the erofs compression format. https://erofs.docs.kernel.org/en/latest/quickstart.html

You can run it by checking out this branch from github (into /root/lorax in this example) and running:

```
#!/bin/bash

# Gather up the list of system repo files and use them for lorax
REPOS=$(for f in /etc/yum.repos.d/*repo; do echo -n "--repo $f "; done)
if [ -z "$REPOS" ]; then
    echo "No system repos found"
    exit 1
fi

PATH=/root/lorax/src/bin:/root/lorax/src/sbin:$PATH PYTHONPATH=/root/lorax/src/ \
/root/lorax/src/sbin/lorax --product="Fedora" --version=41  --release=41 \
--volid="Fedora-rawhide-test" \
--rootfs-type erofs \
--proxy http://proxy.notae.us:8123 \
$REPOS /var/tmp/lorax-fedora-iso/ || exit 1
```

There will be a boot.iso and an install.img in /var/tmp/lorax-fedora-iso/images/

The resulting boot.iso will boot and mount the erofs filesystem, but the overlay doesn't appear to work so it is read only. Dracut still needs some work to fully support this, but this should be a good starting point.

