### PR TITLE
runtime-postinstall: Make sure blacklist_exceptions has been removed

### DIFF
--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -103,7 +103,6 @@ append etc/depmod.d/dd.conf "search updates built-in"
 
 ## create multipath.conf so multipath gets auto-started
 append etc/multipath.conf "defaults {\n\tfind_multipaths smart\n\tuser_friendly_names yes\n}\n"
-append etc/multipath.conf "blacklist_exceptions {\n\tproperty \"(SCSI_IDENT_|ID_WWN)\"\n}\n"
 
 ## make lvm auto-activate
 remove etc/lvm/archive/*


### PR DESCRIPTION
While syncing the templates with the current RHEL10 templates I goofed and un-reverted the revert so this reverts the un-revert so it stays reverted.

Or more simply, don't write the blacklist_exceptions section to multipath.conf otherwise the system won't boot.

See https://bugzilla.redhat.com/show_bug.cgi?id=1853668 for details.

Resolves: RHEL-53721
