### PR TITLE
fedora-livemedia: Bump the rootfs to 10240

### DIFF
--- a/docs/fedora-livemedia.ks
+++ b/docs/fedora-livemedia.ks
@@ -29,7 +29,7 @@ clearpart --all --initlabel
 rootpw rootme
 # Disk partitioning information
 reqpart
-part / --size=6656
+part / --size=10240
 
 %post
 # enable tmpfs for /tmp


### PR DESCRIPTION
This matches the current size used for RHEL10.
