### PR TITLE
mkksiso: Fix rebuilding the efiboot.img on some systems

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:rawhide
+FROM registry.fedoraproject.org/fedora:latest
 COPY test-packages .
 RUN dnf -y install $(cat test-packages) && touch /.in-container
 RUN useradd weldr

--- a/src/bin/mkksiso
+++ b/src/bin/mkksiso
@@ -242,8 +242,8 @@ def RebuildEFIBoot(input_iso, tmpdir):
 
     returns new efiboot.img file with a temporary name.
     """
-    if not os.path.exists(tmpdir+"/EFI/BOOT/BOOT.conf"):
-        raise RuntimeError("Missing mkefiboot requirement: EFI/BOOT/BOOT.conf")
+    if not os.path.exists(tmpdir+"/EFI/BOOT"):
+        raise RuntimeError("Missing mkefiboot requirement: EFI/BOOT")
 
     # Extract the EFI directory files from the iso
     with tempfile.TemporaryDirectory(prefix="mkksiso-") as tmpefi:
@@ -489,9 +489,9 @@ def MakeKickstartISO(input_iso, output_iso, ks="", updates_image="", add_paths=N
         if os.uname().machine.startswith("s390"):
             RebuildS390CDBoot(tmpdir)
 
-        # If this is a UEFI iso rebuild the efiboot.img file and put it in /efiboot.img
+        # If this is a UEFI iso, rebuild the efiboot.img file and put it in /efiboot.img
         efibootimg = None
-        if not skip_efi and "EFI/BOOT/BOOT.conf" in files:
+        if not skip_efi and ("EFI/BOOT/grub.cfg" in files or "EFI/BOOT/BOOT.conf" in files):
             if os.getuid() != 0:
                 raise RuntimeError("mkefiboot requires root privileges")
 

--- a/src/bin/mkksiso
+++ b/src/bin/mkksiso
@@ -616,8 +616,13 @@ def main():
         if errors:
             raise RuntimeError("Problems running %s" % sys.argv[0])
 
+        remove_args = args.rm_args
+        if args.ks and "inst.ks" not in remove_args:
+            # Add inst.ks to the list of args to remove so that any previous use is overriden
+            remove_args = ("inst.ks " + remove_args).strip()
+
         MakeKickstartISO(args.input_iso, args.output_iso, args.ks or args.ks_pos, args.updates,
-                         args.add_paths, args.cmdline, args.rm_args,
+                         args.add_paths, args.cmdline, remove_args,
                          args.volid, args.replace, args.no_md5sum, args.skip_efi)
     except RuntimeError as e:
         log.error(str(e))


### PR DESCRIPTION
Check for BOOT.conf or grub.cfg in /EFI/BOOT, and only raise an error in RebuildEFIBoot if the directory is missing.

Fixes #1442
