### PR TITLE
postinstall: Setup /var/tmp as tmpfs

### DIFF
--- a/share/templates.d/99-generic/config_files/common/var-tmp.mount
+++ b/share/templates.d/99-generic/config_files/common/var-tmp.mount
@@ -1,0 +1,25 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Temporary Directory /var/tmp
+Documentation=https://systemd.io/TEMPORARY_DIRECTORIES
+Documentation=man:file-hierarchy(7)
+Documentation=https://systemd.io/API_FILE_SYSTEMS
+ConditionPathIsSymbolicLink=!/var/tmp
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=swap.target
+
+[Mount]
+What=tmpfs
+Where=/var/tmp
+Type=tmpfs
+Options=mode=1777,strictatime,nosuid,nodev,size=50%%,nr_inodes=1m

--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -29,9 +29,13 @@ install ${configdir}/systemd-allowroot.conf etc/systemd/user/pipewire.service.d/
 mkdir etc/systemd/user/pipewire.socket.d/
 install ${configdir}/systemd-allowroot.conf etc/systemd/user/pipewire.socket.d/allowroot.conf
 
-## Make sure tmpfs is enabled
+## Make sure tmpfs on /tmp and /var/tmp is enabled
 mkdir etc/systemd/system/local-fs.target.wants/
 symlink /lib/systemd/system/tmp.mount etc/systemd/system/local-fs.target.wants/tmp.mount
+install ${configdir}/var-tmp.mount etc/systemd/system/var-tmp.mount
+symlink /etc/systemd/system/var-tmp.mount etc/systemd/system/local-fs.target.wants/var-tmp.mount
+
+
 
 ## Disable unwanted systemd services
 systemctl disable systemd-readahead-collect.service \


### PR DESCRIPTION
In some cases /var/tmp is too small for the ostreecontainer kickstart install method. Switch to using tmpfs so that it will be able to take advantage of larger amounts of ram if it is available.