### PR TITLE
ltmpl: Use output directory's real path

### DIFF
--- a/src/pylorax/ltmpl.py
+++ b/src/pylorax/ltmpl.py
@@ -361,7 +361,7 @@ class LoraxTemplateRunner(TemplateRunner, InstallpkgMixin):
     def __init__(self, inroot, outroot, dbo=None, fatalerrors=True,
                                         templatedir=None, defaults=None):
         self.inroot = inroot
-        self.outroot = outroot
+        self.outroot = os.path.realpath(outroot)
         self.dbo = dbo
         builtins = DataHolder(exists=lambda p: rexists(p, root=inroot),
                               glob=lambda g: list(rglob(g, root=inroot)))


### PR DESCRIPTION
The output directory could contain symlinks, causing safe_joinpaths to fail even when the template doesn't have symlinks pointing outside outroot.

Resolves: RHEL-246711

<!--
Thanks for proposing a change to Lorax,

If you are changing how lorax functions (eg. adding something that requires a
package to be installed by the templates) please also file an issue with other
projects using this version of Lorax with their own copies of the templates. At
this time this consists of:

* https://src.fedoraproject.org/rpms/lorax-templates-rhel

-->
