### PR TITLE
tests: Add some unicode to the executils tests

### DIFF
--- a/src/pylorax/__init__.py
+++ b/src/pylorax/__init__.py
@@ -205,7 +205,7 @@ class Lorax(BaseLoraxClass):
         logger.addHandler(sh)
 
     def init_file_logging(self, logdir, logname="pylorax.log"):
-        fh = logging.FileHandler(filename=joinpaths(logdir, logname), mode="w")
+        fh = logging.FileHandler(filename=joinpaths(logdir, logname), mode="w", encoding="UTF-8")
         fh.setLevel(logging.DEBUG)
         logger.addHandler(fh)
 
@@ -476,7 +476,7 @@ def setup_logging(logfile, theLogger):
     logger.addHandler(sh)
     theLogger.addHandler(sh)
 
-    fh = logging.FileHandler(filename=logfile, mode="w")
+    fh = logging.FileHandler(filename=logfile, mode="w", encoding="UTF-8")
     fh.setLevel(logging.DEBUG)
     fmt = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
     fh.setFormatter(fmt)
@@ -486,7 +486,7 @@ def setup_logging(logfile, theLogger):
     # External program output log
     program_log.setLevel(logging.DEBUG)
     f = os.path.abspath(os.path.dirname(logfile))+"/program.log"
-    fh = logging.FileHandler(filename=f, mode="w")
+    fh = logging.FileHandler(filename=f, mode="w", encoding="UTF-8")
     fh.setLevel(logging.DEBUG)
     fmt = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
     fh.setFormatter(fmt)

--- a/src/pylorax/executils.py
+++ b/src/pylorax/executils.py
@@ -155,6 +155,7 @@ def _run_program(argv, root='/', stdin=None, stdout=None, env_prune=None, log_ou
 
         proc = startProgram(argv, root=root, stdin=stdin, stdout=subprocess.PIPE, stderr=stderr,
                             env_prune=env_prune, universal_newlines=not binary_output,
+                            encoding="UTF-8",
                             env_add=env_add, reset_handlers=reset_handlers, reset_lang=reset_lang)
 
         output_string = None

--- a/tests/pylorax/templates/runcmd-unicode.tmpl
+++ b/tests/pylorax/templates/runcmd-unicode.tmpl
@@ -1,0 +1,2 @@
+<%page args="root" />
+runcmd python3 -c "import sys; print('Truffula trees.\nGürzenichstraße'); sys.exit(0)"

--- a/tests/pylorax/test_executils.py
+++ b/tests/pylorax/test_executils.py
@@ -61,14 +61,14 @@ class ExecUtilsTest(unittest.TestCase):
         program_log.addHandler(fh)
 
         try:
-            cmd = ["python3", "-c", "import sys; print('The Once-ler was here.'); sys.exit(1)"]
+            cmd = ["python3", "-c", "import sys; print('The Once-ler was here. Gürzenichstraße'); sys.exit(1)"]
             rc = execWithRedirect(cmd[0], cmd[1:])
             self.assertEqual(rc, 1)
 
             fh.close()
             with open(tmp_f.name, "r") as f:
                 logged_text = f.readlines()[-1].strip()
-            self.assertEqual(logged_text, "The Once-ler was here.")
+            self.assertEqual(logged_text, "The Once-ler was here. Gürzenichstraße")
         finally:
             os.unlink(tmp_f.name)
             program_log.removeHandler(fh)
@@ -77,6 +77,11 @@ class ExecUtilsTest(unittest.TestCase):
         cmd = ["python3", "-c", "import sys; print('Truffula trees.', end=''); sys.exit(0)"]
         stdout = execWithCapture(cmd[0], cmd[1:], callback=lambda p: True)
         self.assertEqual(stdout.strip(), "Truffula trees.")
+
+    def test_execWithCapture_unicode(self):
+        cmd = ["python3", "-c", "import sys; print('Truffula trees. Gürzenichstraße', end=''); sys.exit(0)"]
+        stdout = execWithCapture(cmd[0], cmd[1:], callback=lambda p: True)
+        self.assertEqual(stdout.strip(), "Truffula trees. Gürzenichstraße")
 
     def test_returncode(self):
         cmd = ["python3", "-c", "import sys; print('Truffula trees.'); sys.exit(1)"]
@@ -89,9 +94,14 @@ class ExecUtilsTest(unittest.TestCase):
         self.assertEqual(stdout.strip(), "")
 
     def test_execReadlines(self):
-        cmd = ["python3", "-c", "import sys; print('Truffula trees.'); sys.exit(0)"]
+        cmd = ["python3", "-c", r"import sys; print('Truffula trees.\nEveryone needs Thneeds'); sys.exit(0)"]
         iterator = execReadlines(cmd[0], cmd[1:], callback=lambda p: True, filter_stderr=True)
-        self.assertEqual(list(iterator), ["Truffula trees."])
+        self.assertEqual(list(iterator), ["Truffula trees.", "Everyone needs Thneeds"])
+
+    def test_execReadlines_unicode(self):
+        cmd = ["python3", "-c", r"import sys; print('Truffula trees.\nGürzenichstraße'); sys.exit(0)"]
+        iterator = execReadlines(cmd[0], cmd[1:], callback=lambda p: True, filter_stderr=True)
+        self.assertEqual(list(iterator), ["Truffula trees.", "Gürzenichstraße"])
 
     def test_execReadlines_error(self):
         with self.assertRaises(OSError):
@@ -106,6 +116,11 @@ class ExecUtilsTest(unittest.TestCase):
         cmd = ["python3", "-c", "import sys; print('Everyone needs Thneeds'); sys.exit(0)"]
         stdout = runcmd_output(cmd)
         self.assertEqual(stdout.strip(), "Everyone needs Thneeds")
+
+    def test_runcmd_output_unicode(self):
+        cmd = ["python3", "-c", "import sys; print('Gürzenichstraße'); sys.exit(0)"]
+        stdout = runcmd_output(cmd)
+        self.assertEqual(stdout.strip(), "Gürzenichstraße")
 
     def test_chroot(self):
         """Test the preexec function"""

--- a/tests/pylorax/test_executils.py
+++ b/tests/pylorax/test_executils.py
@@ -57,7 +57,7 @@ class ExecUtilsTest(unittest.TestCase):
         program_log.setLevel(logging.INFO)
 
         tmp_f = tempfile.NamedTemporaryFile(prefix="lorax.test.log.", delete=False)
-        fh = logging.FileHandler(filename=tmp_f.name, mode="w")
+        fh = logging.FileHandler(filename=tmp_f.name, mode="w", encoding="UTF-8")
         program_log.addHandler(fh)
 
         try:
@@ -66,7 +66,7 @@ class ExecUtilsTest(unittest.TestCase):
             self.assertEqual(rc, 1)
 
             fh.close()
-            with open(tmp_f.name, "r") as f:
+            with open(tmp_f.name, "r", encoding="UTF-8") as f:
                 logged_text = f.readlines()[-1].strip()
             self.assertEqual(logged_text, "The Once-ler was here. Gürzenichstraße")
         finally:

--- a/tests/pylorax/test_ltmpl.py
+++ b/tests/pylorax/test_ltmpl.py
@@ -352,6 +352,10 @@ class LoraxTemplateRunnerTestCase(unittest.TestCase):
         self.runner.run("runcmd-cmd.tmpl", root=self.root_dir)
         self.assertTrue(os.path.exists(joinpaths(self.root_dir, "/lorax-runcmd")))
 
+    def test_runcmd_unicode(self):
+        """Test runcmd template command with unicode output"""
+        self.runner.run("runcmd-unicode.tmpl", root=self.root_dir)
+
     def test_removekmod(self):
         """Test removekmod template command"""
         self.runner.run("removekmod-cmd.tmpl")


### PR DESCRIPTION
Trying to debug what is going on with this report of unicode output causing runcmd to crash:

https://bodhi.fedoraproject.org/updates/FEDORA-2025-eb260cb695

Simply adding unicode to the output doesn't cause an error.

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
