### PR TITLE
lorax: Fall back to erofs if mksquashfs is not installed

### DIFF
--- a/lorax.spec
+++ b/lorax.spec
@@ -42,7 +42,7 @@ Requires:       gzip
 Requires:       isomd5sum
 Requires:       module-init-tools
 Requires:       parted
-Requires:       squashfs-tools >= 4.2
+Recommends:     squashfs-tools >= 4.2
 Requires:       erofs-utils >= 1.8.2
 Requires:       util-linux
 Requires:       xz-lzma-compat

--- a/src/pylorax/cmdline/livemedia.py
+++ b/src/pylorax/cmdline/livemedia.py
@@ -158,6 +158,19 @@ def main():
         list(log.error(e) for e in errors)
         sys.exit(1)
 
+    # When making an iso check for required mksquashfs or mkfs.erofs tools
+    # If mksquashfs is missing fall back to erofs
+    if opts.make_iso:
+        if opts.rootfs_type.startswith("squashfs"):
+            if not shutil.which("mksquashfs"):
+                log.warning("mksquashfs not installed, falling back to --rootfs-type=erofs")
+                opts.rootfs_type = "erofs"
+
+        if opts.rootfs_type.startswith("erofs"):
+            if not shutil.which("mkfs.erofs"):
+                log.error("mkfs.erofs not installed, exiting")
+                sys.exit(1)
+
     if not os.path.exists(opts.result_dir):
         os.makedirs(opts.result_dir)
 

--- a/src/pylorax/cmdline/lorax.py
+++ b/src/pylorax/cmdline/lorax.py
@@ -112,6 +112,18 @@ def main():
 
     log_selinux_state()
 
+    # Check for required mksquashfs or mkfs.erofs tools
+    # If mksquashfs is missing fall back to erofs
+    if opts.rootfs_type.startswith("squashfs"):
+        if not shutil.which("mksquashfs"):
+            log.warning("mksquashfs not installed, falling back to --rootfs-type=erofs")
+            opts.rootfs_type = "erofs"
+
+    if opts.rootfs_type.startswith("erofs"):
+        if not shutil.which("mkfs.erofs"):
+            log.error("mkfs.erofs not installed, exiting")
+            sys.exit(1)
+
     if not opts.workdir:
         if not os.path.exists(opts.tmp):
             os.makedirs(opts.tmp)


### PR DESCRIPTION
This switches the requirement on squashfs-tools to a 'Recommends' so that if it is missing lorax will still be installed.

It checks that mksquashfs is available when the rootfs-type is squashfs or squashfs-ext4, if it is not it falls back to rootfs and checks to make sure mkfs.erofs is available.

The default rootfs-type is still squashfs, and can still be overridden using --rootfs-type=erofs.

Resolves: RHEL-68936

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
