### PR TITLE
livemedia: Add isomd5sum

### DIFF
--- a/docs/livemedia.ks
+++ b/docs/livemedia.ks
@@ -131,6 +131,8 @@ esac
 ## This is a minimal desktop live system without Anaconda which doesn't support live on RHEL
 @workstation-product
 system-logos
+## Since Anaconda isn't included we need to make sure isomd5sum is included
+isomd5sum
 
 dracut-config-generic
 dracut-live


### PR DESCRIPTION
This is needed for the iso checksum check of the live media. On the boot.iso (and in Fedora) it is pulled in by anaconda-install-* packages, but since liveinst isn't supported on RHEL we don't use those. Add it to the kickstart to make sure the checksum service can run at boot time.

Resolves: RHEL-58896
