### PR TITLE
tests: Add a test to make sure redhat-release-eula isn't included

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ test:
 					--cov=pylorax \
 					--cov=mkksiso \
 					--cov=minimizer \
+					./tests/no-eula/ \
 					./tests/pylorax/ \
 					./tests/image-minimizer/ \
 					./tests/mkksiso/

--- a/tests/no-eula/test_noeula.py
+++ b/tests/no-eula/test_noeula.py
@@ -1,0 +1,10 @@
+import unittest
+
+# Make sure that redhat-release-eula was removed after copying over lorax-templates-rhel
+class NoEULATestCase(unittest.TestCase):
+    def test_noeula(self):
+        """Make sure redhat-release-eula is not in runtime-install.tmpl"""
+        with open("./share/templates.d/99-generic/runtime-install.tmpl") as f:
+            for line in f.readlines():
+                self.assertTrue("redhat-release-eula" not in line,
+                                "Remove redhat-release-eula from runtime-install.tmpl")


### PR DESCRIPTION
Make sure the generic templates don't install redhat-release-eula.

Related: RHEL-54381
