### PR TITLE
runtime-cleanup: don't strip avahi-libs

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -361,7 +361,7 @@ removefrom gstreamer1-plugins-base --allbut \
 removepkg geoclue2
 
 ## And remove the packages that those extra libraries pulled in
-removepkg cdparanoia-libs libvisual avahi-glib avahi-libs ModemManager-glib
+removepkg cdparanoia-libs libvisual avahi-glib ModemManager-glib
 
 ## Remove build-id links, they are used with debuginfo
 remove /usr/lib/.build-id


### PR DESCRIPTION
Since https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/8522 (GTK 4.19.2), GTK-based apps will not start if it's missing.