### PR TITLE
Handle relocation of packaged repo configs to /usr/share/dnf5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,6 @@ endif
 export TEST_OS
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 
-ifeq ($(REPOS_DIR),)
-REPOS_DIR = /etc/yum.repos.d
-endif
-
 default: all
 
 src/pylorax/version.py: lorax.spec
@@ -174,9 +170,7 @@ $(VM_IMAGE): srpm bots
 vm: $(VM_IMAGE)
 	echo $(VM_IMAGE)
 
-# grab all repositories from the host system, overwriting what's inside the VM
-# and update the image. Mostly used when testing downstream snapshots to make
-# sure VM_IMAGE is as close as possible to the host!
+# legacy compatibility, used to do different stuff with repos
 vm-local-repos: vm
 
 vm-reset:

--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
+++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
@@ -11,9 +11,6 @@ SOURCE_DATE_EPOCH = os.environ.get('SOURCE_DATE_EPOCH', str(int(time.time())))
 ## move_stubs()
 move usr/share/anaconda/list-harddrives-stub usr/bin/list-harddrives
 
-## move_repos()
-move etc/yum.repos.d etc/anaconda.repos.d
-
 ## Setup mdadm config to turn off homehost
 remove etc/mdadm.conf
 append etc/mdadm.conf "HOMEHOST <ignore>\n"

--- a/test/README.md
+++ b/test/README.md
@@ -41,14 +41,6 @@ To delete the generated image, run
 Base images are stored in `bots/images`. Set `TEST_DATA` to override this
 directory.
 
-To configure the image with all repositories found on the host system use
-
-    $ make vm-local-repos
-
-You may also define `REPOS_DIR` variable to point to another directory
-containing yum .repo files. By default the value is `/etc/yum.repos.d`!
-This is mostly useful when running tests by hand on a downstream snapshot!
-
 ## Running tests
 
 After building a test image, run

--- a/test/vm.install
+++ b/test/vm.install
@@ -22,13 +22,13 @@ if ! rpm -q beakerlib; then
 fi
 
 # disable mirrors & re-enable direct download
-sed -i "s/metalink.*//" /etc/yum.repos.d/*.repo
-sed -i "s/#\(baseurl=.*\)/\1/" /etc/yum.repos.d/*.repo
-sed -i "s/download.fedoraproject/dl.fedoraproject/" /etc/yum.repos.d/*.repo
+sed -i "s/metalink.*//" /etc/yum.repos.d/*.repo /usr/share/dnf5/repos.d/*.repo
+sed -i "s/#\(baseurl=.*\)/\1/" /etc/yum.repos.d/*.repo /usr/share/dnf5/repos.d/*.repo
+sed -i "s/download.fedoraproject/dl.fedoraproject/" /etc/yum.repos.d/*.repo /usr/share/dnf5/repos.d/*.repo
 
 # HACK: Fedora ships baseurl with `example.com` as domain
 # Example: `#baseurl=http://download.example/pub/fedora/linux/updates/$releasever/Everything/$basearch/`
-sed -i "s/download.example/dl.fedoraproject.org/" /etc/yum.repos.d/*.repo
+sed -i "s/download.example/dl.fedoraproject.org/" /etc/yum.repos.d/*.repo /usr/share/dnf5/repos.d/*.repo
 
 # Grow root partition on LVM test images to make room for built images
 PVS=$(pvs --noheadings -opv_name)

--- a/tests/lorax/test_build_bootiso.sh
+++ b/tests/lorax/test_build_bootiso.sh
@@ -13,14 +13,16 @@ set -e
 . "$(dirname $0)/lib/lib.sh"
 
 CLI="${CLI:-./src/bin/lorax}"
+REPODIR="/etc/yum.repos.d"
+test -f /usr/share/dnf5/repos.d/fedora.repo && REPODIR="/usr/share/dnf5/repos.d"
 
 # Make up a name (slightly unsafe), should not exist before running lorax so use -u
 rlJournalStart
     rlPhaseStartTest "Build lorax boot.iso"
         rlAssertEquals "SELinux operates in enforcing mode" "$(getenforce)" "Enforcing"
         lorax -p Fedora-Lorax-Test -v "$RELEASE" -r "$RELEASE" \
-              --repo /etc/yum.repos.d/fedora.repo \
-              --repo /etc/yum.repos.d/fedora-updates.repo \
+              --repo $REPODIR/fedora.repo \
+              --repo $REPODIR/fedora-updates.repo \
               --sharedir "$SHARE_DIR" /var/tmp/test-results/
         rlAssertEquals "exit code should be zero" $? 0
         IMAGE="/var/tmp/test-results/images/boot.iso"


### PR DESCRIPTION
In Fedora 45+, packaged repo configs are moved to /usr/share/dnf5:
https://fedoraproject.org/wiki/Changes/RelocateRpmRepoConfigsToUsr
This adjusts lorax appropriately. We drop the renaming of the repo directory entirely because it is no longer needed. It was originally introduced in https://github.com/rhinstaller/anaconda/commit/c51389518415d9182f01757314c7cfa272534557 to solve a problem involving upgrades. anaconda has not handled upgrades since 2012. anaconda will be updated to not expect this rename any more.