### PR TITLE
dnfbase: Use load_repos instead of update_and_load_enabled_repos

### DIFF
--- a/src/pylorax/dnfbase.py
+++ b/src/pylorax/dnfbase.py
@@ -216,7 +216,8 @@ def get_dnf_base_object(installroot, sources, mirrorlists=None, repos=None,
 
     log.info("Fetching metadata...")
     try:
-        sack.update_and_load_enabled_repos(False)
+        # Only load available repos, not system repos
+        sack.load_repos(dnf5.repo.Repo.Type_AVAILABLE)
     except RuntimeError as e:
         log.error("Problem fetching metadata: %s", e)
         return None


### PR DESCRIPTION
The old function is deprecated, use load_repos directly and only load the available repos (the ones lorax has setup), not the system repos.

Fixes #1464

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
