### PR TITLE
rsyslog.conf: Update to use current config syntax

### DIFF
--- a/share/templates.d/99-generic/config_files/common/rsyslog.conf
+++ b/share/templates.d/99-generic/config_files/common/rsyslog.conf
@@ -1,62 +1,43 @@
-# rsyslog configuration file
+# minimal rsyslog configuration file for the installer boot.iso
 
-# For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
-# If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
+# provides support for local system logging (e.g. via logger command)
+# disables message dropping, we need all of them
+# Turn off message reception via local log socket;
+# local messages are retrieved through imjournal now.
+module(load="imuxsock"
+    SysSock.RateLimit.Interval="0"
+    SysSock.Use="off")
 
-#### MODULES ####
-
-# The imjournal module below is now used as a message source instead of imuxsock.
-$ModLoad imuxsock # provides support for local system logging (e.g. via logger command)
-$SystemLogRateLimitInterval 0 # disables message dropping, we need all of them
-$ModLoad imjournal # provides access to the systemd journal
-#$ModLoad imklog # reads kernel messages (the same are read from journald)
-#$ModLoad immark  # provides --MARK-- message capability
+# provides access to the systemd journal
 # Disable rate limiting to the journal, we need all the messages for debugging
-$imjournalRatelimitInterval 0
-$imjournalRatelimitBurst 0
+module(load="imjournal"
+    Ratelimit.Interval="0"
+    Ratelimit.Burst="0"
+    StateFile="imjournal.state")
 
-# Provides UDP syslog reception
-#$ModLoad imudp
-#$UDPServerRun 514
+module(load="imfile" mode="inotify")
+input(type="imfile"
+    File="/tmp/X.log"
+    Tag="xserver:"
+    Facility="local1")
 
-# Provides TCP syslog reception
-#$ModLoad imtcp
-#$InputTCPServerRun 514
+input(type="imfile"
+    File="/tmp/anaconda-tb-all.log"
+    Tag="anaconda-tb:"
+    Facility="local1")
 
-$ModLoad imfile
-$InputFileName /tmp/X.log
-$InputFileTag xserver:
-$InputFileStateFile xserver-statefile
-$InputFileFacility local1
-$InputRunFileMonitor
-$InputFileName /tmp/anaconda-tb-all.log
-$InputFileTag anaconda-tb:
-$InputFileStateFile anaconda-tb-statefile
-$InputFileFacility local1
-$InputRunFileMonitor
+module(load="builtin:omfile"
+    Template="RSYSLOG_TraditionalFileFormat"
+)
 
 
 #### GLOBAL DIRECTIVES ####
 
 # Where to place auxiliary files
-$WorkDirectory /var/lib/rsyslog
-
-# Use default timestamp format
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
-
-# File syncing capability is disabled by default. This feature is usually not required,
-# not useful and an extreme performance hit
-#$ActionFileEnableSync on
+global(workDirectory="/var/lib/rsyslog")
 
 # Include all config files in /etc/rsyslog.d/
-$IncludeConfig /etc/rsyslog.d/*.conf
-
-# Turn off message reception via local log socket;
-# local messages are retrieved through imjournal now.
-$OmitLocalLogging on
-
-# File to store the position in the journal
-$IMJournalStateFile imjournal.state
+include(file="/etc/rsyslog.d/*.conf")
 
 #### TEMPLATES ####
 


### PR DESCRIPTION
This commit switches to using the rewritten config file from the upstream templates. This fixes the problem with writing the state file to the workDirectory and uses modern syntax.

Resolves: RHEL-46857

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
