### PR TITLE
tests: Fix mkksiso unit test

### DIFF
--- a/tests/mkksiso/test_mkksiso.py
+++ b/tests/mkksiso/test_mkksiso.py
@@ -265,6 +265,6 @@ class ISOTestCase(unittest.TestCase):
             MakeKickstartISO(self.test_iso, self.out_iso, updates_image=mocked_updates.name, skip_efi=True)
 
             with tempfile.TemporaryDirectory(prefix="mkksiso-") as tmpdir:
-                ExtractISOFiles(self.out_iso, ["updates/updates.img"], tmpdir)
+                ExtractISOFiles(self.out_iso, [os.path.basename(mocked_updates.name)], tmpdir)
 
-                self.assertTrue(os.path.exists(os.path.join(tmpdir, "updates/updates.img")))
+                self.assertTrue(os.path.exists(os.path.join(tmpdir, os.path.basename(mocked_updates.name))))


### PR DESCRIPTION
NOTE: The tests will fail until the rawhide container is updated with a new astroid. Tests pass when run locally with a Fedora 41 container.

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
