### PR TITLE
No more dnf, change to `installpkg python3-dnf`

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -11,7 +11,7 @@ installpkg anaconda anaconda-widgets
 ## work around dnf5 bug - https://github.com/rpm-software-management/dnf5/issues/1111
 installpkg anaconda-install-img-deps>=40.15
 ## Other available payloads
-installpkg dnf
+installpkg python3-dnf
 installpkg rpm-ostree ostree
 ## speed up compression on multicore systems
 installpkg pigz


### PR DESCRIPTION
The dnf team wants to drop the 'dnf' binary package, see https://src.fedoraproject.org/rpms/dnf/c/51ac29c . However, this makes lorax blow up because of this line, see
https://bodhi.fedoraproject.org/updates/FEDORA-2024-a7176faa5b#comment-3745816 Let's change it to python3-dnf , which should work so long as everything in the installer uses the Python interface and nothing calls 'dnf' directly.