### PR TITLE
runtime-postinstall: Remove systemd-gpt-auto-generator

### DIFF
--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -43,6 +43,7 @@ remove usr/lib/systemd/system/rngd.service
 
 ## remove because it cannot be disabled
 remove usr/lib/systemd/system-generators/lvm2-activation-generator
+remove usr/lib/systemd/system-generators/systemd-gpt-auto-generator
 
 ## Remove the more terrible parts of systemd-tmpfiles.
 ## etc.conf is written with the assumption that /etc/ is empty, which is


### PR DESCRIPTION
In some circumstances this causes a timeout when booting the installer iso. I have been able to reproduce it with a UEFI Secure Boot qemu test using the iso as -hda instead of -cdrom.

It is not needed for the installer environment so just remove the generator file. Note: This has no effect on the installed system.

Resolves: rhbz#2350605

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
