### PR TITLE
runtime-cleanup: Leave stat binary

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -127,7 +127,7 @@ removefrom coreutils /usr/bin/pathchk
 removefrom coreutils /usr/bin/pinky /usr/bin/pr /usr/bin/printenv
 removefrom coreutils /usr/bin/printf /usr/bin/ptx /usr/bin/runcon
 removefrom coreutils /usr/bin/sha224sum /usr/bin/sha384sum
-removefrom coreutils /usr/bin/sha512sum /usr/bin/shuf /usr/bin/stat
+removefrom coreutils /usr/bin/sha512sum /usr/bin/shuf
 removefrom coreutils /usr/bin/sum /usr/bin/test
 removefrom coreutils /usr/bin/timeout /usr/bin/truncate /usr/bin/tsort
 removefrom coreutils /usr/bin/unexpand /usr/bin/users /usr/bin/vdir


### PR DESCRIPTION
This will be needed by dnsconfd when it is added by Anaconda.
