### PR TITLE
support product version to contain blank character in templates.d/99-generic

### DIFF
--- a/share/templates.d/99-generic/efi.tmpl
+++ b/share/templates.d/99-generic/efi.tmpl
@@ -36,7 +36,7 @@ ${make_efiboot("images/efiboot.img")}
     %endif
     install ${configdir}/grub2-efi.cfg ${eficonf}
     replace @PRODUCT@ '${product.name}' ${eficonf}
-    replace @VERSION@ ${product.version} ${eficonf}
+    replace @VERSION@ '${product.version}' ${eficonf}
     replace @KERNELNAME@ vmlinuz ${eficonf}
     replace @KERNELPATH@ /${kdir}/vmlinuz ${eficonf}
     replace @INITRDPATH@ /${kdir}/initrd.img ${eficonf}

--- a/share/templates.d/99-generic/live/efi.tmpl
+++ b/share/templates.d/99-generic/live/efi.tmpl
@@ -36,7 +36,7 @@ ${make_efiboot("images/efiboot.img")}
     %endif
     install ${configdir}/grub2-efi.cfg ${eficonf}
     replace @PRODUCT@ '${product.name}' ${eficonf}
-    replace @VERSION@ ${product.version} ${eficonf}
+    replace @VERSION@ '${product.version}' ${eficonf}
     replace @KERNELNAME@ vmlinuz ${eficonf}
     replace @KERNELPATH@ /${kdir}/vmlinuz ${eficonf}
     replace @INITRDPATH@ /${kdir}/initrd.img ${eficonf}

--- a/share/templates.d/99-generic/live/ppc64le.tmpl
+++ b/share/templates.d/99-generic/live/ppc64le.tmpl
@@ -42,7 +42,7 @@ install /usr/lib/grub/powerpc-ieee1275/*.lst ${GRUBDIR}/powerpc-ieee1275
 
 install ${configdir}/grub.cfg.in     ${GRUBDIR}/grub.cfg
 replace @PRODUCT@ '${product.name}'  ${GRUBDIR}/grub.cfg
-replace @VERSION@ ${product.version} ${GRUBDIR}/grub.cfg
+replace @VERSION@ '${product.version}' ${GRUBDIR}/grub.cfg
 replace @ROOT@ 'root=live:CDLABEL=${isolabel|udev}' ${GRUBDIR}/grub.cfg
 replace @EXTRA@ '${extra_boot_args}' ${GRUBDIR}/grub.cfg
 

--- a/share/templates.d/99-generic/live/x86.tmpl
+++ b/share/templates.d/99-generic/live/x86.tmpl
@@ -48,7 +48,7 @@ mkdir ${KERNELDIR}
 ## configure grub2 config file
 mkdir ${GRUB2DIR}
 install ${configdir}/grub2-bios.cfg ${GRUB2DIR}/grub.cfg
-replace @VERSION@ ${product.version} ${GRUB2DIR}/grub.cfg
+replace @VERSION@ '${product.version}' ${GRUB2DIR}/grub.cfg
 replace @PRODUCT@ '${product.name}'  ${GRUB2DIR}/grub.cfg
 replace @KERNELPATH@ /${KERNELDIR}/vmlinuz ${GRUB2DIR}/grub.cfg
 replace @INITRDPATH@ /${KERNELDIR}/initrd.img ${GRUB2DIR}/grub.cfg

--- a/share/templates.d/99-generic/ppc64le.tmpl
+++ b/share/templates.d/99-generic/ppc64le.tmpl
@@ -42,7 +42,7 @@ install /usr/lib/grub/powerpc-ieee1275/*.lst ${GRUBDIR}/powerpc-ieee1275
 
 install ${configdir}/grub.cfg.in     ${GRUBDIR}/grub.cfg
 replace @PRODUCT@ '${product.name}'  ${GRUBDIR}/grub.cfg
-replace @VERSION@ ${product.version} ${GRUBDIR}/grub.cfg
+replace @VERSION@ '${product.version}' ${GRUBDIR}/grub.cfg
 replace @ROOT@ 'inst.stage2=hd:LABEL=${isolabel|udev}' ${GRUBDIR}/grub.cfg
 
 ## Install kernel and bootloader config (in separate places for each arch)

--- a/share/templates.d/99-generic/x86.tmpl
+++ b/share/templates.d/99-generic/x86.tmpl
@@ -43,7 +43,7 @@ mkdir ${KERNELDIR}
 ## configure grub2 config file
 mkdir ${GRUB2DIR}
 install ${configdir}/grub2-bios.cfg ${GRUB2DIR}/grub.cfg
-replace @VERSION@ ${product.version} ${GRUB2DIR}/grub.cfg
+replace @VERSION@ '${product.version}' ${GRUB2DIR}/grub.cfg
 replace @PRODUCT@ '${product.name}'  ${GRUB2DIR}/grub.cfg
 replace @KERNELPATH@ /${KERNELDIR}/vmlinuz ${GRUB2DIR}/grub.cfg
 replace @INITRDPATH@ /${KERNELDIR}/initrd.img ${GRUB2DIR}/grub.cfg

--- a/tests/pylorax/templates/replace-cmd.tmpl
+++ b/tests/pylorax/templates/replace-cmd.tmpl
@@ -1,6 +1,8 @@
 <%page />
-append /etc/lorax-replace "Running @VERSION@ for lorax"
-replace @VERSION@ 1.2.3 /etc/lorax-replace
+append /etc/lorax-replace-1 "Running @VERSION@ for lorax"
+append /etc/lorax-replace-2 "Running @VERSION@ for lorax"
+replace @VERSION@ 1.2.3 /etc/lorax-replace-1
+replace @VERSION@ '1.2.3 release' /etc/lorax-replace-2
 
 # Test 4 different ways to lock root account
 append /etc/lorax-shadow-1 "root:!::0:99999:7:::"

--- a/tests/pylorax/test_ltmpl.py
+++ b/tests/pylorax/test_ltmpl.py
@@ -279,10 +279,15 @@ class LoraxTemplateRunnerTestCase(unittest.TestCase):
     def test_replace(self):
         """Test append, and replace template command"""
         self.runner.run("replace-cmd.tmpl")
-        self.assertTrue(os.path.exists(joinpaths(self.root_dir, "/etc/lorax-replace")))
-        with open(joinpaths(self.root_dir, "/etc/lorax-replace")) as f:
+        self.assertTrue(os.path.exists(joinpaths(self.root_dir, "/etc/lorax-replace-1")))
+        with open(joinpaths(self.root_dir, "/etc/lorax-replace-1")) as f:
             data = f.read()
         self.assertEqual(data, "Running 1.2.3 for lorax\n")
+
+        self.assertTrue(os.path.exists(joinpaths(self.root_dir, "/etc/lorax-replace-2")))
+        with open(joinpaths(self.root_dir, "/etc/lorax-replace-2")) as f:
+            data = f.read()
+        self.assertEqual(data, "Running 1.2.3 release for lorax\n")
 
         # Check that replace on all 4 variations of a locked root result in an account with
         # no password


### PR DESCRIPTION
When I use " lorax -v 'XX XX' ",finally grub.conf is not in accordance with expectation. So I find the ${product.version} need **'**