### PR TITLE
Keep the fb kernel module

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -86,7 +86,7 @@ removekmod drivers/char --allbut virtio_console hw_random \
 removekmod drivers/hid --allbut hid-logitech-dj hid-logitech-hidpp
 
 ## As of 2020-09 most of this are built-in too, but again, keep them listed
-removekmod drivers/video --allbut hyperv_fb syscopyarea sysfillrect sysimgblt fb_sys_fops
+removekmod drivers/video --allbut hyperv_fb syscopyarea sysfillrect sysimgblt fb_sys_fops fb
 remove lib/modules/*/{build,source,*.map}
 ## NOTE: depmod gets re-run after cleanup finishes
 


### PR DESCRIPTION
The fb kernel module is needed for graphical installations on s390x in KVM. The module dropped from RHEL-10 initrd.img due to dracut switching the drm dracut module with simpledrm (RHEL-188254). Keep the fb kernel module in install.img.

Related: RHEL-224409