### PR TITLE
Adjust to glibc UsrMerge/UsrMove/MoveToUsr transition (RHEL-67332)

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -188,13 +188,13 @@ removefrom gdk-pixbuf2 /usr/share/locale*
 removefrom gfs2-utils /usr/sbin/*
 removefrom glib2 /etc/* /usr/bin/* /usr/share/locale/*
 removefrom glibc /etc/gai.conf /etc/localtime /etc/rpc
-removefrom glibc /lib/*/nosegneg/* /${libdir}/libBrokenLocale*
-removefrom glibc /${libdir}/libSegFault* /${libdir}/libanl*
-removefrom glibc /${libdir}/libcidn* /${libdir}/libnss_compat*
+removefrom glibc /lib/*/nosegneg/* */${libdir}/libBrokenLocale*
+removefrom glibc */${libdir}/libSegFault* */${libdir}/libanl*
+removefrom glibc /${libdir}/libcidn* */${libdir}/libnss_compat*
 removefrom glibc /${libdir}/libnss_hesiod* /${libdir}/libnss_nis*
 # python-pyudev uses ctypes.util.find_library, which uses /sbin/ldconfig
 removefrom glibc /${libdir}/rtkaio* /sbin/sln
-removefrom glibc /usr/libexec/* /usr/sbin/*
+removefrom glibc /usr/libexec/* /usr/sbin/iconvconfig
 removefrom glibc-common /etc/* /usr/bin/catchsegv /usr/bin/gencat
 removefrom glibc-common /usr/bin/getent
 removefrom glibc-common /usr/bin/locale /usr/bin/rpcgen /usr/bin/sprof


### PR DESCRIPTION
In `lorax-templates-rhel`, this is covered by:

```
commit 7fd84027d6f484ccd6676bd016426f62bc29b372
Author: Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>
Date:   Wed Jul 17 11:23:45 2024 +0200

    Prepare for the sbin merge
```

because it removes the `*` wildcard for `sbin` subdirectories.