### PR TITLE
templates: Remove explicit installation of anaconda-widgets

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -7,7 +7,7 @@ GRUB2VER="1:2.06-67"
 %>
 
 ## anaconda package
-installpkg anaconda anaconda-widgets
+installpkg anaconda
 ## work around dnf5 bug - https://github.com/rpm-software-management/dnf5/issues/1111
 installpkg anaconda-install-img-deps>=40.15
 ## Other available payloads


### PR DESCRIPTION
anaconda-widgets is a dependency of anaconda-gui and does not need to be listed separately.