### PR TITLE
runtime-install: drop tigervnc

### DIFF
--- a/share/templates.d/99-generic/runtime-install.tmpl
+++ b/share/templates.d/99-generic/runtime-install.tmpl
@@ -122,8 +122,6 @@ installpkg selinux-policy-targeted audit
 
 ## network tools/servers
 installpkg ethtool openssh-server nfs-utils openssh-clients
-installpkg tigervnc-server-minimal
-installpkg tigervnc-server-module
 installpkg net-tools
 installpkg bridge-utils
 installpkg nmap-ncat


### PR DESCRIPTION
anaconda dropped VNC support in
https://github.com/rhinstaller/anaconda/pull/5829 . There is no point to having these any more, and they pull Xorg and its deps into the image unnecessarily.