### PR TITLE
runtime-cleanup: Move rpm database cleanup to the end

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -68,7 +68,6 @@ remove /usr/share/mime/multipart /usr/share/mime/packages /usr/share/mime/text
 remove /usr/share/mime/video /usr/share/mime/x-content /usr/share/mime/x-epoc
 remove /var/db /var/games /var/tmp /var/yp /var/nis /var/opt /var/local
 remove /var/mail /var/spool /var/preserve /var/report
-remove /usr/lib/sysimage/rpm/* /var/lib/rpm/* /var/lib/yum /var/lib/dnf
 ## clean up the files created by various '> /dev/null's
 remove /dev/*
 
@@ -378,6 +377,10 @@ remove /var/lib/systemd/catalog/database
 ## non-reproducible caches
 remove /var/cache/ldconfig/aux-cache
 remove /etc/pki/ca-trust/extracted/java/cacerts
+
+# Remove the rpm database
+# NOTE: must run after all removepkg, removefrom, and removekmod commands
+remove /usr/lib/sysimage/rpm/* /var/lib/rpm/* /var/lib/yum /var/lib/dnf
 
 ## sort groups
 runcmd chroot ${root} /bin/sh -c "LC_ALL=C sort /etc/group > /etc/group- && mv /etc/group- /etc/group"


### PR DESCRIPTION
Other tools can use the Lorax templates, eg. osbuild-composer, and they may depend on the rpm database remaining intact until the script is finished with all the removepkg, removefrom, and removekmod commands.

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
