### PR TITLE
Drop all installs of shim-ia32 (it no longer exists)

### DIFF
--- a/docs/fedora-livemedia.ks
+++ b/docs/fedora-livemedia.ks
@@ -89,7 +89,6 @@ case $ARCH in
         echo "%packages" >> $PKGS
         echo "@^workstation-product-environment" >> $PKGS
         echo "shim" >> $PKGS
-        echo "shim-ia32" >> $PKGS
         echo "grub2" >> $PKGS
         echo "grub2-efi" >> $PKGS
         echo "grub2-efi-ia32" >> $PKGS

--- a/share/templates.d/99-generic/efi.tmpl
+++ b/share/templates.d/99-generic/efi.tmpl
@@ -13,8 +13,11 @@ install boot/efi/EFI/*/mm${efiarch64|lower}.efi ${EFIBOOTDIR}/
 install boot/efi/EFI/*/gcd${efiarch64|lower}.efi ${EFIBOOTDIR}/grub${efiarch64|lower}.efi
 %endif
 %if efiarch32:
+## shim-ia32 is gone in F44+, other ia32 bits remain for now
+%if exists("boot/efi/EFI/*/shim${efiarch32|lower}.efi"):
 install boot/efi/EFI/*/shim${efiarch32|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch32}.EFI
 install boot/efi/EFI/*/mm${efiarch32|lower}.efi ${EFIBOOTDIR}/
+%endif
 install boot/efi/EFI/*/gcd${efiarch32|lower}.efi ${EFIBOOTDIR}/grub${efiarch32|lower}.efi
 %endif
 install usr/share/grub/unicode.pf2 ${EFIBOOTDIR}/fonts/

--- a/share/templates.d/99-generic/live/efi.tmpl
+++ b/share/templates.d/99-generic/live/efi.tmpl
@@ -13,8 +13,11 @@ install boot/efi/EFI/*/mm${efiarch64|lower}.efi ${EFIBOOTDIR}/
 install boot/efi/EFI/*/gcd${efiarch64|lower}.efi ${EFIBOOTDIR}/grub${efiarch64|lower}.efi
 %endif
 %if efiarch32:
+## shim-ia32 is gone in F44+, other ia32 bits remain for now
+%if exists("boot/efi/EFI/*/shim${efiarch32|lower}.efi"):
 install boot/efi/EFI/*/shim${efiarch32|lower}.efi ${EFIBOOTDIR}/BOOT${efiarch32}.EFI
 install boot/efi/EFI/*/mm${efiarch32|lower}.efi ${EFIBOOTDIR}/
+%endif
 install boot/efi/EFI/*/gcd${efiarch32|lower}.efi ${EFIBOOTDIR}/grub${efiarch32|lower}.efi
 %endif
 install usr/share/grub/unicode.pf2 ${EFIBOOTDIR}/fonts/

--- a/share/templates.d/99-generic/live/live-install.tmpl
+++ b/share/templates.d/99-generic/live/live-install.tmpl
@@ -10,7 +10,7 @@
     installpkg grub2-tools-efi
     installpkg efibootmgr
     installpkg shim-x64 grub2-efi-x64-cdboot
-    installpkg shim-ia32 grub2-efi-ia32-cdboot
+    installpkg grub2-efi-ia32-cdboot
     installpkg biosdevname
     installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
     installpkg grub2-pc-modules

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -70,7 +70,6 @@ installpkg glibc-all-langpacks
     installpkg efibootmgr
     installpkg shim-x64
     installpkg grub2-efi-x64-cdboot>=${GRUB2VER}
-    installpkg shim-ia32
     installpkg grub2-efi-ia32-cdboot>=${GRUB2VER}
     installpkg biosdevname
     installpkg grub2-tools>=${GRUB2VER} grub2-tools-minimal>=${GRUB2VER}


### PR DESCRIPTION
There is no shim-ia32 in shim-15.8-4, which was recently tagged for f44. This is because it was built after
https://github.com/rhboot/efi-rpm-macros/commit/5c7fcc9 , so it appears to be an intentional change - @vathpela may confirm.