### PR TITLE
Update template for anaconda webui to start as user

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -291,7 +291,6 @@ removefrom openssh-clients /usr/libexec/*
 removefrom openssh-server /etc/ssh/* /usr/libexec/openssh/sftp-server
 removefrom pam /usr/share/locale/*
 removefrom policycoreutils /etc/* /usr/bin/* /usr/share/locale/*
-removefrom polkit /usr/bin/*
 removefrom popt /usr/share/locale/*
 removefrom procps-ng /usr/bin/free /usr/bin/pgrep /usr/bin/pkill
 removefrom procps-ng /usr/bin/pmap /usr/bin/pwdx /usr/bin/skill /usr/bin/slabtop

--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -85,6 +85,9 @@ symlink /etc/systemd/system/inst.rngd.service etc/systemd/system/basic.target.wa
 ## set up "install" user account
 append etc/passwd "install:x:0:0:root:/root:/usr/libexec/anaconda/run-anaconda"
 append etc/shadow "install::14438:0:99999:7:::"
+## set up "install-user" who is needed to start webui without root permission in boot iso.
+append etc/passwd "install-user:x:1001:1001::/tmp/install-user:/usr/bin/bash"
+append etc/shadow "install-user::14438:0:99999:7:::"
 ## remove root password
 replace "root:\*:" "root::" etc/shadow
 


### PR DESCRIPTION
This commit is about adding the pkexec command to the lorax build to make it possible to run anaconda webui as a nonroot user and creating a new user to run the installer under.

PR with patch: https://github.com/rhinstaller/anaconda/pull/5689 