### PR TITLE
Makefile: Separate install and all targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ src/pylorax/version.py: lorax.spec
 all: src/pylorax/version.py
 	$(PYTHON) -m build --no-isolation
 
-install: all
+install: src/pylorax/version.py
 	$(PYTHON) -m pip install --no-build-isolation --root=$(DESTDIR) --prefix=$(PREFIX) .
 	mkdir -p $(DESTDIR)/$(mandir)/man1
 	install -m 644 docs/man/*.1 $(DESTDIR)/$(mandir)/man1

--- a/lorax.spec
+++ b/lorax.spec
@@ -14,7 +14,6 @@ License:        GPL-2.0-or-later
 Url:            %{forgeurl}
 Source0:        %{forgesource}
 
-BuildRequires:  python3-build
 BuildRequires:  python3-devel
 BuildRequires:  python3-pip
 BuildRequires:  python3-setuptools


### PR DESCRIPTION
And remove python3-build from lorax.spec -- with this change it is only needed for building the release artifacts, not for building the rpm.

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
