### PR TITLE
templates: Drop dnf install

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -11,7 +11,6 @@ installpkg anaconda anaconda-widgets
 ## work around dnf5 bug - https://github.com/rpm-software-management/dnf5/issues/1111
 installpkg anaconda-install-img-deps>=40.15
 ## Other available payloads
-installpkg dnf
 installpkg rpm-ostree ostree
 ## speed up compression on multicore systems
 installpkg pigz


### PR DESCRIPTION
See https://src.fedoraproject.org/rpms/dnf/c/51ac29c

The dnf cmdline is no longer provided by dnf5. And anything needed similar functionality should have it as a requirement, not an installpkg line in the template.

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
