### PR TITLE
mkksiso: Fix rebuilding the efiboot.img on some systems

### DIFF
--- a/src/bin/mkksiso
+++ b/src/bin/mkksiso
@@ -242,8 +242,8 @@ def RebuildEFIBoot(input_iso, tmpdir):
 
     returns new efiboot.img file with a temporary name.
     """
-    if not os.path.exists(tmpdir+"/EFI/BOOT/BOOT.conf"):
-        raise RuntimeError("Missing mkefiboot requirement: EFI/BOOT/BOOT.conf")
+    if not os.path.exists(tmpdir+"/EFI/BOOT"):
+        raise RuntimeError("Missing mkefiboot requirement: EFI/BOOT")
 
     # Extract the EFI directory files from the iso
     with tempfile.TemporaryDirectory(prefix="mkksiso-") as tmpefi:
@@ -489,9 +489,9 @@ def MakeKickstartISO(input_iso, output_iso, ks="", updates_image="", add_paths=N
         if os.uname().machine.startswith("s390"):
             RebuildS390CDBoot(tmpdir)
 
-        # If this is a UEFI iso rebuild the efiboot.img file and put it in /efiboot.img
+        # If this is a UEFI iso, rebuild the efiboot.img file and put it in /efiboot.img
         efibootimg = None
-        if not skip_efi and "EFI/BOOT/BOOT.conf" in files:
+        if not skip_efi and ("EFI/BOOT/grub.cfg" in files or "EFI/BOOT/BOOT.conf" in files):
             if os.getuid() != 0:
                 raise RuntimeError("mkefiboot requires root privileges")
 


### PR DESCRIPTION
Check for BOOT.conf or grub.cfg in /EFI/BOOT, and only raise an error in RebuildEFIBoot if the directory is missing.

Resolves: RHEL-83202

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
