### PR TITLE
runtime-postinstall: Remove root password

### DIFF
--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -97,7 +97,7 @@ append etc/shadow "install::14438:0:99999:7:::"
 append etc/passwd "install-user:x:1001:1001::/tmp/install-user:/usr/bin/bash"
 append etc/shadow "install-user::14438:0:99999:7:::"
 ## remove root password
-replace "root:\*:" "root::" etc/shadow
+replace "root:.*?:" "root::" etc/shadow
 
 ## gsettings settings
 install ${configdir}/org.gtk.Settings.Debug.gschema.override usr/share/glib-2.0/schemas

--- a/tests/pylorax/templates/replace-cmd.tmpl
+++ b/tests/pylorax/templates/replace-cmd.tmpl
@@ -1,3 +1,15 @@
 <%page />
 append /etc/lorax-replace "Running @VERSION@ for lorax"
 replace @VERSION@ 1.2.3 /etc/lorax-replace
+
+# Test 4 different ways to lock root account
+append /etc/lorax-shadow-1 "root:!::0:99999:7:::"
+append /etc/lorax-shadow-2 "root:*::0:99999:7:::"
+append /etc/lorax-shadow-3 "root:!*::0:99999:7:::"
+append /etc/lorax-shadow-4 "root:!unprovisioned::0:99999:7:::"
+
+# All of these should end up the same
+replace "root:.*?:" "root::" /etc/lorax-shadow-1
+replace "root:.*?:" "root::" /etc/lorax-shadow-2
+replace "root:.*?:" "root::" /etc/lorax-shadow-3
+replace "root:.*?:" "root::" /etc/lorax-shadow-4

--- a/tests/pylorax/test_ltmpl.py
+++ b/tests/pylorax/test_ltmpl.py
@@ -284,6 +284,14 @@ class LoraxTemplateRunnerTestCase(unittest.TestCase):
             data = f.read()
         self.assertEqual(data, "Running 1.2.3 for lorax\n")
 
+        # Check that replace on all 4 variations of a locked root result in an account with
+        # no password
+        for path in ["/etc/lorax-shadow-1", "/etc/lorax-shadow-2", "/etc/lorax-shadow-3",
+                     "/etc/lorax-shadow-1"]:
+            with open(joinpaths(self.root_dir, path)) as f:
+                data = f.read()
+            self.assertEqual(data, "root:::0:99999:7:::\n")
+
     def test_treeinfo(self):
         """Test treeinfo template command"""
         self.runner.run("treeinfo-cmd.tmpl")


### PR DESCRIPTION
The setup package has recently (setup-2.15.0-23) started generating the /etc/shadow content instead of using it as the input. This has changed how system accounts are locked in a default install (root ends up being !unprovisioned and others use !*).

The replace command in runtime-postinstall.tmpl would not remove the root password in recent builds, leading to inst.sshd not working because root required a password that didn't exist.

This also expands the replace command tests to check for other possible ways to lock the root account and confirm they all result in an account with no password.

Resolves: rhbz#2364082

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
