### PR TITLE
Add mac80211_hwsim for wifi testing to installer image

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -96,6 +96,10 @@ removekmod drivers/video --allbut hyperv_fb syscopyarea sysfillrect sysimgblt fb
 remove lib/modules/*/{build,source,*.map}
 ## NOTE: depmod gets re-run after cleanup finishes
 
+## wireless testing in guest
+## Remove all internal modules except /internal/drivers/net/wireless/virtual/mac80211_hwsim.ko.xz
+removefrom kernel-modules-internal --allbut /lib/modules/*/internal/drivers/net/wireless/virtual/mac80211_hwsim.ko.xz
+
 ## remove unused themes, theme engines, icons, etc.
 removefrom gtk3 /usr/lib64/gtk-3.0/*/printbackends/*
 removefrom gtk3 /usr/share/themes/*

--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -19,6 +19,8 @@ installpkg pigz
 ## NOTE: Without explicitly including kernel-modules-extra dnf will choose kernel-debuginfo-*
 ##       to satify a gfs2-utils kmod requirement
 installpkg kernel kernel-modules kernel-modules-extra
+## wireless testing - mac80211_hwsim
+installpkg kernel-modules-internal
 installpkg grubby
 %if basearch != "s390x":
     ## skip the firmware for sound, video, and scanners, none of which will


### PR DESCRIPTION
Resolves: INSTALLER-4402

We need the kernel module in the installer image to [support wireless configuration testing](https://issues.redhat.com/browse/INSTALLER-4402?focusedId=28151985&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-28151985).

It is not possible to use `removekmod` as is because it supports only modules in `kernel` subdirectory while this patch is dealing with `internal` subdirectory. I tried to extend the functionality of the command but it is not really easy, seems to me it would require parameterization or new command (to keep backwards compatibility) which, if at all should be discussed with @bcl. 

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
