### PR TITLE
config_files: Do not remove `chcon` in runtime cleanup

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -115,7 +115,7 @@ removefrom bind-utils /usr/bin/host /usr/bin/nsupdate
 removefrom ca-certificates /etc/pki/java/*
 removefrom ca-certificates /etc/pki/tls/certs/ca-bundle.trust.crt
 removefrom coreutils /usr/bin/link /usr/bin/nice /usr/bin/stty /usr/bin/unlink
-removefrom coreutils /usr/bin/[ /usr/bin/base64 /usr/bin/chcon
+removefrom coreutils /usr/bin/[ /usr/bin/base64
 removefrom coreutils /usr/bin/cksum /usr/bin/csplit
 removefrom coreutils /usr/bin/dir /usr/bin/dircolors
 removefrom coreutils /usr/bin/expand /usr/bin/factor


### PR DESCRIPTION
chcon is being used by the bootc and recently added to bootc.spec file as an explicite requirement: https://github.com/bootc-dev/bootc/pull/1391 When it is not presented in the system the result is failure of the `bootc install to-filesystem` command used by Anaconda installer.

