### PR TITLE
fix: split in reverse order when constructing the `*-logos` package name

### DIFF
--- a/src/pylorax/treebuilder.py
+++ b/src/pylorax/treebuilder.py
@@ -136,7 +136,7 @@ class RuntimeBuilder(object):
         if release == 'fedora-release-eln':
             logos = 'fedora-eln'
         else:
-            logos, _suffix = release.split('-', 1)
+            logos, _suffix = release.rsplit('-', 1)
         return DataHolder(release=release, logos=logos+"-logos")
 
     def install(self):


### PR DESCRIPTION
When using releases containing more than two "-", this code breaks by splitting at the wrong delimiter.

Example:

With 'my-super-os-release', lorax is going to search for 'my-logos';
With this change lorax will search for 'my-super-os-logos' instead.