### PR TITLE
creator: Change rootfs description to match cmdline argument

### DIFF
--- a/src/pylorax/creator.py
+++ b/src/pylorax/creator.py
@@ -227,7 +227,7 @@ def make_runtime(opts, mount_dir, work_dir, size=None):
                   compression=compression, compressargs=compressargs)
     elif opts.rootfs_type == "squashfs-ext4":
         compression, compressargs = squashfs_args(opts)
-        log.info("Creating a squashfs+ext4 runtime")
+        log.info("Creating a squashfs-ext4 runtime")
         return rb.create_ext4_runtime(joinpaths(work_dir, RUNTIME), size=size,
                   compression=compression, compressargs=compressargs)
     elif opts.rootfs_type == "erofs":
@@ -235,7 +235,7 @@ def make_runtime(opts, mount_dir, work_dir, size=None):
         return rb.create_erofs_runtime(joinpaths(work_dir, RUNTIME), size=size,
                   compression="lzma")
     elif opts.rootfs_type == "erofs-ext4":
-        log.info("Creating a erofs+ext4 runtime")
+        log.info("Creating a erofs-ext4 runtime")
         return rb.create_erofs_ext4_runtime(joinpaths(work_dir, RUNTIME), size=size,
                   compression="lzma")
     else:


### PR DESCRIPTION
This changes the log entry from squashfs+ext4/erofs+ext4 to squashfs-ext4/erofs-ext4 which matches the cmdline argument passed to --rootfs-type, making the naming of it more consistent.

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
