### PR TITLE
treebuilder: use fedora-eln-logos for ELN

### DIFF
--- a/src/pylorax/treebuilder.py
+++ b/src/pylorax/treebuilder.py
@@ -133,7 +133,10 @@ class RuntimeBuilder(object):
         logger.info('got release: %s', release)
 
         # logos uses the basename from release (fedora, redhat, centos, ...)
-        logos, _suffix = release.split('-', 1)
+        if release == 'fedora-release-eln':
+            logos = 'fedora-eln'
+        else:
+            logos, _suffix = release.split('-', 1)
         return DataHolder(release=release, logos=logos+"-logos")
 
     def install(self):


### PR DESCRIPTION
ELN now has its own logos package to make it visually distinct from mainline Fedora.  Because its release package is named as a variant of Fedora rather than a distinct distribution, this requires special handling.