### PR TITLE
Switch RHEL10 default rootfs to erofs

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -39,7 +39,7 @@ Requires:       gzip
 Requires:       isomd5sum
 Requires:       module-init-tools
 Requires:       parted
-Requires:       squashfs-tools >= 4.2
+Recommends:     squashfs-tools >= 4.2
 Requires:       erofs-utils
 Requires:       util-linux
 Requires:       xz-lzma-compat

--- a/src/pylorax/cmdline.py
+++ b/src/pylorax/cmdline.py
@@ -110,10 +110,10 @@ def lorax_parser(dracut_default=""):
     optional.add_argument("--dnfplugin", action="append", default=[], dest="dnfplugins",
                           help="Enable a DNF plugin by name/glob, or * to enable all of them.")
     optional.add_argument("--squashfs-only", action="store_true",
-                          help="Ignored, provided for backward compatibility.")
+                          help="Ignored. Use --rootfs-type instead")
     optional.add_argument("--skip-branding", action="store_true", default=False,
                           help="Disable automatic branding package selection. Use --installpkgs to add custom branding.")
-    optional.add_argument("--rootfs-type", metavar="ROOTFSTYPE", default="squashfs",
+    optional.add_argument("--rootfs-type", metavar="ROOTFSTYPE", default="erofs",
                           dest="rootfs_type",
                           help="Type of rootfs: %s" % ",".join(ROOTFSTYPES))
 
@@ -328,8 +328,8 @@ def lmc_parser(dracut_default=""):
                         help="substituted for @VERSION@ in bootloader config files")
     parser.add_argument("--volid", default=None, help="volume id")
     parser.add_argument("--squashfs-only", action="store_true",
-                          help="Ignored, provided for backward compatibility.")
-    parser.add_argument("--rootfs-type", metavar="ROOTFSTYPE", default="squashfs",
+                        help="Ignored. Use --rootfs-type instead")
+    parser.add_argument("--rootfs-type", metavar="ROOTFSTYPE", default="erofs",
                         help="Type of rootfs: %s" % ",".join(ROOTFSTYPES))
     parser.add_argument("--timeout", default=None, type=int,
                         help="Cancel installer after X minutes")

--- a/src/sbin/livemedia-creator
+++ b/src/sbin/livemedia-creator
@@ -36,6 +36,18 @@ def main():
     parser = lmc_parser(DRACUT_DEFAULT)
     opts = parser.parse_args()
 
+    if opts.squashfs_only and opts.rootfs_type != "squashfs":
+        parser.error("--squashfs-only conflicts with --rootfs-type")
+
+    # Check for required rootfs tools
+    if opts.rootfs_type.startswith("squashfs") \
+       and not os.path.exists("/usr/sbin/mksquashfs"):
+        parser.error(f"--rootfs-type={opts.rootfs_type} requires squashfs-tools to be installed.")
+
+    if opts.rootfs_type.startswith("erofs") \
+       and not os.path.exists("/usr/bin/mkfs.erofs"):
+        parser.error(f"--rootfs-type={opts.rootfs_type} requires erofs-utils to be installed.")
+
     setup_logging(opts.logfile, log)
 
     log.debug( opts )

--- a/src/sbin/lorax
+++ b/src/sbin/lorax
@@ -119,6 +119,18 @@ def main():
     if opts.rootfs_type not in ROOTFSTYPES:
         parser.error("--rootfs-type must be one of %s" % ",".join(ROOTFSTYPES))
 
+    if opts.squashfs_only and opts.rootfs_type != "squashfs":
+        parser.error("--squashfs-only conflicts with --rootfs-type")
+
+    # Check for required rootfs tools
+    if opts.rootfs_type.startswith("squashfs") \
+       and not os.path.exists("/usr/sbin/mksquashfs"):
+        parser.error(f"--rootfs-type={opts.rootfs_type} requires squashfs-tools to be installed.")
+
+    if opts.rootfs_type.startswith("erofs") \
+       and not os.path.exists("/usr/bin/mkfs.erofs"):
+        parser.error(f"--rootfs-type={opts.rootfs_type} requires erofs-utils to be installed.")
+
     setup_logging(opts)
     log.debug(opts)
 


### PR DESCRIPTION
This switches the default to erofs, makes squashfs-tools a Recommends (need to find out if that is ok to do with an unsupported package), and checks for the required tools early so you don't waste time if they aren't installed.