### PR TITLE
templates: Synchronize with lorax-templates-rhel

### DIFF
--- a/share/templates.d/99-generic/appliance/libvirt.tmpl
+++ b/share/templates.d/99-generic/appliance/libvirt.tmpl
@@ -9,7 +9,7 @@
       <os>
         <loader dev='hd'/>
       </os>
-%for disk, letter in zip(disks, range(97, 123)):
+%for disk, letter in zip(disks, xrange(97, 123)):
       <drive disk='${disk.name}' target='hd${chr(letter)}'/>
 %endfor
     </boot>

--- a/share/templates.d/99-generic/arm.tmpl
+++ b/share/templates.d/99-generic/arm.tmpl
@@ -1,4 +1,4 @@
-<%page args="kernels, runtime_img, runtime_base, basearch, inroot, outroot, arch"/>
+<%page args="kernels, runtime_img, runtime_base, basearch, outroot, arch"/>
 <%
 configdir="tmp/config_files/uboot"
 PXEBOOTDIR="images/pxeboot"
@@ -12,15 +12,7 @@ LORAXDIR="usr/share/lorax/"
 platforms = ""
 delimiter = ''
 
-import os
 from os.path import basename
-from pylorax.sysutils import joinpaths
-
-# Test the runtime_img, if it is > 4GiB we need to set -iso-level to 3
-if os.stat(joinpaths(inroot, runtime_img)).st_size >= 4*1024**3:
-    isoargs = "-iso-level 3"
-else:
-    isoargs = ""
 %>
 
 mkdir images
@@ -46,58 +38,21 @@ mkdir ${KERNELDIR}
     %endif
 %endfor
 
-<% efiargs=""; efigraft="" %>
-%if exists("boot/efi/EFI/*/gcdaa64.efi"):
-    <%
-    efiarch32 = ARM
-    efiarch64 = None
-    efigraft="EFI/BOOT={0}/EFI/BOOT".format(outroot)
-    images = ["images/efiboot.img"]
-    %>
-    %for img in images:
-        <%
-        efiargs += " -eltorito-alt-boot -e {0} -no-emul-boot".format(img)
-        efigraft += " {0}={1}/{0}".format(img,outroot)
-        %>
-        treeinfo images-${basearch} ${img|basename} ${img}
-    %endfor
-    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch32=efiarch32, efiarch64=efiarch64, isolabel=isolabel"/>
-%endif
-
 # add platform to treeinfo for Beaker support
 treeinfo ${basearch} platforms ${platforms}
 
 # Create optional product.img and updates.img
-<% filegraft=""; images=["product", "updates"] %>
+<% images=["product", "updates"] %>
 %for img in images:
     %if exists("%s/%s/" % (LORAXDIR, img)):
         installimg --xz -9 --memlimit-compress=3700MiB ${LORAXDIR}/${img}/ images/${img}.img
         treeinfo images-${basearch} ${img}.img images/${img}.img
-        <% filegraft += " images/{0}.img={1}/images/{0}.img".format(img, outroot) %>
     %endif
 %endfor
 
-# Inherit iso-graft/ if it exists from external templates
-<%
-    import os
-    if os.path.exists(workdir + "/iso-graft"):
-        filegraft += " " + workdir + "/iso-graft"
-%>
-
 # Add the license files
-%for f in glob("usr/share/licenses/*-release-common/*"):
+%for f in glob("/usr/share/licenses/*-release/*"):
     install ${f} ${f|basename}
-    <% filegraft += " {0}={1}/{0}".format(basename(f), outroot) %>
 %endfor
 
-%if exists("boot/efi/EFI/*/gcdarm.efi"):
-## make boot.iso
-runcmd xorrisofs ${isoargs} -o ${outroot}/images/boot.iso \
-       ${efiargs} -R -J -V '${isolabel}' \
-       -graft-points \
-       .discinfo=${outroot}/.discinfo \
-       ${KERNELDIR}=${outroot}/${KERNELDIR} \
-       ${STAGE2IMG}=${outroot}/${STAGE2IMG} \
-       ${efigraft} ${filegraft}
-treeinfo images-${basearch} boot.iso images/boot.iso
-%endif
+## FIXME: ARM may need some extra boot config

--- a/share/templates.d/99-generic/live/live-install.tmpl
+++ b/share/templates.d/99-generic/live/live-install.tmpl
@@ -20,7 +20,7 @@
     installpkg biosdevname memtest86+ syslinux
     installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
 %endif
-%if basearch == "ppc64le":
+%if basearch in ("ppc64le"):
     installpkg powerpc-utils
     installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
     installpkg grub2-${basearch}


### PR DESCRIPTION
Resolves: RHEL-54712

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
