### PR TITLE
executils: decoding after deserialization

### DIFF
--- a/src/pylorax/executils.py
+++ b/src/pylorax/executils.py
@@ -285,7 +285,7 @@ def execReadlines(command, argv, stdin=None, root='/', env_prune=None, filter_st
             self._proc = proc
             self._argv = argv
             self._callback = callback
-            self._data = ""
+            self._data = b""
 
         def __iter__(self):
             return self
@@ -306,12 +306,12 @@ def execReadlines(command, argv, stdin=None, root='/', env_prune=None, filter_st
                 if select.select([self._proc.stdout], [], [], 0)[0]:
                     size = len(self._proc.stdout.peek(1))
                     if size > 0:
-                        self._data += self._proc.stdout.read(size).decode("utf-8")
+                        self._data += self._proc.stdout.read(size)
 
-                if self._data.find("\n") >= 0:
-                    line = self._data.split("\n", 1)
+                if self._data.find(b"\n") >= 0:
+                    line = self._data.split(b"\n", 1)
                     self._data = line[1]
-                    return line[0]
+                    return line[0].decode("utf-8")
 
                 if self._proc.poll() is not None or not self._callback(self._proc):
                     # Output finished, wait 60s for the process to end


### PR DESCRIPTION
To prevent an error like:
"ERROR livemedia-creator: 'utf-8' codec can't decode byte 0xd1 in position 4095: unexpected end of data", when using a ru-RU.UTF8 locale in kickstart file (on char with more than 1 byte size). Probably could occur on another locales as well.
It is proposed to decode already deserialized data.

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
