### PR TITLE
runtime-install: skip qcom-accel-firmware

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -48,7 +48,7 @@ installpkg grubby
                            --except mrvlprestera-firmware --except mlxsw_spectrum-firmware \
                            --except hackrf-firmware --except python-virt-firmware \
                            --except python3-virt-firmware --except crust-firmware \
-                           --except qcom-firmware \
+                           --except qcom-firmware --except qcom-accel-firmware \
                            --except amd-ucode-firmware
     installpkg b43-openfwwf
 %endif


### PR DESCRIPTION
This is "for Qualcomm Technologies data center and Open-vRAN accelerators". It's definitely not needed in the installer environment on x86_64. I'm fairly sure it's not even needed on aarch64 - I don't think that hardware needs to be working during system deployment. Let's check with Peter, though.