### PR TITLE
templates: Synchronize generic templates with lorax-templates-rhel

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -87,7 +87,7 @@ removekmod drivers/char --allbut virtio_console hw_random \
 removekmod drivers/hid --allbut hid-logitech-dj hid-logitech-hidpp hid-multitouch
 
 ## As of 2020-09 most of this are built-in too, but again, keep them listed
-removekmod drivers/video --allbut hyperv_fb syscopyarea sysfillrect sysimgblt fb_sys_fops
+removekmod drivers/video --allbut hyperv_fb syscopyarea sysfillrect sysimgblt fb_sys_fops fb
 remove lib/modules/*/{build,source,*.map}
 ## NOTE: depmod gets re-run after cleanup finishes
 


### PR DESCRIPTION
This includes keeping the kernel fb video drivers.

Related: RHEL-224409
Resolves: RHEL-224460

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
