### PR TITLE
fix rootfs path in .bash_history and profile

### DIFF
--- a/share/templates.d/99-generic/config_files/common/bash_history
+++ b/share/templates.d/99-generic/config_files/common/bash_history
@@ -6,6 +6,6 @@ tail -f /tmp/storage.log
 echo b > /proc/sysrq-trigger
 dmsetup table
 multipath -d
-HOME=/root chroot /mnt/sysimage bash -l -i
+HOME=/root chroot /mnt/sysroot bash -l -i
 less /tmp/anaconda.log
 grep -v _yum_lock /tmp/packaging.log

--- a/share/templates.d/99-generic/config_files/common/profile
+++ b/share/templates.d/99-generic/config_files/common/profile
@@ -1,3 +1,3 @@
 PS1="[anaconda \u@\h \W]\\$ "
-PATH=/usr/bin:/mnt/sysimage/usr/bin
+PATH=/usr/bin:/mnt/sysroot/usr/bin
 export PATH PS1


### PR DESCRIPTION
- For rpm-ostree systems, `/` is mounted to `/mnt/sysroot` instead, which is not the same as `/mnt/sysimage`.
- For usual systems, `/mnt/sysroot` is attached to the same file system as `/mnt/sysimage`, so it's indifferent.

So only `/mnt/sysroot` path suits for the both systems.

chroot to `/mnt/sysimage` on rpm-ostree systems produces an error:
```console
# HOME=/root chroot /mnt/sysimage bash -l -i
chroot: failed to run command ‘bash’: No such file or directory
```
More details:
https://github.com/rhinstaller/anaconda/blob/main/docs/developer/mount-points.rst

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
