### PR TITLE
erofs: Change the erofs compression default to zstd

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -39,7 +39,7 @@ Requires:       isomd5sum
 Requires:       module-init-tools
 Requires:       parted
 Requires:       squashfs-tools >= 4.2
-Requires:       erofs-utils
+Requires:       erofs-utils >= 1.8.2
 Requires:       util-linux
 Requires:       xz-lzma-compat
 Requires:       xz

--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -154,8 +154,8 @@ class Lorax(BaseLoraxClass):
         self.conf.set("compression", "bcj", "on")
 
         self.conf.add_section("compression.erofs")
-        self.conf.set("compression.erofs", "type", "lzma")
-        self.conf.set("compression.erofs", "args", "")
+        self.conf.set("compression.erofs", "type", "zstd,8")
+        self.conf.set("compression.erofs", "args", "-Ededupe,all-fragments -C 65536")
 
         # read the config file
         if os.path.isfile(conf_file):

--- a/src/pylorax/imgutils.py
+++ b/src/pylorax/imgutils.py
@@ -118,7 +118,7 @@ def mksquashfs(rootdir, outfile, compression="default", compressargs=None):
         compressargs = ["-comp", compression] + compressargs
     return execWithRedirect("mksquashfs", [rootdir, outfile] + compressargs)
 
-def mkerofs(rootdir, outfile, compression="lzma", compressargs=None):
+def mkerofs(rootdir, outfile, compression="zstd", compressargs=None):
     '''Make an erofs image containing the given rootdir.'''
     compressargs = compressargs or []
     compressargs = ["-z", compression] + compressargs

--- a/src/pylorax/treebuilder.py
+++ b/src/pylorax/treebuilder.py
@@ -263,7 +263,7 @@ class RuntimeBuilder(object):
         remove(workdir)
         return rc
 
-    def create_erofs_runtime(self, outfile="/var/tmp/erofs.img", compression="lzma", compressargs=None, size=2):
+    def create_erofs_runtime(self, outfile="/var/tmp/erofs.img", compression="zstd", compressargs=None, size=2):
         """Create a plain erofs runtime"""
         compressargs = compressargs or []
         os.makedirs(os.path.dirname(outfile))
@@ -271,7 +271,7 @@ class RuntimeBuilder(object):
         # erofs the rootfs
         return imgutils.mkerofs(self.vars.root, outfile, compression, compressargs)
 
-    def create_erofs_ext4_runtime(self, outfile="/var/tmp/erofs.img", compression="lzma", compressargs=None, size=2):
+    def create_erofs_ext4_runtime(self, outfile="/var/tmp/erofs.img", compression="zstd", compressargs=None, size=2):
         """Create a erofs compressed ext4 runtime"""
         # make live rootfs image - must be named "LiveOS/rootfs.img" for dracut
         compressargs = compressargs or []


### PR DESCRIPTION
--rootfs-type erofs now uses:
zstd,8 -Ededupe,all-fragments -C 65536

unless overridden by the 'compression.erofs' section of a lorax config file.
