### PR TITLE
runtime-cleanup: Keep the cec driver

### DIFF
--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
+++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
@@ -69,7 +69,7 @@ remove /dev/*
 remove /usr/share/icons/*/icon-theme.cache
 
 ## clean up kernel modules
-removekmod sound drivers/media drivers/hwmon drivers/iio \
+removekmod sound drivers/hwmon drivers/iio \
            net/atm net/bluetooth net/sched net/sctp \
            net/rds net/l2tp net/decnet net/netfilter net/ipv4 net/ipv6 \
            drivers/watchdog drivers/rtc drivers/input/joystick \
@@ -84,6 +84,9 @@ removekmod sound drivers/media drivers/hwmon drivers/iio \
 removekmod drivers/char --allbut virtio_console hw_random \
                                   virtio-rng ipmi hmcdrv
 removekmod drivers/hid --allbut hid-logitech-dj hid-logitech-hidpp
+## Need to keep cec media driver for drm_display_helper (a dependency of nouveau,
+## radeon, amdgpu)
+removekmod drivers/media --allbut cec
 
 ## As of 2020-09 most of this are built-in too, but again, keep them listed
 removekmod drivers/video --allbut hyperv_fb syscopyarea sysfillrect sysimgblt fb_sys_fops fb


### PR DESCRIPTION
This is used by the drm_display_helper module which is a dependency of nouveau, radeon, and amdgpu drivers. Without this a modprobe of these drivers would fail in the installer environment.

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
