### PR TITLE
Fix --updates the updates image wasn't loaded

### DIFF
--- a/src/bin/mkksiso
+++ b/src/bin/mkksiso
@@ -560,9 +560,9 @@ def setup_arg_parser():
     parser.add_argument("--no-md5sum", action="store_false", default=True,
                         help="Do not run implantisomd5 on the ouput iso")
     parser.add_argument("--ks", type=os.path.abspath, metavar="KICKSTART",
-                        help="Optional kickstart to add to the ISO")
+                        help="Optional kickstart to add to the ISO (adding inst.ks automatically)")
     parser.add_argument("-u", "--updates", type=os.path.abspath, metavar="IMAGE",
-                        help="Optional updates image to add to the ISO")
+                        help="Optional updates image to add to the ISO (adding inst.updates automatically)")
     parser.add_argument("-V", "--volid", dest="volid", help="Set the ISO volume id, defaults to input's", default=None)
     parser.add_argument("-R", "--replace", nargs=2, action="append", metavar=("FROM", "TO"),
                         help="Replace string in grub.cfg. Can be used multiple times")

--- a/src/bin/mkksiso
+++ b/src/bin/mkksiso
@@ -475,6 +475,10 @@ def MakeKickstartISO(input_iso, output_iso, ks="", updates_image="", add_paths=N
             add_args["inst.ks"] = ["hd:LABEL=%s:/%s" % (new_volid or old_volid, os.path.basename(ks))]
             add_paths.append(ks)
 
+        if updates_image:
+            add_args["inst.updates"] = ["hd:LABEL=%s:/%s" % (new_volid or old_volid, os.path.basename(updates_image))]
+            add_paths.append(updates_image)
+
         replace_list.append((old_volid, new_volid))
         log.debug(replace_list)
         # Add kickstart command and optionally change the volid of the available config files
@@ -512,11 +516,7 @@ def MakeKickstartISO(input_iso, output_iso, ks="", updates_image="", add_paths=N
         for p in add_paths:
             cmd.extend(["-map", p, os.path.basename(p)])
 
-        # include updates image which will be automatically loaded when on correct place
-        if updates_image:
-            cmd.extend(["-map", updates_image, "updates/updates.img"])
-
-        check_paths = add_paths if not updates_image else add_paths + [updates_image]
+        check_paths = add_paths
         if CheckBigFiles(check_paths):
             if "-as" not in cmd:
                 cmd.extend(["-as", "mkisofs"])


### PR DESCRIPTION
Seems that the original idea with autoloading in Anaconda is not working as it should. So to fix this and simplify everything, just use the same logic as what is used for the kickstart file.