### PR TITLE
findkernels: Enable support for 64k kernel flavor

### DIFF
--- a/src/pylorax/treebuilder.py
+++ b/src/pylorax/treebuilder.py
@@ -413,7 +413,7 @@ class TreeBuilder(object):
 
 def findkernels(root="/", kdir="boot"):
     # To find possible flavors, awk '/BuildKernel/ { print $4 }' kernel.spec
-    flavors = ('debug', 'PAE', 'PAEdebug', 'smp', 'xen', 'lpae')
+    flavors = ('debug', 'PAE', 'PAEdebug', 'smp', 'xen', 'lpae', '64k')
     kre = re.compile(r"vmlinuz-(?P<version>.+?\.(?P<arch>[a-z0-9_]+)"
                      r"(.(?P<flavor>{0}))?)$".format("|".join(flavors)))
     kernels = []


### PR DESCRIPTION
In order to support new kernel flavors we need to add it to the list of them in treebuilder. The kernel will then be included in the kernels list passed to the templates, allowing it to be used with installkernel and installinitrd.

Resolves: RHEL-163728

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
