### PR TITLE
spec: update lorax-lmc-virt dependencies

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -92,19 +92,29 @@ Requires: lorax = %{version}-%{release}
 %description docs
 Includes the full html documentation for lorax, livemedia-creator, and the pylorax library.
 
+%if ! (0%{?rhel} >= 10 && "%{_arch}" == "ppc64le")
 %package lmc-virt
 Summary:  livemedia-creator libvirt dependencies
 Requires: lorax = %{version}-%{release}
+%if 0%{?rhel}
+# RHEL doesn't have qemu, just qemu-kvm
+Requires: qemu-kvm
+%else
 Requires: qemu
+Recommends: qemu-kvm
+%endif
 
-# Fedora edk2 builds currently only support these arches
-%ifarch x86_64 aarch64
+# edk2 builds currently only support these arches
+%ifarch x86_64
 Requires: edk2-ovmf
 %endif
-Recommends: qemu-kvm
+%ifarch aarch64
+Requires: edk2-aarch64
+%endif
 
 %description lmc-virt
 Additional dependencies required by livemedia-creator when using it with qemu.
+%endif
 
 %package lmc-novirt
 Summary:  livemedia-creator no-virt dependencies
@@ -162,7 +172,9 @@ make DESTDIR=$RPM_BUILD_ROOT mandir=%{_mandir} install
 %files docs
 %doc docs/html/*
 
+%if ! (0%{?rhel} >= 10 && "%{_arch}" == "ppc64le")
 %files lmc-virt
+%endif
 
 %files lmc-novirt
 


### PR DESCRIPTION
This syncs changes from RHEL 10 into ELN.

* Use edk2-aarch64 on aarch64
* Use qemu-kvm on RHEL, not qemu
* Disable lorax-lmc-virt on RHEL ppc64le
