### PR TITLE
Exclude build on the i686 architecture

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -9,6 +9,9 @@ Release:        1%{?dist}
 Summary:        Tool for creating the anaconda install images
 License:        GPL-2.0-or-later
 
+# qemu is no longer available on 32-bit
+ExcludeArch:    %{ix86}
+
 %global tag %{version}
 %forgemeta
 Url:            %{forgeurl}
@@ -184,6 +187,9 @@ make DESTDIR=$RPM_BUILD_ROOT mandir=%{_mandir} install
 %{_datadir}/lorax/templates.d/*
 
 %changelog
+* Wed Nov 26 2025 Daniel P. Berrangé <berrange@redhat.com> - 44.3-2
+- Add ExcludeArch for i686 to remove qemu dependency
+
 * Wed Oct 15 2025 Brian C. Lane <bcl@redhat.com> 44.3-1
 - Do not remove SELinux from the runtime (ppolawsk@redhat.com)
 


### PR DESCRIPTION
This is to enable the dependency on QEMU to be removed for i686, since QEMU intends to drop i686 support.

lorax is NOT currently a leaf package on i686:

```
  $ ./leafdrop lorax
  lorax is Required by:
  - python-imgcreate-sysdeps
  lorax is BuildRequired by:
  - pungi 
  NO: Package lorax is not a leaf package on i686.
```

Considering those two reported deps, python-imgcreate-sysdeps is a sub-RPM from 'livecd-tools'

```
  $ rpm -qi python-imgcreate-sysdeps | grep Source
  Source RPM  : livecd-tools-31.0-18.fc43.src.rpm
  $ ./leafdrop livecd-tools
  python3-imgcreate is Required by:
  - appliance-tools 
  NO: Package livecd-tools is not a leaf package on i686. 
  $ ./leafdrop appliance-tools
  YES: Package appliance-tools is a leaf package on i686.
```

where appliance-tools is 'noarch' so will never be built in an i686 build root, thus 'livecd-tools' has recently have an ExcludeArch added for i686.

And 'pungi' is also a 'noarch' so again will never be built in an i686 build root and its only consumer is bodhi-composer, which is a sub-RPM of bodhi-server which is also 'noarch' and thus also won't be built in an i686 build root:

```
  $ ./leafdrop pungi
  pungi is Required by:
  - bodhi-composer 
  NO: Package pungi is not a leaf package on i686. 
  $ rpm -qi bodhi-composer |grep Source
  Source RPM  : bodhi-server-25.5.1-5.fc43.src.rpm 
  - $ ./leafdrop bodhi-server
  YES: Package bodhi-server is a leaf package on i686.
```

Therefore it is viable to exclude i686 for lorax now.

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
