### PR TITLE
Increase root partition to 10 GiB for a live medium

### DIFF
--- a/docs/livemedia.ks
+++ b/docs/livemedia.ks
@@ -30,7 +30,7 @@ clearpart --all --initlabel
 rootpw rootme
 # Disk partitioning information
 reqpart
-part / --size=8000
+part / --size=10240
 
 %post
 # FIXME: it'd be better to get this installed from a package


### PR DESCRIPTION
The current value of 8 GiB is not sufficient anymore to build a live medium using livemedia.ks (see https://redhat.atlassian.net/browse/RHEL-214304).

I'm not sure if it would be worth increasing the size also on RHEL-10 and Fedora as a preventive measure, but at least RHEL-10 is not affected this problem.