### PR TITLE
livemedia-creator: Set 0755 permission on / cpio overlay

### DIFF
--- a/src/pylorax/installer.py
+++ b/src/pylorax/installer.py
@@ -115,6 +115,9 @@ def append_initrd(initrd, files):
     qemu_initrd = tempfile.mktemp(prefix="lmc-initrd-", suffix=".img")
     shutil.copy2(initrd, qemu_initrd)
     ks_dir = tempfile.mkdtemp(prefix="lmc-ksdir-")
+    # Make sure / of the cpio overlay has correct permissions. It is 0700 otherwise and
+    # will cause problems with non-root services running in dracut, like dbus.
+    os.chmod(ks_dir, 0o755)
     for ks in files:
         shutil.copy2(ks, ks_dir)
     ks_initrd = tempfile.mktemp(prefix="lmc-ks-", suffix=".img")


### PR DESCRIPTION
livemedia-creator uses a cpio overlay on top of the inird to pass in the kickstart when using virt to do the installation. When doing this the default / permissions end up being 0700 can result in problems for services running as non-root, eg. dbus, causing the install to hang.

Setting the permission of the overlay / directory to 0755 fixes this.

Thanks to jstodola for the debugging and fix of this.

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
