### PR TITLE
ltmpl: Use output directory's real path

### DIFF
--- a/src/pylorax/ltmpl.py
+++ b/src/pylorax/ltmpl.py
@@ -220,7 +220,7 @@ class LoraxTemplateRunner(TemplateRunner):
     def __init__(self, inroot, outroot, dbo=None, fatalerrors=True,
                                         templatedir=None, defaults=None):
         self.inroot = inroot
-        self.outroot = outroot
+        self.outroot = os.path.realpath(outroot)
         self.dbo = dbo
         builtins = DataHolder(exists=lambda p: rexists(p, root=inroot),
                               glob=lambda g: list(rglob(g, root=inroot)))

--- a/test-packages
+++ b/test-packages
@@ -26,6 +26,7 @@ qemu-img
 rsync
 squashfs-tools
 sudo
+tito
 which
 xorriso
 xz-lzma-compat

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -29,7 +29,7 @@ class LoraxLintConfig(PocketLintConfig):
 
     @property
     def ignoreNames(self):
-        return { "bots", "rpmbuild", "rel-eng" }
+        return { "bots", "rpmbuild" }
 
     @property
     def extraArgs(self):


### PR DESCRIPTION
The output directory could contain symlinks, causing safe_joinpaths to
fail even when the template doesn't have symlinks pointing outside
outroot.
    
Resolves: RHEL-246532



<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
